### PR TITLE
Update LLaMA model urls with correct versioning

### DIFF
--- a/src/modelUrls.ts
+++ b/src/modelUrls.ts
@@ -1,16 +1,16 @@
 export const LLAMA3_2_3B_URL =
-  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/main/llama-3.2-3B/original/llama3_2_3B_bf16.pte';
+  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/v0.1.0/llama-3.2-3B/original/llama3_2_3B_bf16.pte';
 export const LLAMA3_2_3B_QLORA_URL =
-  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/main/llama-3.2-3B/QLoRA/llama3_2-3B_qat_lora.pte';
+  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/v0.1.0/llama-3.2-3B/QLoRA/llama3_2-3B_qat_lora.pte';
 export const LLAMA3_2_3B_SPINQUANT_URL =
-  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/main/llama-3.2-3B/spinquant/llama3_2_3B_spinquant.pte';
+  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/v0.1.0/llama-3.2-3B/spinquant/llama3_2_3B_spinquant.pte';
 export const LLAMA3_2_1B_URL =
-  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/main/llama-3.2-1B/original/llama3_2_bf16.pte';
+  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/v0.1.0/llama-3.2-1B/original/llama3_2_bf16.pte';
 export const LLAMA3_2_1B_QLORA_URL =
-  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/main/llama-3.2-1B/QLoRA/llama3_2_qat_lora.pte';
+  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/v0.1.0/llama-3.2-1B/QLoRA/llama3_2_qat_lora.pte';
 export const LLAMA3_2_1B_SPINQUANT_URL =
-  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/main/llama-3.2-1B/spinquant/llama3_2_spinquant.pte';
+  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/v0.1.0/llama-3.2-1B/spinquant/llama3_2_spinquant.pte';
 export const LLAMA3_2_1B_TOKENIZER =
-  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/main/llama-3.2-1B/original/tokenizer.bin';
+  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/v0.1.0/llama-3.2-1B/original/tokenizer.bin';
 export const LLAMA3_2_3B_TOKENIZER =
-  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/main/llama-3.2-3B/original/tokenizer.bin';
+  'https://huggingface.co/software-mansion/react-native-executorch-llama-3.2/resolve/v0.1.0/llama-3.2-3B/original/tokenizer.bin';


### PR DESCRIPTION
Currently, the model URL points to the main branch on the hugginface repo. Instead, we want to match it with the v0.1.0 version. This PR introduces that change.