### PR TITLE
Fix docs build check post-step 

### DIFF
--- a/.github/workflows/docs-build-check.yml
+++ b/.github/workflows/docs-build-check.yml
@@ -27,7 +27,8 @@ jobs:
           cache: 'yarn'
       - name: Install node dependencies
         working-directory: ${{ env.WORKING_DIRECTORY }}
-        run: yarn
+        # the mkdir is a workaround to avoid this: https://github.com/actions/setup-node/issues/317
+        run: mkdir -p .yarn/cache && yarn
       - name: Generate docs
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: yarn build


### PR DESCRIPTION
Currently, the docs build check action fails. The reason is that setup-node with yarn caching throws an error when yarn cache directory doesn't exist. The action throws an error to prevent saving empty folder, see https://github.com/actions/setup-node/issues/317. This PR is a workaround for that. 