### PR TITLE
Send a request to config.json when downloading model from HF repository

### DIFF
--- a/android/src/main/java/com/rnexecutorch/Fetcher.kt
+++ b/android/src/main/java/com/rnexecutorch/Fetcher.kt
@@ -13,121 +13,127 @@ import java.io.FileOutputStream
 import java.net.URL
 
 enum class ResourceType {
-    TOKENIZER,
-    MODEL
+  TOKENIZER,
+  MODEL,
 }
 
 class Fetcher {
-    companion object {
-        private fun saveResponseToFile(
-            response: Response,
-            directory: File,
-            fileName: String
-        ): File {
-            val file = File(directory.path, fileName)
-            file.outputStream().use { outputStream ->
-                response.body?.byteStream()?.copyTo(outputStream)
-            }
-            return file
+  companion object {
+    private fun saveResponseToFile(
+      response: Response,
+      directory: File,
+      fileName: String,
+    ): File {
+      val file = File(directory.path, fileName)
+      file.outputStream().use { outputStream ->
+        response.body?.byteStream()?.copyTo(outputStream)
+      }
+      return file
+    }
+
+    private fun hasValidExtension(fileName: String, resourceType: ResourceType): Boolean {
+      return when (resourceType) {
+        ResourceType.TOKENIZER -> {
+          fileName.endsWith(".bin")
         }
 
-        private fun hasValidExtension(fileName: String, resourceType: ResourceType): Boolean {
-            return when (resourceType) {
-                ResourceType.TOKENIZER -> {
-                    fileName.endsWith(".bin")
-                }
+        ResourceType.MODEL -> {
+          fileName.endsWith(".pte")
+        }
+      }
+    }
 
-                ResourceType.MODEL -> {
-                    fileName.endsWith(".pte")
-                }
-            }
+    private fun extractFileName(url: URL): String {
+      if (url.path == "/assets/") {
+        val pathSegments = url.toString().split('/')
+        return pathSegments[pathSegments.size - 1].split("?")[0]
+      } else if (url.protocol == "file") {
+        val localPath = url.toString().split("://")[1]
+        val file = File(localPath)
+        if (file.exists()) {
+          return localPath
         }
 
-        private fun extractFileName(url: URL): String {
-            if (url.path == "/assets/") {
-                val pathSegments = url.toString().split('/')
-                return pathSegments[pathSegments.size - 1].split("?")[0]
-            } else if (url.protocol == "file") {
-                val localPath = url.toString().split("://")[1]
-                val file = File(localPath)
-                if (file.exists()) {
-                    return localPath
-                }
+        throw Exception("file_not_found")
+      } else {
+        return url.path.substringAfterLast('/')
+      }
+    }
 
-                throw Exception("file_not_found")
-            } else {
-                return url.path.substringAfterLast('/')
-            }
+    private fun fetchModel(
+      file: File,
+      validFile: File,
+      client: OkHttpClient,
+      url: URL,
+      onComplete: (String?, Exception?) -> Unit,
+      listener: ProgressResponseBody.ProgressListener? = null,
+    ) {
+      val request = Request.Builder().url(url).build()
+      client.newCall(request).enqueue(object : Callback {
+        override fun onFailure(call: Call, e: IOException) {
+          onComplete(null, e)
         }
 
-        private fun fetchModel(file: File, validFile: File, client: OkHttpClient, url: URL, onComplete: (String?, Exception?) -> Unit,
-                               listener: ProgressResponseBody.ProgressListener? = null){
-            val request = Request.Builder().url(url).build()
-            client.newCall(request).enqueue(object : Callback {
-                override fun onFailure(call: Call, e: IOException) {
-                    onComplete(null, e)
-                }
-
-                override fun onResponse(call: Call, response: Response) {
-                    if (!response.isSuccessful) {
-                        onComplete(null, Exception("download_error"))
-                    }
-
-                    response.body?.let { body ->
-                        val progressBody = listener?.let { ProgressResponseBody(body, it) }
-                        val inputStream = progressBody?.source()?.inputStream()
-                        inputStream?.use { input ->
-                            FileOutputStream(file).use { output ->
-                                val buffer = ByteArray(2048)
-                                var bytesRead: Int
-                                while (input.read(buffer).also { bytesRead = it } != -1) {
-                                    output.write(buffer, 0, bytesRead)
-                                }
-                            }
-                        }
-
-                        if (file.renameTo(validFile)) {
-                            onComplete(validFile.absolutePath, null)
-                        } else {
-                            onComplete(null, Exception("Failed to move the file to the valid location"))
-                        }
-                    }
-                }
-            })
-        }
-
-        private fun isUrlPointingToHfRepo(url: URL): Boolean {
-          val expectedHost = "huggingface.co"
-          val expectedPathPrefix = "/software-mansion/"
-          if (url.host != expectedHost) {
-            return false
+        override fun onResponse(call: Call, response: Response) {
+          if (!response.isSuccessful) {
+            onComplete(null, Exception("download_error"))
           }
-          return url.path.startsWith(expectedPathPrefix)
-        }
 
-        private fun resolveConfigUrlFromModelUrl(modelUrl: URL): URL {
-          // Create a new URL using the base URL and append the desired path
-          val baseUrl = modelUrl.protocol + "://" + modelUrl.host + modelUrl.path.substringBefore("resolve/")
-          return URL(baseUrl + "resolve/main/config.json")
-        }
+          response.body?.let { body ->
+            val progressBody = listener?.let { ProgressResponseBody(body, it) }
+            val inputStream = progressBody?.source()?.inputStream()
+            inputStream?.use { input ->
+              FileOutputStream(file).use { output ->
+                val buffer = ByteArray(2048)
+                var bytesRead: Int
+                while (input.read(buffer).also { bytesRead = it } != -1) {
+                  output.write(buffer, 0, bytesRead)
+                }
+              }
+            }
 
-        private fun sendRequestToUrl(url: URL, method: String, body: RequestBody?, client: OkHttpClient) : Response {
-          val request = Request.Builder()
-            .url(url)
-            .method(method, body)
-            .build()
-          val response = client.newCall(request).execute()
-          return response
+            if (file.renameTo(validFile)) {
+              onComplete(validFile.absolutePath, null)
+            } else {
+              onComplete(null, Exception("Failed to move the file to the valid location"))
+            }
+          }
         }
+      })
+    }
 
-        fun downloadResource(
-            context: Context,
-            client: OkHttpClient,
-            url: URL,
-            resourceType: ResourceType,
-            onComplete: (String?, Exception?) -> Unit,
-            listener: ProgressResponseBody.ProgressListener? = null
-        ) {
+    private fun isUrlPointingToHfRepo(url: URL): Boolean {
+      val expectedHost = "huggingface.co"
+      val expectedPathPrefix = "/software-mansion/"
+      if (url.host != expectedHost) {
+        return false
+      }
+      return url.path.startsWith(expectedPathPrefix)
+    }
+
+    private fun resolveConfigUrlFromModelUrl(modelUrl: URL): URL {
+      // Create a new URL using the base URL and append the desired path
+      val baseUrl = modelUrl.protocol + "://" + modelUrl.host + modelUrl.path.substringBefore("resolve/")
+      return URL(baseUrl + "resolve/main/config.json")
+    }
+
+    private fun sendRequestToUrl(url: URL, method: String, body: RequestBody?, client: OkHttpClient): Response {
+      val request = Request.Builder()
+        .url(url)
+        .method(method, body)
+        .build()
+      val response = client.newCall(request).execute()
+      return response
+    }
+
+    fun downloadResource(
+      context: Context,
+      client: OkHttpClient,
+      url: URL,
+      resourceType: ResourceType,
+      onComplete: (String?, Exception?) -> Unit,
+      listener: ProgressResponseBody.ProgressListener? = null,
+    ) {
             /*
             Fetching model and tokenizer file
             1. Extract file name from provided URL
@@ -140,65 +146,65 @@ class Fetcher {
             6. If the file does not exist, and is a tokenizer, fetch the file
             7. If the file is a model, fetch the file with ProgressResponseBody
              */
-            val fileName: String
+      val fileName: String
 
-            try {
-                fileName = extractFileName(url)
-            } catch (e: Exception) {
-                onComplete(null, e)
-                return
-            }
+      try {
+        fileName = extractFileName(url)
+      } catch (e: Exception) {
+        onComplete(null, e)
+        return
+      }
 
-            if(fileName.contains("/")){
-                onComplete(fileName, null)
-                return
-            }
+      if (fileName.contains("/")) {
+        onComplete(fileName, null)
+        return
+      }
 
-            if (!hasValidExtension(fileName, resourceType)) {
-                onComplete(null, Exception("invalid_resource_extension"))
-                return
-            }
+      if (!hasValidExtension(fileName, resourceType)) {
+        onComplete(null, Exception("invalid_resource_extension"))
+        return
+      }
 
-            var tempFile = File(context.filesDir, fileName)
-            if(tempFile.exists()){
-                tempFile.delete()
-            }
+      var tempFile = File(context.filesDir, fileName)
+      if (tempFile.exists()) {
+        tempFile.delete()
+      }
 
-            val modelsDirectory = File(context.filesDir, "models").apply {
-                if (!exists()) {
-                    mkdirs()
-                }
-            }
-
-            var validFile = File(modelsDirectory, fileName)
-            if (validFile.exists()) {
-                onComplete(validFile.absolutePath, null)
-                return
-            }
-
-            if (resourceType == ResourceType.TOKENIZER) {
-                val request = Request.Builder().url(url).build()
-                val response = client.newCall(request).execute()
-
-                if (!response.isSuccessful) {
-                    onComplete(null, Exception("download_error"))
-                    return
-                }
-
-                validFile = saveResponseToFile(response, modelsDirectory, fileName)
-                onComplete(validFile.absolutePath, null)
-                return
-            }
-
-            // If the url is a Software Mansion HuggingFace repo, we want to send a HEAD
-            // request to the config.json file, this increments HF download counter
-            // https://huggingface.co/docs/hub/models-download-stats
-            if (isUrlPointingToHfRepo(url)) {
-              val configUrl = resolveConfigUrlFromModelUrl(url)
-              sendRequestToUrl(configUrl, "HEAD", null, client);
-            }
-
-            fetchModel(tempFile, validFile, client, url, onComplete, listener)
+      val modelsDirectory = File(context.filesDir, "models").apply {
+        if (!exists()) {
+          mkdirs()
         }
+      }
+
+      var validFile = File(modelsDirectory, fileName)
+      if (validFile.exists()) {
+        onComplete(validFile.absolutePath, null)
+        return
+      }
+
+      if (resourceType == ResourceType.TOKENIZER) {
+        val request = Request.Builder().url(url).build()
+        val response = client.newCall(request).execute()
+
+        if (!response.isSuccessful) {
+          onComplete(null, Exception("download_error"))
+          return
+        }
+
+        validFile = saveResponseToFile(response, modelsDirectory, fileName)
+        onComplete(validFile.absolutePath, null)
+        return
+      }
+
+      // If the url is a Software Mansion HuggingFace repo, we want to send a HEAD
+      // request to the config.json file, this increments HF download counter
+      // https://huggingface.co/docs/hub/models-download-stats
+      if (isUrlPointingToHfRepo(url)) {
+        val configUrl = resolveConfigUrlFromModelUrl(url)
+        sendRequestToUrl(configUrl, "HEAD", null, client)
+      }
+
+      fetchModel(tempFile, validFile, client, url, onComplete, listener)
     }
+  }
 }

--- a/ios/utils/LargeFileFetcher.mm
+++ b/ios/utils/LargeFileFetcher.mm
@@ -57,9 +57,6 @@
 - (void)sendHeadRequestToURL:(NSURL *)url {
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     [request setHTTPMethod:@"HEAD"];
-    
-    NSLog(@"Sending a HEAD TO %@", [url absoluteString]);
-    
     NSURLSessionDataTask *dataTask = [_session dataTaskWithRequest:request];
     [dataTask resume];
 }
@@ -89,19 +86,19 @@
   }
 
   // If the url is a Software Mansion HuggingFace repo, we want to send a HEAD
-  // request to the config.json file, this increments the HF download counter
+  // request to the config.json file, this increments HF download counter
   // https://huggingface.co/docs/hub/models-download-stats
   NSString *huggingFaceOrgNSString = @"https://huggingface.co/software-mansion/";
-  NSString *urlNSString = [url absoluteString];
+  NSString *modelURLNSString = [url absoluteString];
 
-  if ([urlNSString hasPrefix:huggingFaceOrgNSString]) {
-    NSRange resolveRange = [urlNSString rangeOfString:@"resolve"];
+  if ([modelURLNSString hasPrefix:huggingFaceOrgNSString]) {
+    NSRange resolveRange = [modelURLNSString rangeOfString:@"resolve"];
     if (resolveRange.location != NSNotFound) {
-      urlNSString = [urlNSString substringToIndex:resolveRange.location + resolveRange.length];
+      NSString *configURLNSString = [modelURLNSString substringToIndex:resolveRange.location + resolveRange.length];
+      configURLNSString = [configURLNSString stringByAppendingString:@"/main/config.json"];
+      NSURL *configNSURL = [NSURL URLWithString:configURLNSString];
+      [self sendHeadRequestToURL:configNSURL];
     }
-    urlNSString = [urlNSString stringByAppendingString:@"/main/config.json"];
-    NSURL *configURL = [NSURL URLWithString:urlNSString];
-    [self sendHeadRequestToURL:configURL];
   }  
   
   //Cancel all running background download tasks and start new one


### PR DESCRIPTION
## Description
Currently, the HuggingFace download count is not incremented when downloading models. HF counts the model downloads by counting the requests sent to the config.json file in the repository root (a HEAD request is enough). This PR sends a HEAD request to the config json, when the model source is our organization. 
source: https://huggingface.co/docs/hub/models-download-stats

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Tested on
- [x] iOS
- [x] Android

### Testing instructions
<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots
<!-- Add screenshots here, if applicable -->

### Related issues
<!-- Link related issues here using #issue-number -->

### Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes
<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->