### PR TITLE
fix: wrong handle of assets files in release apk

### DIFF
--- a/android/src/main/java/com/swmansion/rnexecutorch/ETModule.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/ETModule.kt
@@ -22,12 +22,13 @@ class ETModule(reactContext: ReactApplicationContext) : NativeETModuleSpec(react
   }
 
   private fun downloadModel(
-    url: URL, resourceType: ResourceType, callback: (path: String?, error: Exception?) -> Unit
+    url: String, resourceType: ResourceType, callback: (path: String?, error: Exception?) -> Unit
   ) {
     Fetcher.downloadResource(reactApplicationContext,
       client,
       url,
       resourceType,
+      false,
       { path, error -> callback(path, error) },
       object : ProgressResponseBody.ProgressListener {
         override fun onProgress(bytesRead: Long, contentLength: Long, done: Boolean) {
@@ -38,7 +39,7 @@ class ETModule(reactContext: ReactApplicationContext) : NativeETModuleSpec(react
   override fun loadModule(modelPath: String, promise: Promise) {
     try {
       downloadModel(
-        URL(modelPath), ResourceType.MODEL
+        modelPath, ResourceType.MODEL
       ) { path, error ->
         if (error != null) {
           promise.reject(error.message!!, "-1")

--- a/android/src/main/java/com/swmansion/rnexecutorch/RnExecutorchModule.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/RnExecutorchModule.kt
@@ -1,8 +1,6 @@
 package com.swmansion.rnexecutorch
 
-import android.os.Build
 import android.util.Log
-import androidx.annotation.RequiresApi
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.swmansion.rnexecutorch.utils.Fetcher
@@ -72,7 +70,6 @@ class RnExecutorchModule(reactContext: ReactApplicationContext) :
     promise.resolve("Model loaded successfully")
   }
 
-  @RequiresApi(Build.VERSION_CODES.TIRAMISU)
   override fun loadLLM(
     modelSource: String,
     tokenizerSource: String,

--- a/android/src/main/java/com/swmansion/rnexecutorch/utils/Fetcher.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/utils/Fetcher.kt
@@ -31,14 +31,14 @@ class Fetcher {
       return file
     }
 
-    private fun hasValidExtension(fileName: String, resourceType: ResourceType): Boolean {
+    private fun hasValidExtension(extension: String, resourceType: ResourceType): Boolean {
       return when (resourceType) {
         ResourceType.TOKENIZER -> {
-          fileName.endsWith(".bin")
+          extension == "bin"
         }
 
         ResourceType.MODEL -> {
-          fileName.endsWith(".pte")
+          extension == "pte"
         }
       }
     }
@@ -47,17 +47,9 @@ class Fetcher {
       if (url.path == "/assets/") {
         val pathSegments = url.toString().split('/')
         return pathSegments[pathSegments.size - 1].split("?")[0]
-      } else if (url.protocol == "file") {
-        val localPath = url.toString().split("://")[1]
-        val file = File(localPath)
-        if (file.exists()) {
-          return localPath
-        }
-
-        throw Exception("file_not_found")
-      } else {
-        return url.path.substringAfterLast('/')
       }
+
+      return url.path.substringAfterLast('/')
     }
 
     private fun fetchModel(
@@ -132,85 +124,132 @@ class Fetcher {
       return response
     }
 
+    private fun getIdOfResource(context: Context, resourceName: String): Int {
+      return context.resources.getIdentifier(resourceName, "raw", context.packageName)
+    }
+
     fun downloadResource(
       context: Context,
       client: OkHttpClient,
-      url: URL,
+      url: String,
       resourceType: ResourceType,
+      isLargeFile: Boolean,
       onComplete: (String?, Exception?) -> Unit,
       listener: ProgressResponseBody.ProgressListener? = null,
     ) {
       /*
       Fetching model and tokenizer file
-      1. Extract file name from provided URL
-      2. If file name contains / it means that the file is local and we should return the path
-      3. Check if the file has a valid extension
-          a. For tokenizer, the extension should be .bin
-          b. For model, the extension should be .pte
-      4. Check if models directory exists, if not create it
-      5. Check if the file already exists in the models directory, if yes return the path
-      6. If the file does not exist, and is a tokenizer, fetch the file
-      7. If the file is a model, fetch the file with ProgressResponseBody
+      1. Check if the provided file is a bundled local file
+         a. Check if it exists
+         b. Check if it has valid extension
+         c. Copy the file and return the path
+      2. Check if the provided file is a path to a local file
+         a. Check if it exists
+         b. Check if it has valid extension
+         c. Return the path
+      3. The provided file is a remote file
+          a. Check if it has valid extension
+          b. Check if it's a large file
+              i. Create temporary file to store it at download time
+              ii. Move it to the models directory and return the path
+          c. If it's not a large file download it and return the path
        */
-      val fileName: String
 
       try {
-        fileName = extractFileName(url)
+        if (!url.contains("://")) {
+          //The provided file is from react-native assets folder in release mode
+          val resId = getIdOfResource(context, url)
+          val resName = context.resources.getResourceEntryName(resId)
+          val fileExtension = if (resourceType == ResourceType.TOKENIZER) "bin" else "pte"
+          context.resources.openRawResource(resId).use { inputStream ->
+            val file = File(
+              context.filesDir,
+              "$resName.$fileExtension"
+            )
+            file.outputStream().use { outputStream ->
+              inputStream.copyTo(outputStream)
+            }
+            onComplete(file.absolutePath, null)
+            return
+          }
+        }
+
+        /*
+          The provided file is either a remote file or a local file
+          - local file: file://path/to/file
+          - remote file: https://path/to/file || http://10.0.2.2:8080/path/to/file
+        */
+        val resUrl = URL(url)
+        if (resUrl.protocol == "file") {
+          // The provided file is a local file, get rid of the file:// prefix and return path
+          val localPath = resUrl.toString().split("://")[1]
+          if(!hasValidExtension(localPath.takeLast(3), resourceType)) {
+            throw Exception("invalid_extension")
+          }
+
+          val file = File(localPath)
+          if (file.exists()) {
+            onComplete(localPath, null)
+            return
+          }
+
+          throw Exception("file_not_found")
+        }
+
+        /*
+           The provided file is a remote file, if it's a large file
+           create temporary file to store it at download time and later
+           move it to the models directory
+         */
+        val fileName = extractFileName(resUrl)
+
+        if (!hasValidExtension(fileName.takeLast(3), resourceType)) {
+          throw Exception("invalid_extension")
+        }
+
+        val modelsDirectory = File(context.filesDir, "models").apply {
+          if (!exists()) {
+            mkdirs()
+          }
+        }
+
+        var validFile = File(modelsDirectory, fileName)
+        if (validFile.exists()) {
+          onComplete(validFile.absolutePath, null)
+          return
+        }
+
+        // If the url is a Software Mansion HuggingFace repo, we want to send a HEAD
+        // request to the config.json file, this increments HF download counter
+        // https://huggingface.co/docs/hub/models-download-stats
+        if (isUrlPointingToHfRepo(resUrl)) {
+          val configUrl = resolveConfigUrlFromModelUrl(resUrl)
+          sendRequestToUrl(configUrl, "HEAD", null, client)
+        }
+
+        if (!isLargeFile) {
+          val request = Request.Builder().url(url).build()
+          val response = client.newCall(request).execute()
+
+          if (!response.isSuccessful) {
+            throw Exception("download_error")
+          }
+
+          validFile = saveResponseToFile(response, modelsDirectory, fileName)
+          onComplete(validFile.absolutePath, null)
+          return
+        }
+
+        val tempFile = File(context.filesDir, fileName)
+        if (tempFile.exists()) {
+          tempFile.delete()
+        }
+
+        fetchModel(tempFile, validFile, client, resUrl, onComplete, listener)
       } catch (e: Exception) {
         onComplete(null, e)
         return
       }
-
-      if (fileName.contains("/")) {
-        onComplete(fileName, null)
-        return
-      }
-
-      if (!hasValidExtension(fileName, resourceType)) {
-        onComplete(null, Exception("invalid_resource_extension"))
-        return
-      }
-
-      val tempFile = File(context.filesDir, fileName)
-      if (tempFile.exists()) {
-        tempFile.delete()
-      }
-
-      val modelsDirectory = File(context.filesDir, "models").apply {
-        if (!exists()) {
-          mkdirs()
-        }
-      }
-
-      var validFile = File(modelsDirectory, fileName)
-      if (validFile.exists()) {
-        onComplete(validFile.absolutePath, null)
-        return
-      }
-
-      if (resourceType == ResourceType.TOKENIZER) {
-        val request = Request.Builder().url(url).build()
-        val response = client.newCall(request).execute()
-
-        if (!response.isSuccessful) {
-          onComplete(null, Exception("download_error"))
-          return
-        }
-
-        validFile = saveResponseToFile(response, modelsDirectory, fileName)
-        onComplete(validFile.absolutePath, null)
-        return
-      }
-
-      // If the url is a Software Mansion HuggingFace repo, we want to send a HEAD
-      // request to the config.json file, this increments HF download counter
-      // https://huggingface.co/docs/hub/models-download-stats
-      if (isUrlPointingToHfRepo(url)) {
-        val configUrl = resolveConfigUrlFromModelUrl(url)
-        sendRequestToUrl(configUrl, "HEAD", null, client)
-      }
-
-      fetchModel(tempFile, validFile, client, url, onComplete, listener)
     }
   }
 }

--- a/docs/docs/fundamentals/getting-started.mdx
+++ b/docs/docs/fundamentals/getting-started.mdx
@@ -49,6 +49,10 @@ This allows us to use binaries, such as exported models or tokenizers for LLMs.
 When using Expo, please note that you need to use a custom development build of your app, not the standard Expo Go app. This is because we rely on native modules, which Expo Go doesn’t support.
 :::
 
+:::info[Info]
+Because we are using ExecuTorch under the hood, you won't be able to build ios app for release with simulator selected as the target device. Make sure to test release builds on real devices.
+:::
+
 Running the app with the library:
 ```bash
 yarn run expo:<ios | android> -d


### PR DESCRIPTION
## Description
The file loaded from React-Native assets is served in a different way in debug and release mode, for now in release mode it was blocking applications from working

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improves or adds clarity to existing documentation)

### Tested on
- [x] iOS
- [x] Android

### Testing instructions
<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots
<!-- Add screenshots here, if applicable -->

### Related issues
<!-- Link related issues here using #issue-number -->

### Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes
<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->