### PR TITLE
fix: path of result image was missing file:// prefix(ios)

### DIFF
--- a/ios/RnExecutorch/utils/ImageProcessor.mm
+++ b/ios/RnExecutorch/utils/ImageProcessor.mm
@@ -54,7 +54,7 @@
                                  userInfo:nil];
   }
   
-  return outputPath;
+  return [NSString stringWithFormat:@"file://%@", outputPath];
 }
 
 + (cv::Mat)readImage:(NSString *)source {


### PR DESCRIPTION
## Description
Result path returned from style transfer was missing file:// prefix, due to that using style transfered image for other task was throwing error

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Tested on
- [x] iOS
- [ ] Android

### Testing instructions
<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots
<!-- Add screenshots here, if applicable -->

### Related issues
<!-- Link related issues here using #issue-number -->

### Checklist
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes
<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->