### PR TITLE
Remove abstract pre/postprocess from BaseModel

### DIFF
--- a/android/src/main/java/com/swmansion/rnexecutorch/models/BaseModel.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/models/BaseModel.kt
@@ -52,8 +52,4 @@ abstract class BaseModel<Input, Output>(
   }
 
   abstract fun runModel(input: Input): Output
-
-  protected abstract fun preprocess(input: Input): EValue
-
-  protected abstract fun postprocess(output: Array<EValue>): Output
 }

--- a/android/src/main/java/com/swmansion/rnexecutorch/models/StyleTransferModel.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/models/StyleTransferModel.kt
@@ -20,13 +20,13 @@ class StyleTransferModel(
     return Size(height.toDouble(), width.toDouble())
   }
 
-  override fun preprocess(input: Mat): EValue {
+  fun preprocess(input: Mat): EValue {
     originalSize = input.size()
     Imgproc.resize(input, input, getModelImageSize())
     return ImageProcessor.matToEValue(input, module.getInputShape(0))
   }
 
-  override fun postprocess(output: Array<EValue>): Mat {
+  fun postprocess(output: Array<EValue>): Mat {
     val tensor = output[0].toTensor()
     val modelShape = getModelImageSize()
     val result = ImageProcessor.eValueToMat(tensor.dataAsFloatArray, modelShape.width.toInt(), modelShape.height.toInt())

--- a/android/src/main/java/com/swmansion/rnexecutorch/models/classification/ClassificationModel.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/models/classification/ClassificationModel.kt
@@ -19,12 +19,12 @@ class ClassificationModel(
     return Size(height.toDouble(), width.toDouble())
   }
 
-  override fun preprocess(input: Mat): EValue {
+  fun preprocess(input: Mat): EValue {
     Imgproc.resize(input, input, getModelImageSize())
     return ImageProcessor.matToEValue(input, module.getInputShape(0))
   }
 
-  override fun postprocess(output: Array<EValue>): Map<String, Float> {
+  fun postprocess(output: Array<EValue>): Map<String, Float> {
     val tensor = output[0].toTensor()
     val probabilities = softmax(tensor.dataAsFloatArray.toTypedArray())
 

--- a/android/src/main/java/com/swmansion/rnexecutorch/models/objectDetection/SSDLiteLargeModel.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/models/objectDetection/SSDLiteLargeModel.kt
@@ -29,7 +29,7 @@ class SSDLiteLargeModel(
     return Size(height.toDouble(), width.toDouble())
   }
 
-  override fun preprocess(input: Mat): EValue {
+  fun preprocess(input: Mat): EValue {
     this.widthRatio = (input.size().width / getModelImageSize().width).toFloat()
     this.heightRatio = (input.size().height / getModelImageSize().height).toFloat()
     Imgproc.resize(input, input, getModelImageSize())
@@ -42,7 +42,7 @@ class SSDLiteLargeModel(
     return postprocess(modelOutput)
   }
 
-  override fun postprocess(output: Array<EValue>): Array<Detection> {
+  fun postprocess(output: Array<EValue>): Array<Detection> {
     val scoresTensor = output[1].toTensor()
     val numel = scoresTensor.numel()
     val bboxes = output[0].toTensor().dataAsFloatArray

--- a/android/src/main/java/com/swmansion/rnexecutorch/models/ocr/Detector.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/models/ocr/Detector.kt
@@ -25,7 +25,7 @@ class Detector(
     return modelImageSize
   }
 
-  override fun preprocess(input: Mat): EValue {
+  fun preprocess(input: Mat): EValue {
     originalSize = Size(input.cols().toDouble(), input.rows().toDouble())
     val resizedImage =
       ImageProcessor.resizeWithPadding(
@@ -42,7 +42,7 @@ class Detector(
     )
   }
 
-  override fun postprocess(output: Array<EValue>): List<OCRbBox> {
+  fun postprocess(output: Array<EValue>): List<OCRbBox> {
     val outputTensor = output[0].toTensor()
     val outputArray = outputTensor.dataAsFloatArray
     val modelImageSize = getModelImageSize()

--- a/android/src/main/java/com/swmansion/rnexecutorch/models/ocr/Recognizer.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/models/ocr/Recognizer.kt
@@ -19,9 +19,9 @@ class Recognizer(
     return Size(height.toDouble(), width.toDouble())
   }
 
-  override fun preprocess(input: Mat): EValue = ImageProcessor.matToEValueGray(input)
+  fun preprocess(input: Mat): EValue = ImageProcessor.matToEValueGray(input)
 
-  override fun postprocess(output: Array<EValue>): Pair<List<Int>, Double> {
+  fun postprocess(output: Array<EValue>): Pair<List<Int>, Double> {
     val modelOutputHeight = getModelOutputSize().height.toInt()
     val tensor = output[0].toTensor().dataAsFloatArray
     val numElements = tensor.size

--- a/android/src/main/java/com/swmansion/rnexecutorch/models/ocr/VerticalDetector.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/models/ocr/VerticalDetector.kt
@@ -26,7 +26,7 @@ class VerticalDetector(
     return modelImageSize
   }
 
-  override fun preprocess(input: Mat): EValue {
+  fun preprocess(input: Mat): EValue {
     originalSize = Size(input.cols().toDouble(), input.rows().toDouble())
     val resizedImage =
       ImageProcessor.resizeWithPadding(
@@ -43,7 +43,7 @@ class VerticalDetector(
     )
   }
 
-  override fun postprocess(output: Array<EValue>): List<OCRbBox> {
+  fun postprocess(output: Array<EValue>): List<OCRbBox> {
     val outputTensor = output[0].toTensor()
     val outputArray = outputTensor.dataAsFloatArray
     val modelImageSize = getModelImageSize()

--- a/android/src/main/java/com/swmansion/rnexecutorch/models/speechToText/BaseS2TDecoder.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/models/speechToText/BaseS2TDecoder.kt
@@ -28,13 +28,13 @@ abstract class BaseS2TDecoder(
 
   abstract fun getInputShape(inputLength: Int): LongArray
 
-  override fun preprocess(input: ReadableArray): EValue {
+  fun preprocess(input: ReadableArray): EValue {
     val inputArray = input.getArray(0)!!
     val preprocessorInputShape = this.getInputShape(inputArray.size())
     return EValue.from(Tensor.fromBlob(createFloatArray(inputArray), preprocessorInputShape))
   }
 
-  override fun postprocess(output: Array<EValue>): Int {
+  fun postprocess(output: Array<EValue>): Int {
     TODO("Not yet implemented")
   }
 }

--- a/android/src/main/java/com/swmansion/rnexecutorch/models/speechToText/BaseS2TDecoder.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/models/speechToText/BaseS2TDecoder.kt
@@ -33,8 +33,4 @@ abstract class BaseS2TDecoder(
     val preprocessorInputShape = this.getInputShape(inputArray.size())
     return EValue.from(Tensor.fromBlob(createFloatArray(inputArray), preprocessorInputShape))
   }
-
-  fun postprocess(output: Array<EValue>): Int {
-    TODO("Not yet implemented")
-  }
 }

--- a/android/src/main/java/com/swmansion/rnexecutorch/models/speechToText/MoonshineEncoder.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/models/speechToText/MoonshineEncoder.kt
@@ -20,7 +20,7 @@ class MoonshineEncoder(
     return EValue.from(Tensor.fromBlob(createFloatArray(input), preprocessorInputShape))
   }
 
-  public fun postprocess(output: Array<EValue>): WritableArray {
+  fun postprocess(output: Array<EValue>): WritableArray {
     val outputWritableArray: WritableArray = Arguments.createArray()
     output[0].toTensor().dataAsFloatArray.map {
       outputWritableArray.pushDouble(

--- a/android/src/main/java/com/swmansion/rnexecutorch/models/speechToText/MoonshineEncoder.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/models/speechToText/MoonshineEncoder.kt
@@ -14,13 +14,13 @@ class MoonshineEncoder(
 ) : BaseModel<ReadableArray, WritableArray>(reactApplicationContext) {
   override fun runModel(input: ReadableArray): WritableArray = this.postprocess(this.module.forward(this.preprocess(input)))
 
-  override fun preprocess(input: ReadableArray): EValue {
+  fun preprocess(input: ReadableArray): EValue {
     val size = input.size()
     val preprocessorInputShape = longArrayOf(1, size.toLong())
     return EValue.from(Tensor.fromBlob(createFloatArray(input), preprocessorInputShape))
   }
 
-  public override fun postprocess(output: Array<EValue>): WritableArray {
+  public fun postprocess(output: Array<EValue>): WritableArray {
     val outputWritableArray: WritableArray = Arguments.createArray()
     output[0].toTensor().dataAsFloatArray.map {
       outputWritableArray.pushDouble(

--- a/android/src/main/java/com/swmansion/rnexecutorch/models/speechToText/WhisperEncoder.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/models/speechToText/WhisperEncoder.kt
@@ -33,7 +33,7 @@ class WhisperEncoder(
     return EValue.from(inputTensor)
   }
 
-  public fun postprocess(output: Array<EValue>): WritableArray {
+  fun postprocess(output: Array<EValue>): WritableArray {
     val outputWritableArray: WritableArray = Arguments.createArray()
 
     output[0].toTensor().dataAsFloatArray.map {

--- a/android/src/main/java/com/swmansion/rnexecutorch/models/speechToText/WhisperEncoder.kt
+++ b/android/src/main/java/com/swmansion/rnexecutorch/models/speechToText/WhisperEncoder.kt
@@ -24,7 +24,7 @@ class WhisperEncoder(
     return this.postprocess(hiddenState)
   }
 
-  override fun preprocess(input: ReadableArray): EValue {
+  fun preprocess(input: ReadableArray): EValue {
     val waveformFloatArray = ArrayUtils.createFloatArray(input)
 
     val stftResult = this.stft.fromWaveform(waveformFloatArray)
@@ -33,7 +33,7 @@ class WhisperEncoder(
     return EValue.from(inputTensor)
   }
 
-  public override fun postprocess(output: Array<EValue>): WritableArray {
+  public fun postprocess(output: Array<EValue>): WritableArray {
     val outputWritableArray: WritableArray = Arguments.createArray()
 
     output[0].toTensor().dataAsFloatArray.map {


### PR DESCRIPTION
## Description
Remove abstract pre/postprocess methods from BaseModel in native Android code. The methods are always called on concrete classes so it's not necessary for them to be abstract.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Tested on
- [ ] iOS
- [x] Android

### Checklist
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings