### PR TITLE
fix: Make yarn v1 work with react-native-executorch

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,8 +198,6 @@
     "expo": "^52.0.37",
     "expo-asset": "^11.0.3",
     "expo-file-system": "^18.0.10",
-    "react": "18.3.1",
-    "react-native": "0.76.7",
     "react-native-live-audio-stream": "^1.1.1"
   }
 }


### PR DESCRIPTION
## Description
Currently, we have react and react-native listed as a dependency in package.json. We also have it listed in devDependencies, which makes the yarn v1 fail when installing the package. Fixes #121 

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Tested on
- [x] iOS
- [x] Android

### Testing instructions
<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots
<!-- Add screenshots here, if applicable -->

### Related issues
<!-- Link related issues here using #issue-number -->

### Checklist
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes
<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->