### PR TITLE
fix: remove redundant text from speech-to-text example app

### DIFF
--- a/examples/speech-to-text/screens/SpeechToTextScreen.tsx
+++ b/examples/speech-to-text/screens/SpeechToTextScreen.tsx
@@ -162,7 +162,6 @@ export const SpeechToTextScreen = () => {
               isRecording && styles.borderRed,
             ]}
           >
-            zRXW
             <TouchableOpacity
               disabled={recordingButtonDisabled || isGenerating}
               style={[


### PR DESCRIPTION
… in Text component

There was an unnecessary Text zRXW within View in this file. That was causing the error like Text should be rendered within the Text Component.

## Description

<!-- Provide a concise and descriptive summary of the changes implemented in this PR. -->

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

### Tested on

- [ ] iOS
- [ ] Android


### Checklist

- [ ] I have performed a self-review of my code
### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
