### PR TITLE
docs: Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The minimal supported version is 17.0 for iOS and Android 13.
 
 https://github.com/user-attachments/assets/27ab3406-c7f1-4618-a981-6c86b53547ee
 
-We currently host few example apps demonstrating use cases of our library:
+We currently host a few example apps demonstrating use cases of our library:
 
 - examples/speech-to-text - Whisper and Moonshine models ready for transcription tasks
 - examples/computer-vision - computer vision related tasks

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The minimal supported version is 17.0 for iOS and Android 13.
 
 https://github.com/user-attachments/assets/27ab3406-c7f1-4618-a981-6c86b53547ee
 
-We currently host two example apps demonstrating use cases of our library:
+We currently host few example apps demonstrating use cases of our library:
 
 - examples/speech-to-text - Whisper and Moonshine models ready for transcription tasks
 - examples/computer-vision - computer vision related tasks

--- a/docs/docs/llms/useLLM.md
+++ b/docs/docs/llms/useLLM.md
@@ -144,7 +144,7 @@ await llama.generate(message);
 
 ## Listening for the response
 
-As you might've noticed, there is no return value from the `runInference` function. Instead, the `.response` field of the model is updated with each token.
+As you might've noticed, there is no return value from the `generate` function. Instead, the `.response` field of the model is updated with each token.
 This is how you can render the response of the model:
 
 ```typescript


### PR DESCRIPTION
## Description

- Changed a word from "two examples" to "few examples", so it makes sense. Few is better than three, so it's foolproof longer.

- Changed method name in `useLLM` docs, I think `runInference` is an old name for `generate` and you forgot to change it.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improves or adds clarity to existing documentation)

