### PR TITLE
fix: pass skipSpecialTokens param to Tokenizer in _TokenizerModule

### DIFF
--- a/examples/speech-to-text/screens/SpeechToTextScreen.tsx
+++ b/examples/speech-to-text/screens/SpeechToTextScreen.tsx
@@ -51,7 +51,7 @@ export const SpeechToTextScreen = () => {
     sequence,
     error,
     transcribe,
-  } = useSpeechToText({ modelName: 'whisper', streamingConfig: 'balanced' });
+  } = useSpeechToText({ modelName: 'moonshine', streamingConfig: 'balanced' });
 
   const loadAudio = async (url: string) => {
     const audioContext = new AudioContext({ sampleRate: 16e3 });

--- a/examples/speech-to-text/screens/SpeechToTextScreen.tsx
+++ b/examples/speech-to-text/screens/SpeechToTextScreen.tsx
@@ -51,7 +51,7 @@ export const SpeechToTextScreen = () => {
     sequence,
     error,
     transcribe,
-  } = useSpeechToText({ modelName: 'moonshine', streamingConfig: 'balanced' });
+  } = useSpeechToText({ modelName: 'whisper', streamingConfig: 'balanced' });
 
   const loadAudio = async (url: string) => {
     const audioContext = new AudioContext({ sampleRate: 16e3 });

--- a/src/controllers/SpeechToTextController.ts
+++ b/src/controllers/SpeechToTextController.ts
@@ -334,7 +334,7 @@ export class SpeechToTextController {
 
   private async tokenIdsToText(tokenIds: number[]): Promise<string> {
     try {
-      return this.nativeTokenizer.decode(tokenIds);
+      return this.nativeTokenizer.decode(tokenIds, true);
     } catch (e) {
       this.onErrorCallback?.(
         new Error(`An error has ocurred when decoding the token ids: ${e}`)

--- a/src/native/RnExecutorchModules.ts
+++ b/src/native/RnExecutorchModules.ts
@@ -279,8 +279,8 @@ class _TokenizerModule {
   async load(tokenizerSource: string): Promise<number> {
     return await Tokenizer.load(tokenizerSource);
   }
-  async decode(input: number[]): Promise<string> {
-    return await Tokenizer.decode(input);
+  async decode(input: number[], skipSpecialTokens: boolean): Promise<string> {
+    return await Tokenizer.decode(input, skipSpecialTokens);
   }
   async encode(input: string): Promise<number[]> {
     return await Tokenizer.encode(input);


### PR DESCRIPTION
## Description

Currently, the native module accepts two params, namely tokens to decode and a flag whether we should skip special tokens. The _TokenizerModule wrapper's decode called Tokenizer.decode with just the tokens to decode param, resulting in wrong parameters being passed to native side. This PR solves that problem. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
