### PR TITLE
chore: remove mandatory snack or repro repo link in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -48,7 +48,7 @@ body:
         Issues without a reproduction are likely to stale.
       placeholder: Link to a Snack or a GitHub repository
     validations:
-      required: true
+      required: false
 
   - type: input
     id: react-native-executorch-version


### PR DESCRIPTION
Remove the mandatory snack or reproduction repository from the bug report issue template. 