### PR TITLE
fix: set codegen config type property to 'modules' instead of 'all'

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
   },
   "codegenConfig": {
     "name": "RnExecutorchSpec",
-    "type": "all",
+    "type": "modules",
     "jsSrcsDir": "./src/native",
     "android": {
       "javaPackageName": "com.swmansion.rnexecutorch"


### PR DESCRIPTION
## Description

This PR changes the configuration of the config to 'modules' instead of 'all', since we don't generate code for native Fabric components. 
See https://reactnative.dev/docs/the-new-architecture/using-codegen#configuring-codegen

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
