### PR TITLE
chore: Move react-native-executorch dependency

### DIFF
--- a/examples/text-embeddings/package.json
+++ b/examples/text-embeddings/package.json
@@ -12,12 +12,12 @@
     "expo": "^53.0.0",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
-    "react-native": "0.79.2"
+    "react-native": "0.79.2",
+    "react-native-executorch": "^0.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
-    "react-native-executorch": "^0.3.2",
     "typescript": "~5.8.3"
   },
   "private": true


### PR DESCRIPTION
## Description

Move react-native-executorch dependency from `devDependencies` to `dependencies`

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings