### PR TITLE
fix: make the host function installation generic

### DIFF
--- a/common/rnexecutorch/jsi/JsiHostObject.h
+++ b/common/rnexecutorch/jsi/JsiHostObject.h
@@ -15,9 +15,9 @@
   jsi::Value NAME(jsi::Runtime &runtime, const jsi::Value &thisValue,          \
                   const jsi::Value *args, size_t count)
 
-#define JSI_EXPORT_FUNCTION(CLASS, FUNCTION)                                   \
+#define JSI_EXPORT_FUNCTION(CLASS, FUNCTION, NAME)                             \
   std::make_pair(                                                              \
-      std::string(#FUNCTION),                                                  \
+      NAME,                                                                    \
       static_cast<jsi::Value (JsiHostObject::*)(                               \
           jsi::Runtime &, const jsi::Value &, const jsi::Value *, size_t)>(    \
           &CLASS::FUNCTION))


### PR DESCRIPTION
## Description

Make the model host function installation generic, so that you can easily introduce additional methods that resolve with a promise.

### Tested on

- [x] iOS
- [x] Android

### Related issues

#255 

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings