### PR TITLE
Remove react-native-live-audio-strem dependency from the library.

### DIFF
--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -110,7 +110,6 @@
     "@huggingface/jinja": "^0.5.0",
     "expo": "^53.0.7",
     "expo-asset": "~11.1.5",
-    "expo-file-system": "~18.1.10",
-    "react-native-live-audio-stream": "^1.1.1"
+    "expo-file-system": "~18.1.10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12609,7 +12609,6 @@ __metadata:
     react: "npm:19.0.0"
     react-native: "npm:0.79.2"
     react-native-builder-bob: "npm:^0.30.2"
-    react-native-live-audio-stream: "npm:^1.1.1"
   peerDependencies:
     react: "*"
     react-native: "*"


### PR DESCRIPTION
## Description

We don't use it anywhere in the library - artifact of the past.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Tested on

- [x] iOS
- [ ] Android


### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

