### PR TITLE
fix: remove a dangling reference exception handling 

### DIFF
--- a/packages/react-native-executorch/common/rnexecutorch/host_objects/ModelHostObject.h
+++ b/packages/react-native-executorch/common/rnexecutorch/host_objects/ModelHostObject.h
@@ -69,16 +69,19 @@ public:
                 // breaks proper exception type checking. Remove when the
                 // following change is present in our version:
                 // https://github.com/facebook/react-native/commit/3132cc88dd46f95898a756456bebeeb6c248f20e
-                callInvoker->invokeAsync(
-                    [&e, promise]() { promise->reject(e.what()); });
+                callInvoker->invokeAsync([e = std::move(e), promise]() {
+                  promise->reject(e.what());
+                });
                 return;
               } catch (const jsi::JSError &e) {
-                callInvoker->invokeAsync(
-                    [&e, promise]() { promise->reject(e.what()); });
+                callInvoker->invokeAsync([e = std::move(e), promise]() {
+                  promise->reject(e.what());
+                });
                 return;
               } catch (const std::exception &e) {
-                callInvoker->invokeAsync(
-                    [&e, promise]() { promise->reject(e.what()); });
+                callInvoker->invokeAsync([e = std::move(e), promise]() {
+                  promise->reject(e.what());
+                });
                 return;
               } catch (...) {
                 callInvoker->invokeAsync(


### PR DESCRIPTION
## Description

Remove a dangling reference when handling exceptions in forward method in native C++.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Tested on

- [x] iOS
- [x] Android

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

