### PR TITLE
feat: add memory pressure to models and allow freeing their memory

### DIFF
--- a/packages/react-native-executorch/common/rnexecutorch/TypeConstraints.h
+++ b/packages/react-native-executorch/common/rnexecutorch/TypeConstraints.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <type_traits>
+
+#include <rnexecutorch/models/BaseModel.h>
+
+namespace rnexecutorch {
+
+template <typename T>
+concept DerivedFromBaseModel = std::is_base_of_v<BaseModel, T>;
+
+} // namespace rnexecutorch

--- a/packages/react-native-executorch/common/rnexecutorch/models/BaseModel.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/BaseModel.cpp
@@ -1,5 +1,7 @@
 #include "BaseModel.h"
 
+#include <filesystem>
+
 #include <rnexecutorch/Log.h>
 
 namespace rnexecutorch {
@@ -18,9 +20,18 @@ BaseModel::BaseModel(const std::string &modelSource,
     throw std::runtime_error("Couldn't load the model, error: " +
                              std::to_string(static_cast<uint32_t>(loadError)));
   }
+  // We use the size of the model .pte file as the lower bound for the memory
+  // occupied by the ET module. This is not the whole size however, the module
+  // also allocates planned memory (for ET execution) and backend-specific
+  // memory (e.g. what XNNPACK operates on).
+  std::filesystem::path modelPath{modelSource};
+  memorySizeLowerBound = std::filesystem::file_size(modelPath);
 }
 
 std::vector<std::vector<int32_t>> BaseModel::getInputShape() {
+  if (!module) {
+    throw std::runtime_error("getInputShape called on unloaded model");
+  }
   auto method_meta = module->method_meta("forward");
 
   if (!method_meta.ok()) {
@@ -38,6 +49,17 @@ std::vector<std::vector<int32_t>> BaseModel::getInputShape() {
     output.emplace_back(std::vector<int32_t>(shape.begin(), shape.end()));
   }
   return output;
+}
+
+std::size_t BaseModel::getMemoryLowerBound() { return memorySizeLowerBound; }
+
+void BaseModel::unloadModule() { module.reset(nullptr); }
+
+Result<std::vector<EValue>> BaseModel::forwardET(const EValue &input_value) {
+  if (!module) {
+    throw std::runtime_error("Forward called on unloaded model");
+  }
+  return std::move(module->forward(input_value));
 }
 
 } // namespace rnexecutorch

--- a/packages/react-native-executorch/common/rnexecutorch/models/BaseModel.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/BaseModel.cpp
@@ -59,7 +59,7 @@ Result<std::vector<EValue>> BaseModel::forwardET(const EValue &input_value) {
   if (!module) {
     throw std::runtime_error("Forward called on unloaded model");
   }
-  return std::move(module->forward(input_value));
+  return module->forward(input_value);
 }
 
 } // namespace rnexecutorch

--- a/packages/react-native-executorch/common/rnexecutorch/models/BaseModel.h
+++ b/packages/react-native-executorch/common/rnexecutorch/models/BaseModel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include <ReactCommon/CallInvoker.h>
 #include <executorch/extension/module/module.h>
@@ -8,19 +9,26 @@
 
 namespace rnexecutorch {
 using namespace facebook;
-
+using executorch::runtime::EValue;
+using executorch::runtime::Result;
 class BaseModel {
 public:
   BaseModel(const std::string &modelSource,
             std::shared_ptr<react::CallInvoker> callInvoker);
   std::vector<std::vector<int32_t>> getInputShape();
+  std::size_t getMemoryLowerBound();
+  void unloadModule();
 
 protected:
-  std::unique_ptr<executorch::extension::Module> module;
+  Result<std::vector<EValue>> forwardET(const EValue &input_value);
   // If possible, models should not use the JS runtime to keep JSI internals
   // away from logic, however, sometimes this would incur too big of a penalty
   // (unnecessary copies instead of working on JS memory). In this case
   // CallInvoker can be used to get jsi::Runtime, and use it in a safe manner.
   std::shared_ptr<react::CallInvoker> callInvoker;
+  std::size_t memorySizeLowerBound{0};
+
+private:
+  std::unique_ptr<executorch::extension::Module> module;
 };
 } // namespace rnexecutorch

--- a/packages/react-native-executorch/common/rnexecutorch/models/image_segmentation/ImageSegmentation.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/image_segmentation/ImageSegmentation.cpp
@@ -39,7 +39,7 @@ ImageSegmentation::forward(std::string imageSource,
                            bool resize) {
   auto [inputTensor, originalSize] = preprocess(imageSource);
 
-  auto forwardResult = module->forward(inputTensor);
+  auto forwardResult = forwardET(inputTensor);
   if (!forwardResult.ok()) {
     throw std::runtime_error(
         "Failed to forward, error: " +

--- a/packages/react-native-executorch/common/rnexecutorch/models/style_transfer/StyleTransfer.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/style_transfer/StyleTransfer.cpp
@@ -10,7 +10,6 @@
 
 namespace rnexecutorch {
 using namespace facebook;
-using executorch::extension::Module;
 using executorch::extension::TensorPtr;
 using executorch::runtime::Error;
 
@@ -55,7 +54,7 @@ std::string StyleTransfer::postprocess(const Tensor &tensor,
 std::string StyleTransfer::forward(std::string imageSource) {
   auto [tensor, originalSize] = preprocess(imageSource);
 
-  auto forwardResult = module->forward(tensor);
+  auto forwardResult = forwardET(tensor);
   if (!forwardResult.ok()) {
     throw std::runtime_error(
         "Failed to forward, error: " +

--- a/packages/react-native-executorch/src/hooks/useNonStaticModule.ts
+++ b/packages/react-native-executorch/src/hooks/useNonStaticModule.ts
@@ -4,6 +4,7 @@ import { ETError, getError } from '../Error';
 interface Module {
   load: (...args: any[]) => Promise<void>;
   forward: (...args: any[]) => Promise<any>;
+  delete: () => void;
 }
 
 interface ModuleConstructor<M extends Module> {
@@ -43,7 +44,12 @@ export const useNonStaticModule = <
           setError((err as Error).message);
         }
       })();
+
+      return () => {
+        model.delete();
+      };
     }
+    return () => {};
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [...loadArgs, preventLoad]);
 

--- a/packages/react-native-executorch/src/index.tsx
+++ b/packages/react-native-executorch/src/index.tsx
@@ -4,8 +4,8 @@ import { ETInstallerNativeModule } from './native/RnExecutorchModules';
 
 // eslint-disable no-var
 declare global {
-  var loadStyleTransfer: (source: string) => Promise<any>;
-  var loadImageSegmentation: (source: string) => Promise<any>;
+  var loadStyleTransfer: (source: string) => any;
+  var loadImageSegmentation: (source: string) => any;
 }
 // eslint-disable no-var
 

--- a/packages/react-native-executorch/src/modules/BaseNonStaticModule.ts
+++ b/packages/react-native-executorch/src/modules/BaseNonStaticModule.ts
@@ -1,0 +1,6 @@
+export class BaseNonStaticModule {
+  nativeModule: any = null;
+  delete() {
+    this.nativeModule.unload();
+  }
+}

--- a/packages/react-native-executorch/src/modules/computer_vision/ImageSegmentationModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/ImageSegmentationModule.ts
@@ -2,10 +2,9 @@ import { ResourceFetcher } from '../../utils/ResourceFetcher';
 import { ResourceSource } from '../../types/common';
 import { DeeplabLabel } from '../../types/imageSegmentation';
 import { ETError, getError } from '../../Error';
+import { BaseNonStaticModule } from '../BaseNonStaticModule';
 
-export class ImageSegmentationModule {
-  nativeModule: any = null;
-
+export class ImageSegmentationModule extends BaseNonStaticModule {
   async load(
     modelSource: ResourceSource,
     onDownloadProgressCallback: (_: number) => void = () => {}
@@ -41,9 +40,5 @@ export class ImageSegmentationModule {
       }
     }
     return enumDict;
-  }
-
-  delete() {
-    this.nativeModule.unload();
   }
 }

--- a/packages/react-native-executorch/src/modules/computer_vision/ImageSegmentationModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/ImageSegmentationModule.ts
@@ -42,4 +42,8 @@ export class ImageSegmentationModule {
     }
     return enumDict;
   }
+
+  delete() {
+    this.nativeModule.unload();
+  }
 }

--- a/packages/react-native-executorch/src/modules/computer_vision/StyleTransferModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/StyleTransferModule.ts
@@ -1,10 +1,9 @@
 import { ResourceFetcher } from '../../utils/ResourceFetcher';
 import { ResourceSource } from '../../types/common';
 import { ETError, getError } from '../../Error';
+import { BaseNonStaticModule } from '../BaseNonStaticModule';
 
-export class StyleTransferModule {
-  nativeModule: any = null;
-
+export class StyleTransferModule extends BaseNonStaticModule {
   async load(
     modelSource: ResourceSource,
     onDownloadProgressCallback: (_: number) => void = () => {}
@@ -20,9 +19,5 @@ export class StyleTransferModule {
     if (this.nativeModule == null)
       throw new Error(getError(ETError.ModuleNotLoaded));
     return await this.nativeModule.forward(imageSource);
-  }
-
-  delete() {
-    this.nativeModule.unload();
   }
 }

--- a/packages/react-native-executorch/src/modules/computer_vision/StyleTransferModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/StyleTransferModule.ts
@@ -21,4 +21,8 @@ export class StyleTransferModule {
       throw new Error(getError(ETError.ModuleNotLoaded));
     return await this.nativeModule.forward(imageSource);
   }
+
+  delete() {
+    this.nativeModule.unload();
+  }
 }


### PR DESCRIPTION
## Description

The garbage collector doesn't see the memory allocated on the heap by host objects, so we need to notify it of the memory occupied by ET modules, otherwise it will take a long time before freeing it. We set the memory pressure to the size of the .pte file of the model (an underestimate of the true size) and add a host function to release the module memory.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Tested on

- [x] iOS
- [x] Android

### Related issues

#254

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings