### PR TITLE
fix: Rename unload cpp function

### DIFF
--- a/packages/react-native-executorch/common/rnexecutorch/host_objects/ModelHostObject.h
+++ b/packages/react-native-executorch/common/rnexecutorch/host_objects/ModelHostObject.h
@@ -104,7 +104,7 @@ public:
 
   JSI_HOST_FUNCTION(unload) {
     try {
-      model->unloadModule();
+      model->unload();
     } catch (const std::runtime_error &e) {
       // This catch should be merged with the next one
       // (std::runtime_error inherits from std::exception) HOWEVER react

--- a/packages/react-native-executorch/common/rnexecutorch/models/BaseModel.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/BaseModel.cpp
@@ -53,7 +53,7 @@ std::vector<std::vector<int32_t>> BaseModel::getInputShape() {
 
 std::size_t BaseModel::getMemoryLowerBound() { return memorySizeLowerBound; }
 
-void BaseModel::unloadModule() { module.reset(nullptr); }
+void BaseModel::unload() { module.reset(nullptr); }
 
 Result<std::vector<EValue>> BaseModel::forwardET(const EValue &input_value) {
   if (!module) {

--- a/packages/react-native-executorch/common/rnexecutorch/models/BaseModel.h
+++ b/packages/react-native-executorch/common/rnexecutorch/models/BaseModel.h
@@ -17,7 +17,7 @@ public:
             std::shared_ptr<react::CallInvoker> callInvoker);
   std::vector<std::vector<int32_t>> getInputShape();
   std::size_t getMemoryLowerBound();
-  void unloadModule();
+  void unload();
 
 protected:
   Result<std::vector<EValue>> forwardET(const EValue &input_value);

--- a/packages/react-native-executorch/react-native-executorch.podspec
+++ b/packages/react-native-executorch/react-native-executorch.podspec
@@ -25,13 +25,13 @@ Pod::Spec.new do |s|
       '-framework "Metal"', 
       '-framework "MetalPerformanceShaders"', 
       '-framework "MetalPerformanceShadersGraph"', 
-      '-force_load "\"#{et_binaries_path}\"/libbackend_coreml_ios.a"', 
-      '-force_load "\"#{et_binaries_path}\"/libbackend_mps_ios.a"', 
-      '-force_load "\"#{et_binaries_path}\"/libbackend_xnnpack_ios.a"', 
-      '-force_load "\"#{et_binaries_path}\"/libexecutorch_ios.a"', 
-      '-force_load "\"#{et_binaries_path}\"/libkernels_custom_ios.a"', 
-      '-force_load "\"#{et_binaries_path}\"/libkernels_optimized_ios.a"', 
-      '-force_load "\"#{et_binaries_path}\"/libkernels_quantized_ios.a"'
+      "-force_load \"#{et_binaries_path}\"/libbackend_coreml_ios.a", 
+      "-force_load \"#{et_binaries_path}\"/libbackend_mps_ios.a", 
+      "-force_load \"#{et_binaries_path}\"/libbackend_xnnpack_ios.a", 
+      "-force_load \"#{et_binaries_path}\"/libexecutorch_ios.a", 
+      "-force_load \"#{et_binaries_path}\"/libkernels_custom_ios.a", 
+      "-force_load \"#{et_binaries_path}\"/libkernels_optimized_ios.a", 
+      "-force_load \"#{et_binaries_path}\"/libkernels_quantized_ios.a"
     ].join(' '),
       
     "OTHER_LDFLAGS[sdk=iphonesimulator*][arch=*]" => [

--- a/packages/react-native-executorch/src/native/NativeClassification.ts
+++ b/packages/react-native-executorch/src/native/NativeClassification.ts
@@ -1,9 +1,0 @@
-import type { TurboModule } from 'react-native';
-import { TurboModuleRegistry } from 'react-native';
-
-export interface Spec extends TurboModule {
-  loadModule(modelSource: string): Promise<number>;
-  forward(input: string): Promise<{ [category: string]: number }>;
-}
-
-export default TurboModuleRegistry.get<Spec>('Classification');

--- a/packages/react-native-executorch/src/native/RnExecutorchModules.ts
+++ b/packages/react-native-executorch/src/native/RnExecutorchModules.ts
@@ -6,7 +6,6 @@ import { Spec as VerticalOCRInterface } from './NativeVerticalOCR';
 import { Spec as SpeechToTextInterface } from './NativeSpeechToText';
 import { Spec as TextEmbeddingsInterface } from './NativeTextEmbeddings';
 import { Spec as LLMInterface } from './NativeLLM';
-import { Spec as ClassificationInterface } from './NativeClassification';
 import { Spec as TokenizerInterface } from './NativeTokenizer';
 import { Spec as ETInstallerInterface } from './NativeETInstaller';
 
@@ -35,8 +34,6 @@ const LLMNativeModule: LLMInterface = returnSpecOrThrowLinkingError(
 const ETModuleNativeModule: ETModuleInterface = returnSpecOrThrowLinkingError(
   require('./NativeETModule').default
 );
-const ClassificationNativeModule: ClassificationInterface =
-  returnSpecOrThrowLinkingError(require('./NativeClassification').default);
 const ObjectDetectionNativeModule: ObjectDetectionInterface =
   returnSpecOrThrowLinkingError(require('./NativeObjectDetection').default);
 const SpeechToTextNativeModule: SpeechToTextInterface =
@@ -57,7 +54,6 @@ const ETInstallerNativeModule: ETInstallerInterface =
 export {
   LLMNativeModule,
   ETModuleNativeModule,
-  ClassificationNativeModule,
   ObjectDetectionNativeModule,
   SpeechToTextNativeModule,
   OCRNativeModule,


### PR DESCRIPTION
## Description

It caused crashes when unloading model. Names didn't match

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Tested on

- [x] iOS
- [ ] Android


### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

