### PR TITLE
Refactor Executorch bindings

### DIFF
--- a/docs/docs/executorch-bindings/useExecutorchModule.md
+++ b/docs/docs/executorch-bindings/useExecutorchModule.md
@@ -30,25 +30,29 @@ The `modelSource` parameter expects a location string pointing to the model bina
 
 ### Returns
 
-|       Field        |                            Type                            |                                                                                             Description                                                                                             |
-| :----------------: | :--------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-|      `error`       |              <code>string &#124; null</code>               |                                                                       Contains the error message if the model failed to load.                                                                       |
-|   `isGenerating`   |                         `boolean`                          |                                                                  Indicates whether the model is currently processing an inference.                                                                  |
-|     `isReady`      |                         `boolean`                          |                                                           Indicates whether the model has successfully loaded and is ready for inference.                                                           |
-|    `loadMethod`    |          `(methodName: string) => Promise<void>`           |                                                               Loads resources specific to `methodName` into memory before execution.                                                                |
-|   `loadForward`    |                   `() => Promise<void>`                    |                                            Loads resources specific to `forward` method into memory before execution. Uses `loadMethod` under the hood.                                             |
-|     `forward`      | `(input: ETInput, shape: number[]) => Promise<number[][]>` | Executes the model's forward pass, where `input` is a Javascript typed array and `shape` is an array of integers representing input Tensor shape. The output is a Tensor - raw result of inference. |
-| `downloadProgress` |                          `number`                          |                                                                    Represents the download progress as a value between 0 and 1.                                                                     |
+|       Field        |                       Type                       |                                                                                                                                  Description                                                                                                                                  |
+| :----------------: | :----------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+|      `error`       |         <code>string &#124; null</code>          |                                                                                                            Contains the error message if the model failed to load.                                                                                                            |
+|   `isGenerating`   |                    `boolean`                     |                                                                                                       Indicates whether the model is currently processing an inference.                                                                                                       |
+|     `isReady`      |                    `boolean`                     |                                                                                                Indicates whether the model has successfully loaded and is ready for inference.                                                                                                |
+|    `loadMethod`    |     `(methodName: string) => Promise<void>`      |                                                                                                    Loads resources specific to `methodName` into memory before execution.                                                                                                     |
+|   `loadForward`    |              `() => Promise<void>`               |                                                                                 Loads resources specific to `forward` method into memory before execution. Uses `loadMethod` under the hood.                                                                                  |
+|     `forward`      | `(input: Tensor[] \| Tensor): Promise<number[]>` | Executes the model's forward pass, where `input` is a `Tensor` or array of tensors `Tensor[]`. Tensor is a compound type consisting of two elements: data and shape. Data is a JavaScript typed array, and shape is an array of integers representing the input tensor shape. |
+| `downloadProgress` |                     `number`                     |                                                                                                         Represents the download progress as a value between 0 and 1.                                                                                                          |
 
 ## ETInput
 
-The `ETInput` type defines the typed arrays that can be used as inputs in the `forward` method:
+The `ETInput` type defines the typed arrays that can be used as data in `Tensor`:
 
 - Int8Array
 - Int32Array
 - BigInt64Array
 - Float32Array
 - Float64Array
+
+## Tensor
+
+The `Tensor` is a complex type that aggregates both data and shape of the tensor passed to the `forward` method.
 
 ## Errors
 

--- a/docs/docs/typescript-api/ExecutorchModule.md
+++ b/docs/docs/typescript-api/ExecutorchModule.md
@@ -25,26 +25,31 @@ const output = await ExecutorchModule.forward(input, shape);
 
 ### Methods
 
-| Method               | Type                                                   | Description                                                                                                                                                                                         |
-| -------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `load`               | `(modelSource: ResourceSource): Promise<void>`         | Loads the model, where `modelSource` is a string that specifies the location of the model binary.                                                                                                   |
-| `forward`            | `(input: ETInput, shape: number[]): Promise<number[]>` | Executes the model's forward pass, where `input` is a JavaScript typed array and `shape` is an array of integers representing input Tensor shape. The output is a Tensor - raw result of inference. |
-| `loadMethod`         | `(methodName: string): Promise<void>`                  | Loads resources specific to `methodName` into memory before execution.                                                                                                                              |
-| `loadForward`        | `(): Promise<void>`                                    | Loads resources specific to `forward` method into memory before execution. Uses `loadMethod` under the hood.                                                                                        |
-| `onDownloadProgress` | `(callback: (downloadProgress: number) => void): any`  | Subscribe to the download progress event.                                                                                                                                                           |
+| Method               | Type                                                  | Description                                                                                                                                                                                                                                                                   |
+| -------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `load`               | `(modelSource: ResourceSource): Promise<void>`        | Loads the model, where `modelSource` is a string that specifies the location of the model binary.                                                                                                                                                                             |
+| `forward`            | `(input: Tensor[] \| Tensor): Promise<number[]>`      | Executes the model's forward pass, where `input` is a `Tensor` or array of tensors `Tensor[]`. Tensor is a compound type consisting of two elements: data and shape. Data is a JavaScript typed array, and shape is an array of integers representing the input tensor shape. |
+| `loadMethod`         | `(methodName: string): Promise<void>`                 | Loads resources specific to `methodName` into memory before execution.                                                                                                                                                                                                        |
+| `loadForward`        | `(): Promise<void>`                                   | Loads resources specific to `forward` method into memory before execution. Uses `loadMethod` under the hood.                                                                                                                                                                  |
+| `onDownloadProgress` | `(callback: (downloadProgress: number) => void): any` | Subscribe to the download progress event.                                                                                                                                                                                                                                     |
 
 <details>
 <summary>Type definitions</summary>
 
 ```typescript
-type ResourceSource = string | number | object;
+export type ResourceSource = string | number | object;
 
-export type ETInput =
+type ETInput =
   | Int8Array
   | Int32Array
   | BigInt64Array
   | Float32Array
   | Float64Array;
+
+export interface Tensor {
+  data: ETInput[];
+  shape: number[];
+}
 ```
 
 </details>
@@ -55,7 +60,7 @@ To load the model, use the `load` method. It accepts the `modelSource` which is 
 
 ## Running the model
 
-To run the model use the `forward` method. It accepts two arguments: `input` and `shape`. The `input` is a JavaScript typed array, and `shape` is an array of integers representing the input tensor shape. There's no need to explicitly define the input type, as it will automatically be inferred from the typed array you pass to forward method. Outputs from the model, such as classification probabilities, are returned in raw format.
+To run the model use the `forward` method. It accepts one argument: `input`. The `input` is a `Tensor` or array of tensors `Tensor[]`. Tensor is a compound type consisting of two elements: data and shape. Data is a JavaScript typed array, and `shape` is an array of integers representing the input tensor shape. There's no need to explicitly define the input type, as it will automatically be inferred from the typed array you pass to forward method. Outputs from the model, such as classification probabilities, are returned in raw format.
 
 ## Loading methods
 

--- a/docs/docs/typescript-api/ExecutorchModule.md
+++ b/docs/docs/typescript-api/ExecutorchModule.md
@@ -21,7 +21,7 @@ await ExecutorchModule.load(STYLE_TRANSFER_CANDY);
 
 // Running the model
 const output = await ExecutorchModule.forward({
-  data: input,
+  data: inputData,
   shape: inputShape,
 });
 ```

--- a/docs/docs/typescript-api/ExecutorchModule.md
+++ b/docs/docs/typescript-api/ExecutorchModule.md
@@ -13,14 +13,17 @@ import {
 } from 'react-native-executorch';
 
 // Creating the input array
-const shape = [1, 3, 640, 640];
-const input = new Float32Array(1 * 3 * 640 * 640);
+const inputShape = [1, 3, 640, 640];
+const inputData = new Float32Array(1 * 3 * 640 * 640);
 
 // Loading the model
 await ExecutorchModule.load(STYLE_TRANSFER_CANDY);
 
 // Running the model
-const output = await ExecutorchModule.forward(input, shape);
+const output = await ExecutorchModule.forward({
+  data: input,
+  shape: inputShape,
+});
 ```
 
 ### Methods

--- a/docs/docs/typescript-api/ExecutorchModule.md
+++ b/docs/docs/typescript-api/ExecutorchModule.md
@@ -50,7 +50,7 @@ type ETInput =
   | Float64Array;
 
 export interface Tensor {
-  data: ETInput[];
+  data: ETInput;
   shape: number[];
 }
 ```

--- a/packages/react-native-executorch/src/modules/general/ExecutorchModule.ts
+++ b/packages/react-native-executorch/src/modules/general/ExecutorchModule.ts
@@ -26,12 +26,8 @@ export class ExecutorchModule extends BaseModule {
       if (!currentInput || !currentInput.data) {
         throw new Error('Input tensor is undefined.');
       }
-      const testingTypeElement = currentInput.data[0];
-      if (testingTypeElement === undefined) {
-        throw new Error('Input tensor is undefined.');
-      }
 
-      let currentInputTypeIdentifier = getTypeIdentifier(testingTypeElement);
+      let currentInputTypeIdentifier = getTypeIdentifier(currentInput.data);
       if (currentInputTypeIdentifier === -1) {
         throw new Error(getError(ETError.InvalidArgument));
       }

--- a/packages/react-native-executorch/src/types/common.ts
+++ b/packages/react-native-executorch/src/types/common.ts
@@ -17,7 +17,6 @@ export type ETInput =
   | Float64Array;
 
 export interface Tensor {
-  data: ETInput[];
+  data: ETInput;
   shape: number[];
-  type: ETInput;
 }

--- a/packages/react-native-executorch/src/types/common.ts
+++ b/packages/react-native-executorch/src/types/common.ts
@@ -15,3 +15,9 @@ export type ETInput =
   | BigInt64Array
   | Float32Array
   | Float64Array;
+
+export interface Tensor {
+  data: ETInput[];
+  shape: number[];
+  type: ETInput;
+}


### PR DESCRIPTION
## Description

Refactor Executorch bindings to pass to `ExecutorchModule.forward` `Tensor` instead of separate `ETInput` and `shape`.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (improves or adds clarity to existing documentation)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

Use `ExecutorchModule.forward` with new workflow.

### Screenshots

Not applicable

### Related issues

#209

### Checklist

- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
