### PR TITLE
fix: Fix function in resource fetcher that produced the same name for different requires in development mode

### DIFF
--- a/packages/react-native-executorch/src/utils/ResourceFetcher.ts
+++ b/packages/react-native-executorch/src/utils/ResourceFetcher.ts
@@ -148,7 +148,7 @@ export class ResourceFetcher {
 
   private static getFilenameFromUri(uri: string) {
     let cleanUri = uri.replace(/^https?:\/\//, '');
-    cleanUri = cleanUri.split('?')?.[0]?.split('#')?.[0] ?? cleanUri;
+    cleanUri = cleanUri.split('#')?.[0] ?? cleanUri;
     return cleanUri.replace(/[^a-zA-Z0-9._-]/g, '_');
   }
 


### PR DESCRIPTION
## Description

When loading two models using require the 2nd would overwrite the 1st one, cause this function produced the same name for them. It worked for remote URLs that were different in path part (the one divided by slashes), but locally loaded files only differ by GET params, that were cut off by split('?')[0]. This fixes it.

It might be considered breaking change in a sense it may change names of models in the current app, so models will redownload 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Tested on

- [ ] iOS
- [x] Android

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

