### PR TITLE
fix: ensure audioLanguage is passed to decodeChunk

### DIFF
--- a/packages/react-native-executorch/src/controllers/SpeechToTextController.ts
+++ b/packages/react-native-executorch/src/controllers/SpeechToTextController.ts
@@ -327,7 +327,10 @@ export class SpeechToTextController {
     this.validateAndFixLastChunk();
 
     for (let chunkId = 0; chunkId < this.chunks.length; chunkId++) {
-      const seq = await this.decodeChunk(this.chunks!.at(chunkId)!);
+      const seq = await this.decodeChunk(
+        this.chunks!.at(chunkId)!,
+        audioLanguage
+      );
       // whole audio is inside one chunk, no processing required
       if (this.chunks.length === 1) {
         this.sequence = seq;


### PR DESCRIPTION
## Description

Currently audioLanguage is not properly passed down to decodeChunk, resulting in `getStartingTokenIds` returning just BOS, while it should return some more tokens for multilingual whisper. This PR fixes ensures that audioLanguage is properly passed. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
