### PR TITLE
fix: resource fetcher check if directory exists

### DIFF
--- a/apps/computer-vision/ios/Podfile.lock
+++ b/apps/computer-vision/ios/Podfile.lock
@@ -2454,7 +2454,7 @@ SPEC CHECKSUMS:
   React-logger: 8edfcedc100544791cd82692ca5a574240a16219
   React-Mapbuffer: c3f4b608e4a59dd2f6a416ef4d47a14400194468
   React-microtasksnativemodule: 054f34e9b82f02bd40f09cebd4083828b5b2beb6
-  react-native-executorch: 039d083b638678d321af3c48b6e66edd3903ffb1
+  react-native-executorch: 98a2d5c0fc2290d473db87f2d6f3bf9dc7b77ab1
   react-native-image-picker: 8a3f16000e794f5381a7fe47bb48fd8d06741e47
   react-native-safe-area-context: 562163222d999b79a51577eda2ea8ad2c32b4d06
   react-native-skia: b6cb66e99a953dae6880348c92cfb20a76d90b4f

--- a/packages/react-native-executorch/src/utils/ResourceFetcher.ts
+++ b/packages/react-native-executorch/src/utils/ResourceFetcher.ts
@@ -369,6 +369,7 @@ export class ResourceFetcher {
     if (await ResourceFetcherUtils.checkFileExists(sourceExtended.fileUri)) {
       return ResourceFetcherUtils.removeFilePrefix(sourceExtended.fileUri);
     }
+    await ResourceFetcherUtils.createDirectoryIfNoExists();
 
     const downloadResumable = createDownloadResumable(
       uri,


### PR DESCRIPTION
## Description

In the latest update to the Resource Fetcher, one of the functions omitted a critical check for the existence of the download directory. This  led to errors when attempting to fetch resources for the first time on a device. This pull request introduces a single line of code that fixes this issue.
Thanks @pweglik  for noticing. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
