### PR TITLE
feat: enable 'no-console' lint rule for executorch src except Logger, add Logger.log method

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,6 @@ module.exports = {
   overrides: [
     {
       files: ['packages/react-native-executorch/src/**/*.{js,jsx,ts,tsx}'],
-      excludedFiles: ['packages/react-native-executorch/src/common/Logger.ts'],
       rules: {
         'no-console': 'warn',
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,13 @@ module.exports = {
   plugins: ['prettier', 'markdown'],
   overrides: [
     {
+      files: ['packages/react-native-executorch/src/**/*.{js,jsx,ts,tsx}'],
+      excludedFiles: ['packages/react-native-executorch/src/common/Logger.ts'],
+      rules: {
+        'no-console': 'warn',
+      },
+    },
+    {
       files: ['**/*.md'],
       processor: 'markdown/markdown',
     },

--- a/packages/react-native-executorch/src/common/Logger.ts
+++ b/packages/react-native-executorch/src/common/Logger.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 export class Logger {
   private static readonly PREFIX = '[React Native ExecuTorch]';
 

--- a/packages/react-native-executorch/src/common/Logger.ts
+++ b/packages/react-native-executorch/src/common/Logger.ts
@@ -1,6 +1,10 @@
 export class Logger {
   private static readonly PREFIX = '[React Native ExecuTorch]';
 
+  static log(...data: any[]) {
+    console.log(Logger.PREFIX, ...data);
+  }
+
   static debug(...data: any[]) {
     console.debug(Logger.PREFIX, ...data);
   }


### PR DESCRIPTION
## Description

Changes:
- Added a new override to enforce the no-console rule for files in `react-native-executorch/src`, excluding Logger.ts
- Added a static log method to Logger class

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings