### PR TITLE
Remove redundant UndefinedError from error messages

### DIFF
--- a/packages/react-native-executorch/src/Error.ts
+++ b/packages/react-native-executorch/src/Error.ts
@@ -55,7 +55,7 @@ export const getError = (e: unknown | ETError | Error): string => {
     : ' ' + error.message.slice(`${errorCode}`.length).trimStart();
 
   const ETErrorMessage = (
-    errorCode in ETError ? ETError[errorCode] : ETError[ETError.UndefinedError]
+    errorCode in ETError ? ETError[errorCode] : ''
   ) as string;
 
   return ETErrorMessage + message;


### PR DESCRIPTION
## Description

Improves the way Error messages are logged. e.g. changes:
`LLM error: [Error: UndefinedErrorUndefinedErrorTesing error message]` -> `LLM error: [Error: Tesing error message]`

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

* Add artificial error e.g. in `load` function of `LLMControler.ts`: 
```ts
throw new Error(getError(Error("Tesing error message")));
```

* Run demo app with llms and click `LLM` button.
* Check that `LLM error: [Error: Tesing error message]` is logged into console. Now revert change and check that now error looks like this: `LLM error: [Error: UndefinedErrorUndefinedErrorTesing error message]`

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

#462 

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
