### PR TITLE
Update `react-native-audio-api` dependency to prevent demo app crash

### DIFF
--- a/apps/speech-to-text/package.json
+++ b/apps/speech-to-text/package.json
@@ -22,7 +22,7 @@
     "metro-config": "^0.81.0",
     "react": "19.0.0",
     "react-native": "0.79.2",
-    "react-native-audio-api": "0.5.7",
+    "react-native-audio-api": "0.6.5",
     "react-native-device-info": "^14.0.4",
     "react-native-executorch": "workspace:*",
     "react-native-image-picker": "^7.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12465,6 +12465,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-audio-api@npm:0.6.5":
+  version: 0.6.5
+  resolution: "react-native-audio-api@npm:0.6.5"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  bin:
+    setup-rn-audio-api-web: scripts/setup-rn-audio-api-web.js
+  checksum: 10/9bf5b124ff902f359a237bcd3c386a37b354cc6263ce66765c1788c7a8d42c307a133780c8b57ab2f0db530bfed8ac1d3ff8fb55055228854ccebc8da9a595d8
+  languageName: node
+  linkType: hard
+
 "react-native-builder-bob@npm:^0.30.2":
   version: 0.30.3
   resolution: "react-native-builder-bob@npm:0.30.3"
@@ -13652,7 +13664,7 @@ __metadata:
     metro-config: "npm:^0.81.0"
     react: "npm:19.0.0"
     react-native: "npm:0.79.2"
-    react-native-audio-api: "npm:0.5.7"
+    react-native-audio-api: "npm:0.6.5"
     react-native-device-info: "npm:^14.0.4"
     react-native-executorch: "workspace:*"
     react-native-image-picker: "npm:^7.2.2"


### PR DESCRIPTION
Prevents crash in speech to text app.

Closes #467 

## Description

Currently, the app crashes after clicking `Transcribe with URL`. Bump of `react-native-audio-api` prevents this crash.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improves or adds clarity to existing documentation)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

Test before and after the change. You should see that after installing node modules with updated package app does not crash.

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

#467 

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
