### PR TITLE
Resource Fetcher Set Callback to 1 when download is Finished

### DIFF
--- a/packages/react-native-executorch/src/utils/ResourceFetcher.ts
+++ b/packages/react-native-executorch/src/utils/ResourceFetcher.ts
@@ -151,6 +151,7 @@ export class ResourceFetcher {
       nextSource.results.push(...sourceExtended.results);
       return this.singleFetch(nextSource);
     }
+    sourceExtended.callback!(1);
     return sourceExtended.results;
   }
 


### PR DESCRIPTION
## Description
Previously, if resources were already downloaded, callback could remain at 0. 

Now, always before returning ResourceFetcher sets the callback to 1. 

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
