### PR TITLE
fix: error messages formatting (#476)

### DIFF
--- a/packages/react-native-executorch/src/Error.ts
+++ b/packages/react-native-executorch/src/Error.ts
@@ -7,7 +7,7 @@ export enum ETError {
   LanguageNotSupported = 0x69,
   InvalidModelSource = 0xff,
 
-  //SpeechToText errors
+  // SpeechToText errors
   MultilingualConfiguration = 0xa0,
   MissingDataChunk = 0xa1,
   StreamingNotStarted = 0xa2,
@@ -43,20 +43,16 @@ export enum ETError {
 
 export const getError = (e: unknown | ETError | Error): string => {
   if (typeof e === 'number') {
-    if (e in ETError) return ETError[e] as string;
-    return ETError[ETError.UndefinedError] as string;
+    return ETError[e] ?? ETError[ETError.UndefinedError];
   }
 
   // try to extract number from message (can contain false positives)
   const error = e as Error;
   const errorCode = parseInt(error.message, 10);
-  const message = Number.isNaN(errorCode)
-    ? error.message
-    : ' ' + error.message.slice(`${errorCode}`.length).trimStart();
 
-  const ETErrorMessage = (
-    errorCode in ETError ? ETError[errorCode] : ETError[ETError.UndefinedError]
-  ) as string;
+  if (Number.isNaN(errorCode)) {
+    return error.message;
+  }
 
-  return ETErrorMessage + message;
+  return ETError[errorCode] ?? ETError[ETError.UndefinedError];
 };


### PR DESCRIPTION
## Description

Fix error messages formatting

from
```
[Error: UndefinedErrorModuleNotLoaded]
```
to:
```
[Error: MultilingualConfiguration]
```

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings