### PR TITLE
refactor: C++ consts to SCREAMING_SNAKE_CASE.

### DIFF
--- a/packages/react-native-executorch/common/rnexecutorch/host_objects/JsiConversions.h
+++ b/packages/react-native-executorch/common/rnexecutorch/host_objects/JsiConversions.h
@@ -369,9 +369,10 @@ inline jsi::Value getJsiValue(const std::vector<Detection> &detections,
     bbox.setProperty(runtime, "y2", detections[i].y2);
 
     detection.setProperty(runtime, "bbox", bbox);
-    detection.setProperty(runtime, "label",
-                          jsi::String::createFromAscii(
-                              runtime, cocoLabelsMap.at(detections[i].label)));
+    detection.setProperty(
+        runtime, "label",
+        jsi::String::createFromAscii(runtime,
+                                     COCO_LABELS_MAP.at(detections[i].label)));
     detection.setProperty(runtime, "score", detections[i].score);
     array.setValueAtIndex(runtime, i, detection);
   }

--- a/packages/react-native-executorch/common/rnexecutorch/models/classification/Classification.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/classification/Classification.cpp
@@ -49,13 +49,13 @@ Classification::postprocess(const Tensor &tensor) {
       static_cast<const float *>(tensor.const_data_ptr()), tensor.numel());
   std::vector<float> resultVec(resultData.begin(), resultData.end());
 
-  if (resultVec.size() != imagenet1k_v1_labels.size()) {
+  if (resultVec.size() != IMAGENET1K_V1_LABELS.size()) {
     char errorMessage[100];
     std::snprintf(
         errorMessage, sizeof(errorMessage),
         "Unexpected classification output size, was expecting: %zu classes "
         "but got: %zu classes",
-        imagenet1k_v1_labels.size(), resultVec.size());
+        IMAGENET1K_V1_LABELS.size(), resultVec.size());
     throw std::runtime_error(errorMessage);
   }
 
@@ -63,7 +63,7 @@ Classification::postprocess(const Tensor &tensor) {
 
   std::unordered_map<std::string_view, float> probs;
   for (std::size_t cl = 0; cl < resultVec.size(); ++cl) {
-    probs[imagenet1k_v1_labels[cl]] = resultVec[cl];
+    probs[IMAGENET1K_V1_LABELS[cl]] = resultVec[cl];
   }
 
   return probs;

--- a/packages/react-native-executorch/common/rnexecutorch/models/classification/Constants.h
+++ b/packages/react-native-executorch/common/rnexecutorch/models/classification/Constants.h
@@ -4,7 +4,7 @@
 #include <string_view>
 
 namespace rnexecutorch {
-inline constexpr std::array<std::string_view, 1000> imagenet1k_v1_labels = {
+inline constexpr std::array<std::string_view, 1000> IMAGENET1K_V1_LABELS = {
     "tench, Tinca tinca",
     "goldfish, Carassius auratus",
     "great white shark, white shark, man-eater, man-eating shark, Carcharodon "

--- a/packages/react-native-executorch/common/rnexecutorch/models/image_segmentation/Constants.h
+++ b/packages/react-native-executorch/common/rnexecutorch/models/image_segmentation/Constants.h
@@ -4,7 +4,7 @@
 #include <string_view>
 
 namespace rnexecutorch {
-inline constexpr std::array<std::string_view, 21> deeplabv3_resnet50_labels = {
+inline constexpr std::array<std::string_view, 21> DEEPLABV3_RESNET50_LABELS = {
     "BACKGROUND", "AEROPLANE",   "BICYCLE", "BIRD",  "BOAT",
     "BOTTLE",     "BUS",         "CAR",     "CAT",   "CHAIR",
     "COW",        "DININGTABLE", "DOG",     "HORSE", "MOTORBIKE",

--- a/packages/react-native-executorch/common/rnexecutorch/models/image_segmentation/ImageSegmentation.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/image_segmentation/ImageSegmentation.cpp
@@ -101,8 +101,8 @@ std::shared_ptr<jsi::Object> ImageSegmentation::postprocess(
   auto buffersToReturn = std::make_shared<std::unordered_map<
       std::string_view, std::shared_ptr<OwningArrayBuffer>>>();
   for (std::size_t cl = 0; cl < numClasses; ++cl) {
-    if (classesOfInterest.contains(deeplabv3_resnet50_labels[cl])) {
-      (*buffersToReturn)[deeplabv3_resnet50_labels[cl]] = resultClasses[cl];
+    if (classesOfInterest.contains(DEEPLABV3_RESNET50_LABELS[cl])) {
+      (*buffersToReturn)[DEEPLABV3_RESNET50_LABELS[cl]] = resultClasses[cl];
     }
   }
 

--- a/packages/react-native-executorch/common/rnexecutorch/models/image_segmentation/ImageSegmentation.h
+++ b/packages/react-native-executorch/common/rnexecutorch/models/image_segmentation/ImageSegmentation.h
@@ -36,7 +36,7 @@ private:
                                          std::shared_ptr<OwningArrayBuffer>>>
           classesToOutput);
 
-  static constexpr std::size_t numClasses{deeplabv3_resnet50_labels.size()};
+  static constexpr std::size_t numClasses{DEEPLABV3_RESNET50_LABELS.size()};
   cv::Size modelImageSize;
   std::size_t numModelPixels;
 };

--- a/packages/react-native-executorch/common/rnexecutorch/models/object_detection/Constants.h
+++ b/packages/react-native-executorch/common/rnexecutorch/models/object_detection/Constants.h
@@ -4,7 +4,7 @@
 #include <unordered_map>
 
 namespace rnexecutorch {
-const std::unordered_map<int, std::string> cocoLabelsMap = {
+inline const std::unordered_map<int, std::string> COCO_LABELS_MAP = {
     {1, "PERSON"},         {2, "BICYCLE"},       {3, "CAR"},
     {4, "MOTORCYCLE"},     {5, "AIRPLANE"},      {6, "BUS"},
     {7, "TRAIN"},          {8, "TRUCK"},         {9, "BOAT"},

--- a/packages/react-native-executorch/common/rnexecutorch/models/object_detection/Utils.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/object_detection/Utils.cpp
@@ -1,4 +1,5 @@
 #include "Utils.h"
+#include "Constants.h"
 
 namespace rnexecutorch {
 float intersectionOverUnion(const Detection &a, const Detection &b) {
@@ -48,7 +49,7 @@ std::vector<Detection> nonMaxSuppression(std::vector<Detection> detections) {
           std::remove_if(labelDetections.begin(), labelDetections.end(),
                          [&current](const Detection &other) {
                            return intersectionOverUnion(current, other) >
-                                  iouThreshold;
+                                  IOU_THRESHOLD;
                          }),
           labelDetections.end());
     }

--- a/packages/react-native-executorch/common/rnexecutorch/models/object_detection/Utils.h
+++ b/packages/react-native-executorch/common/rnexecutorch/models/object_detection/Utils.h
@@ -12,7 +12,7 @@ struct Detection {
   float score;
 };
 
-inline constexpr float iouThreshold = 0.55;
+inline constexpr float IOU_THRESHOLD = 0.55;
 
 float intersectionOverUnion(const Detection &a, const Detection &b);
 std::vector<Detection> nonMaxSuppression(std::vector<Detection> detections);

--- a/packages/react-native-executorch/common/rnexecutorch/models/ocr/Constants.h
+++ b/packages/react-native-executorch/common/rnexecutorch/models/ocr/Constants.h
@@ -5,31 +5,30 @@
 
 namespace rnexecutorch::ocr {
 
-inline constexpr float textThreshold = 0.4;
-inline constexpr float textThresholdVertical = 0.3;
-inline constexpr float linkThreshold = 0.4;
-inline constexpr float lowTextThreshold = 0.7;
-inline constexpr float centerThreshold = 0.5;
-inline constexpr float distanceThreshold = 2.0;
-inline constexpr float heightThreshold = 2.0;
-inline constexpr float singleCharacterCenterThreshold = 0.3;
-inline constexpr float lowConfidenceThreshold = 0.3;
-inline constexpr float adjustContrast = 0.2;
-inline constexpr int32_t minSideThreshold = 15;
-inline constexpr int32_t maxSideThreshold = 30;
-inline constexpr int32_t recognizerHeight = 64;
-inline constexpr int32_t largeRecognizerWidth = 512;
-inline constexpr int32_t mediumRecognizerWidth = 256;
-inline constexpr int32_t smallRecognizerWidth = 128;
-inline constexpr int32_t smallVerticalRecognizerWidth = 64;
-inline constexpr int32_t maxWidth =
-    largeRecognizerWidth + (largeRecognizerWidth * 0.15);
-inline constexpr int32_t minSize = 20;
-inline constexpr int32_t singleCharacterMinSize = 70;
-inline constexpr int32_t recognizerImageSize = 1280;
-inline constexpr int32_t verticalLineThreshold = 20;
+inline constexpr float TEXT_THRESHOLD = 0.4;
+inline constexpr float TEXT_THRESHOLD_VERTICAL = 0.3;
+inline constexpr float LINK_THRESHOLD = 0.4;
+inline constexpr float LOW_TEXT_THRESHOLD = 0.7;
+inline constexpr float CENTER_THRESHOLD = 0.5;
+inline constexpr float DISTANCE_THRESHOLD = 2.0;
+inline constexpr float HEIGHT_THRESHOLD = 2.0;
+inline constexpr float SINGLE_CHARACTER_CENTER_THRESHOLD = 0.3;
+inline constexpr float LOW_CONFIDENCE_THRESHOLD = 0.3;
+inline constexpr float ADJUST_CONTRAST = 0.2;
+inline constexpr int32_t MIN_SIDE_THRESHOLD = 15;
+inline constexpr int32_t MAX_SIDE_THRESHOLD = 30;
+inline constexpr int32_t RECOGNIZER_HEIGHT = 64;
+inline constexpr int32_t LARGE_RECOGNIZER_WIDTH = 512;
+inline constexpr int32_t MEDIUM_RECOGNIZER_WIDTH = 256;
+inline constexpr int32_t SMALL_RECOGNIZER_WIDTH = 128;
+inline constexpr int32_t SMALL_VERTICAL_RECOGNIZER_WIDTH = 64;
+inline constexpr int32_t MAX_WIDTH =
+    LARGE_RECOGNIZER_WIDTH + (LARGE_RECOGNIZER_WIDTH * 0.15);
+inline constexpr int32_t SINGLE_CHARACTER_MIN_SIZE = 70;
+inline constexpr int32_t RECOGNIZER_IMAGE_SIZE = 1280;
+inline constexpr int32_t VERTICAL_LINE_THRESHOLD = 20;
 
-inline const cv::Scalar mean(0.485, 0.456, 0.406);
-inline const cv::Scalar variance(0.229, 0.224, 0.225);
+inline const cv::Scalar MEAN(0.485, 0.456, 0.406);
+inline const cv::Scalar VARIANCE(0.229, 0.224, 0.225);
 
 } // namespace rnexecutorch::ocr

--- a/packages/react-native-executorch/common/rnexecutorch/models/ocr/Detector.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/ocr/Detector.cpp
@@ -36,7 +36,7 @@ std::vector<ocr::DetectorBBox> Detector::generate(const cv::Mat &inputImage) {
   cv::Mat resizedInputImage =
       imageprocessing::resizePadded(inputImage, getModelImageSize());
   TensorPtr inputTensor = imageprocessing::getTensorFromMatrix(
-      inputShapes[0], resizedInputImage, ocr::mean, ocr::variance);
+      inputShapes[0], resizedInputImage, ocr::MEAN, ocr::VARIANCE);
   auto forwardResult = BaseModel::forward(inputTensor);
   if (!forwardResult.ok()) {
     throw std::runtime_error(
@@ -73,8 +73,8 @@ Detector::postprocess(const Tensor &tensor) const {
    DetectorUtils.cpp.
   */
   std::vector<ocr::DetectorBBox> bBoxesList = ocr::getDetBoxesFromTextMap(
-      scoreTextMat, scoreAffinityMat, ocr::textThreshold, ocr::linkThreshold,
-      ocr::lowTextThreshold);
+      scoreTextMat, scoreAffinityMat, ocr::TEXT_THRESHOLD, ocr::LINK_THRESHOLD,
+      ocr::LOW_TEXT_THRESHOLD);
 
   /*
    Bounding boxes are at first corresponding to the 400x400 size or 640x640.
@@ -83,7 +83,7 @@ Detector::postprocess(const Tensor &tensor) const {
    (3.2 or 2.0).
   */
   const float restoreRatio =
-      ocr::calculateRestoreRatio(scoreTextMat.rows, ocr::recognizerImageSize);
+      ocr::calculateRestoreRatio(scoreTextMat.rows, ocr::RECOGNIZER_IMAGE_SIZE);
   ocr::restoreBboxRatio(bBoxesList, restoreRatio);
   /*
    Since every bounding box is processed separately by Recognition models, we'd
@@ -91,10 +91,10 @@ Detector::postprocess(const Tensor &tensor) const {
    process many words / full line at once. It is not only faster but also easier
    for Recognizer models than recognition of single characters.
   */
-  bBoxesList = ocr::groupTextBoxes(bBoxesList, ocr::centerThreshold,
-                                   ocr::distanceThreshold, ocr::heightThreshold,
-                                   ocr::minSideThreshold, ocr::maxSideThreshold,
-                                   ocr::maxWidth);
+  bBoxesList = ocr::groupTextBoxes(
+      bBoxesList, ocr::CENTER_THRESHOLD, ocr::DISTANCE_THRESHOLD,
+      ocr::HEIGHT_THRESHOLD, ocr::MIN_SIDE_THRESHOLD, ocr::MAX_SIDE_THRESHOLD,
+      ocr::MAX_WIDTH);
 
   return bBoxesList;
 }

--- a/packages/react-native-executorch/common/rnexecutorch/models/ocr/DetectorUtils.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/ocr/DetectorUtils.cpp
@@ -398,7 +398,7 @@ fitLineToShortestSides(const std::array<Point, 4> &points) {
   constexpr double accuracy =
       0.01; // sufficient accuracy. Value proposed by OPENCV
 
-  isVertical = dx < verticalLineThreshold;
+  isVertical = dx < VERTICAL_LINE_THRESHOLD;
   if (isVertical) {
     for (auto &pt : cvMidPoints) {
       std::swap(pt.x, pt.y);

--- a/packages/react-native-executorch/common/rnexecutorch/models/ocr/OCR.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/ocr/OCR.cpp
@@ -35,7 +35,7 @@ std::vector<OCRDetection> OCR::generate(std::string input) {
   */
   std::vector<OCRDetection> result = recognitionHandler.recognize(
       bboxesList, image,
-      cv::Size(ocr::recognizerImageSize, ocr::recognizerImageSize));
+      cv::Size(ocr::RECOGNIZER_IMAGE_SIZE, ocr::RECOGNIZER_IMAGE_SIZE));
 
   return result;
 }

--- a/packages/react-native-executorch/common/rnexecutorch/models/ocr/RecognitionHandler.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/ocr/RecognitionHandler.cpp
@@ -22,10 +22,10 @@ std::pair<std::vector<int32_t>, float>
 RecognitionHandler::runModel(cv::Mat image) {
 
   // Note that the height of an  image is always equal to 64.
-  if (image.cols >= ocr::largeRecognizerWidth) {
+  if (image.cols >= ocr::LARGE_RECOGNIZER_WIDTH) {
     return recognizerLarge.generate(image);
   }
-  if (image.cols >= ocr::mediumRecognizerWidth) {
+  if (image.cols >= ocr::MEDIUM_RECOGNIZER_WIDTH) {
     return recognizerMedium.generate(image);
   }
   return recognizerSmall.generate(image);
@@ -39,7 +39,7 @@ void RecognitionHandler::processBBox(std::vector<OCRDetection> &boxList,
     Resize the cropped image to have height = 64 (height accepted by
     Recognizer).
   */
-  auto croppedImage = ocr::cropImage(box, imgGray, ocr::recognizerHeight);
+  auto croppedImage = ocr::cropImage(box, imgGray, ocr::RECOGNIZER_HEIGHT);
 
   if (croppedImage.empty()) {
     return;
@@ -50,10 +50,10 @@ void RecognitionHandler::processBBox(std::vector<OCRDetection> &boxList,
     128x64, 256x64, 512x64.
   */
   croppedImage = ocr::normalizeForRecognizer(
-      croppedImage, ocr::recognizerHeight, ocr::adjustContrast, false);
+      croppedImage, ocr::RECOGNIZER_HEIGHT, ocr::ADJUST_CONTRAST, false);
 
   auto [predictionIndices, confidenceScore] = this->runModel(croppedImage);
-  if (confidenceScore < ocr::lowConfidenceThreshold) {
+  if (confidenceScore < ocr::LOW_CONFIDENCE_THRESHOLD) {
     cv::rotate(croppedImage, croppedImage, cv::ROTATE_180);
     auto [rotatedPredictionIndices, rotatedConfidenceScore] =
         runModel(croppedImage);

--- a/packages/react-native-executorch/common/rnexecutorch/models/ocr/RecognitionHandlerUtils.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/ocr/RecognitionHandlerUtils.cpp
@@ -126,13 +126,13 @@ void adjustContrastGrey(cv::Mat &img, double target) {
 
 int32_t getDesiredWidth(const cv::Mat &img, bool isVertical) {
 
-  if (img.cols >= largeRecognizerWidth) {
-    return largeRecognizerWidth;
+  if (img.cols >= LARGE_RECOGNIZER_WIDTH) {
+    return LARGE_RECOGNIZER_WIDTH;
   }
-  if (img.cols >= mediumRecognizerWidth) {
-    return mediumRecognizerWidth;
+  if (img.cols >= MEDIUM_RECOGNIZER_WIDTH) {
+    return MEDIUM_RECOGNIZER_WIDTH;
   }
-  return isVertical ? smallVerticalRecognizerWidth : smallRecognizerWidth;
+  return isVertical ? SMALL_VERTICAL_RECOGNIZER_WIDTH : SMALL_RECOGNIZER_WIDTH;
 }
 
 cv::Mat normalizeForRecognizer(const cv::Mat &image, int32_t modelHeight,

--- a/packages/react-native-executorch/common/rnexecutorch/models/ocr/RecognizerUtils.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/ocr/RecognizerUtils.cpp
@@ -107,10 +107,10 @@ cv::Mat characterBitMask(const cv::Mat &img) {
 
   const int32_t height = thresh.rows;
   const int32_t width = thresh.cols;
-  const int32_t minX = ocr::singleCharacterCenterThreshold * width;
-  const int32_t maxX = (1 - ocr::singleCharacterCenterThreshold) * width;
-  const int32_t minY = ocr::singleCharacterCenterThreshold * height;
-  const int32_t maxY = (1 - ocr::singleCharacterCenterThreshold) * height;
+  const int32_t minX = ocr::SINGLE_CHARACTER_CENTER_THRESHOLD * width;
+  const int32_t maxX = (1 - ocr::SINGLE_CHARACTER_CENTER_THRESHOLD) * width;
+  const int32_t minY = ocr::SINGLE_CHARACTER_CENTER_THRESHOLD * height;
+  const int32_t maxY = (1 - ocr::SINGLE_CHARACTER_CENTER_THRESHOLD) * height;
 
   int32_t selectedComponent = -1;
   int32_t maxArea = -1;
@@ -120,8 +120,8 @@ cv::Mat characterBitMask(const cv::Mat &img) {
     const double cy = centroids.at<double>(i, 1);
 
     if ((minX < cx && cx < maxX && minY < cy &&
-         cy < maxY &&                           // check if centered
-         area > ocr::singleCharacterMinSize) && // check if large enough
+         cy < maxY &&                              // check if centered
+         area > ocr::SINGLE_CHARACTER_MIN_SIZE) && // check if large enough
         area > maxArea) {
       selectedComponent = i;
       maxArea = area;
@@ -193,9 +193,10 @@ cv::Mat prepareForRecognition(const cv::Mat &originalImage,
   auto croppedChar = cropImageWithBoundingBox(originalImage, bbox, originalBbox,
                                               paddings, originalPaddings);
   cv::cvtColor(croppedChar, croppedChar, cv::COLOR_BGR2GRAY);
-  cv::resize(croppedChar, croppedChar,
-             cv::Size(ocr::smallVerticalRecognizerWidth, ocr::recognizerHeight),
-             0, 0, cv::INTER_AREA);
+  cv::resize(
+      croppedChar, croppedChar,
+      cv::Size(ocr::SMALL_VERTICAL_RECOGNIZER_WIDTH, ocr::RECOGNIZER_HEIGHT), 0,
+      0, cv::INTER_AREA);
   return croppedChar;
 }
 } // namespace rnexecutorch::ocr

--- a/packages/react-native-executorch/common/rnexecutorch/models/ocr/RecognizerUtils.h
+++ b/packages/react-native-executorch/common/rnexecutorch/models/ocr/RecognizerUtils.h
@@ -56,7 +56,8 @@ cv::Mat cropImageWithBoundingBox(const cv::Mat &img,
  * Prepare for Recognition by following steps:
  * 1. Crop image to the character bounding box,
  * 2. Convert Image to gray.
- * 3. Resize it to [smallVerticalRecognizerWidth x recognizerHeight] (64 x 64).
+ * 3. Resize it to [SMALL_VERTICAL_RECOGNIZER_WIDTH x RECOGNIZER_HEIGHT] (64 x
+ * 64).
  *
  * @details it utilizes cropImageWithBoundingBox to perform specific cropping.
  */

--- a/packages/react-native-executorch/common/rnexecutorch/models/vertical_ocr/VerticalDetector.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/vertical_ocr/VerticalDetector.cpp
@@ -37,7 +37,7 @@ VerticalDetector::generate(const cv::Mat &inputImage) {
   cv::Mat resizedInputImage =
       imageprocessing::resizePadded(inputImage, getModelImageSize());
   TensorPtr inputTensor = imageprocessing::getTensorFromMatrix(
-      inputShapes[0], resizedInputImage, ocr::mean, ocr::variance);
+      inputShapes[0], resizedInputImage, ocr::MEAN, ocr::VARIANCE);
   auto forwardResult = BaseModel::forward(inputTensor);
   if (!forwardResult.ok()) {
     throw std::runtime_error(
@@ -68,22 +68,22 @@ VerticalDetector::postprocess(const Tensor &tensor) const {
       tensorData,
       cv::Size(modelImageSize.width / 2, modelImageSize.height / 2));
   float txtThreshold = this->detectSingleCharacters
-                           ? ocr::textThreshold
-                           : ocr::textThresholdVertical;
+                           ? ocr::TEXT_THRESHOLD
+                           : ocr::TEXT_THRESHOLD_VERTICAL;
   std::vector<ocr::DetectorBBox> bBoxesList =
       ocr::getDetBoxesFromTextMapVertical(scoreTextMat, scoreAffinityMat,
-                                          txtThreshold, ocr::linkThreshold,
+                                          txtThreshold, ocr::LINK_THRESHOLD,
                                           this->detectSingleCharacters);
   const float restoreRatio =
-      ocr::calculateRestoreRatio(scoreTextMat.rows, ocr::recognizerImageSize);
+      ocr::calculateRestoreRatio(scoreTextMat.rows, ocr::RECOGNIZER_IMAGE_SIZE);
   ocr::restoreBboxRatio(bBoxesList, restoreRatio);
 
   // if this is Narrow Detector, do not group boxes.
   if (!this->detectSingleCharacters) {
     bBoxesList = ocr::groupTextBoxes(
-        bBoxesList, ocr::centerThreshold, ocr::distanceThreshold,
-        ocr::heightThreshold, ocr::minSideThreshold, ocr::maxSideThreshold,
-        ocr::maxWidth);
+        bBoxesList, ocr::CENTER_THRESHOLD, ocr::DISTANCE_THRESHOLD,
+        ocr::HEIGHT_THRESHOLD, ocr::MIN_SIDE_THRESHOLD, ocr::MAX_SIDE_THRESHOLD,
+        ocr::MAX_WIDTH);
   }
 
   return bBoxesList;

--- a/packages/react-native-executorch/common/rnexecutorch/models/vertical_ocr/VerticalOCR.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/vertical_ocr/VerticalOCR.cpp
@@ -73,8 +73,8 @@ std::pair<std::string, float> VerticalOCR::_handleIndependentCharacters(
      to a bit mask with white character and black background.
     */
     croppedChar = ocr::characterBitMask(croppedChar);
-    croppedChar = ocr::normalizeForRecognizer(croppedChar,
-                                              ocr::recognizerHeight, 0.0, true);
+    croppedChar = ocr::normalizeForRecognizer(
+        croppedChar, ocr::RECOGNIZER_HEIGHT, 0.0, true);
 
     const auto &[predIndex, score] = recognizer.generate(croppedChar);
     if (!predIndex.empty()) {
@@ -100,7 +100,7 @@ std::pair<std::string, float> VerticalOCR::_handleJointCharacters(
      Prepare for Recognition by following steps:
      1. Crop image to the character bounding box,
      2. Convert Image to gray.
-     3. Resize it to [smallVerticalRecognizerWidth x recognizerHeight] (64 x
+     3. Resize it to [SMALL_VERTICAL_RECOGNIZER_WIDTH x RECOGNIZER_HEIGHT] (64 x
      64). The same height is required for horizontal concatenation of single
      characters into one image.
     */
@@ -113,9 +113,9 @@ std::pair<std::string, float> VerticalOCR::_handleJointCharacters(
   cv::hconcat(croppedCharacters, mergedCharacters);
   mergedCharacters = imageprocessing::resizePadded(
       mergedCharacters,
-      cv::Size(ocr::largeRecognizerWidth, ocr::recognizerHeight));
+      cv::Size(ocr::LARGE_RECOGNIZER_WIDTH, ocr::RECOGNIZER_HEIGHT));
   mergedCharacters = ocr::normalizeForRecognizer(
-      mergedCharacters, ocr::recognizerHeight, 0.0, false);
+      mergedCharacters, ocr::RECOGNIZER_HEIGHT, 0.0, false);
 
   const auto &[predIndex, confidenceScore] =
       recognizer.generate(mergedCharacters);


### PR DESCRIPTION
## Description

Previously, the constants in C++ code  were named using camelCase, which were also used for standard variables.
Not only it was weird and uncommon  practice,  but also could easily be very misleading and confusing.
For instance, some function arguments in the `DetectorUtils` file shared names with defined constants, making it very difficult to distinguish between them.

I was deciding between usage of SCREAMING_SNAKE_CASE and k-prefix approach, which is sometimes recommended in modern c++ (see for example [google guidelines](https://google.github.io/styleguide/cppguide.html#Constant_Names)).

Disadvantage of SCREAMING_CASE_SNAKE that is commonly mentioned, is that it looks exactly the same as preprocessor macro definition, but in our case I don't believe it is confusing, because we do not really use C macros.

I have decided that SCREAMING_SNAKE_CASE fits better our purposes, it is widely recognized and easily distinguishable from other variables. 

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

Closes #501 

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
