### PR TITLE
Fix: stop yarn typecheck from creating `.js` files inside project. 

### DIFF
--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "example": "yarn workspace react-native-executorch-example",
-    "typecheck": "tsc",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build lib",
     "prepare": "bob build"


### PR DESCRIPTION
## Description

Commit fea6dbfa25bc introduced a modification to `package.json` that caused an issue during the pre-commit hook.

Specifically, after this change, running `yarn typecheck` on any modified `.ts` file within `packages/react-native-executorch` would emit a corresponding `.js` file.

Adding the `--noEmit` flag to the `yarn typecheck` command,  prevents these extra files from being created.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
