### PR TITLE
Add word to cspell and fix naming clash

### DIFF
--- a/.cspell-wordlist.txt
+++ b/.cspell-wordlist.txt
@@ -61,3 +61,4 @@ endoftext
 softmax
 logit
 logits
+probs

--- a/packages/react-native-executorch/src/utils/SpeechToTextModule/ASR.ts
+++ b/packages/react-native-executorch/src/utils/SpeechToTextModule/ASR.ts
@@ -217,10 +217,10 @@ export class ASR {
 
   private async estimateWordTimestampsLinear(
     tokens: number[],
-    start: number,
-    end: number
+    timestampStart: number,
+    timestampEnd: number
   ): Promise<WordObject[]> {
-    const duration = (end - start) * this.timePrecision;
+    const duration = (timestampEnd - timestampStart) * this.timePrecision;
     const segmentText = (
       (await this.tokenizerModule.decode(tokens)) as string
     ).trim();
@@ -235,7 +235,7 @@ export class ASR {
 
     const wordObjects: WordObject[] = [];
     const startTimeOffset =
-      (start - this.timestampBeginToken) * this.timePrecision;
+      (timestampStart - this.timestampBeginToken) * this.timePrecision;
 
     let prevCharNum = 0;
     for (let j = 0; j < words.length; j++) {


### PR DESCRIPTION
## Description

Adds word `probs` to cspell to be recognized and renames two variables to avoid naming clash inside a function.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

Check if warnings are not present

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

#536 

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
