### PR TITLE
Fix: Resource Fetcher not loading downloaded models

### DIFF
--- a/packages/react-native-executorch/src/utils/ResourceFetcherUtils.ts
+++ b/packages/react-native-executorch/src/utils/ResourceFetcherUtils.ts
@@ -78,14 +78,11 @@ export namespace ResourceFetcherUtils {
     for (const source of sources) {
       const type = await ResourceFetcherUtils.getType(source);
       let length = 0;
-
-      if (type === SourceType.REMOTE_FILE && typeof source === 'string') {
-        try {
+      try {
+        if (type === SourceType.REMOTE_FILE && typeof source === 'string') {
           const response = await fetch(source, { method: 'HEAD' });
-          if (!response.ok) {
-            Logger.warn(
-              `Failed to fetch HEAD for ${source}: ${response.status}`
-            );
+          if (!response) {
+            Logger.warn(`Failed to fetch HEAD for ${source}: ${response}`);
             continue;
           }
 
@@ -97,14 +94,14 @@ export namespace ResourceFetcherUtils {
           length = contentLength ? parseInt(contentLength, 10) : 0;
           previousFilesTotalLength = totalLength;
           totalLength += length;
-        } catch (error) {
-          Logger.warn(`Error fetching HEAD for ${source}:`, error);
-          continue;
         }
+      } catch (error) {
+        Logger.warn(`Error fetching HEAD for ${source}:`, error);
+        continue;
+      } finally {
+        results.push({ source, type, length, previousFilesTotalLength });
       }
-      results.push({ source, type, length, previousFilesTotalLength });
     }
-
     return { results, totalLength };
   }
 

--- a/packages/react-native-executorch/src/utils/ResourceFetcherUtils.ts
+++ b/packages/react-native-executorch/src/utils/ResourceFetcherUtils.ts
@@ -81,8 +81,10 @@ export namespace ResourceFetcherUtils {
       try {
         if (type === SourceType.REMOTE_FILE && typeof source === 'string') {
           const response = await fetch(source, { method: 'HEAD' });
-          if (!response) {
-            Logger.warn(`Failed to fetch HEAD for ${source}: ${response}`);
+          if (!response.ok) {
+            Logger.warn(
+              `Failed to fetch HEAD for ${source}: ${response.status}`
+            );
             continue;
           }
 


### PR DESCRIPTION
## Description

Fixes a resource fetcher bug, which prevented from actually loading downloaded models without internet connection. 
Issue occurred due to the wrong error handling in the process of fetching head (to get the content length) of the resource. 

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

Closes #563 

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
