### PR TITLE
Remove `std::format` from c++ code to support _LIBCPP_STD_VER < 20

### DIFF
--- a/packages/react-native-executorch/common/rnexecutorch/RnExecutorchInstaller.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/RnExecutorchInstaller.cpp
@@ -16,7 +16,6 @@
 #if defined(__ANDROID__) && defined(__aarch64__)
 #include <executorch/extension/threadpool/cpuinfo_utils.h>
 #include <executorch/extension/threadpool/threadpool.h>
-#include <format>
 #include <rnexecutorch/Log.h>
 #endif
 
@@ -96,8 +95,7 @@ void RnExecutorchInstaller::injectJSIBindings(
 #if defined(__ANDROID__) && defined(__aarch64__)
   auto num_of_perf_cores =
       ::executorch::extension::cpuinfo::get_num_performant_cores();
-  log(LOG_LEVEL::Info,
-      std::format("Detected {} performant cores", num_of_perf_cores));
+  log(LOG_LEVEL::Info, "Detected ", num_of_perf_cores, " performant cores");
   // setting num_of_cores to floor(num_of_perf_cores / 2) + 1) because depending
   // on cpu arch as when possible we want to leave at least 2 performant cores
   // for other tasks (setting more actually results in drop of performance). For
@@ -107,8 +105,7 @@ void RnExecutorchInstaller::injectJSIBindings(
   auto num_of_cores = static_cast<uint32_t>(num_of_perf_cores / 2) + 1;
   ::executorch::extension::threadpool::get_threadpool()
       ->_unsafe_reset_threadpool(num_of_cores);
-  log(LOG_LEVEL::Info,
-      std::format("Configuring xnnpack for {} threads", num_of_cores));
+  log(LOG_LEVEL::Info, "Configuring xnnpack for ", num_of_cores, " threads", );
 #endif
 }
 

--- a/packages/react-native-executorch/common/rnexecutorch/data_processing/Numerical.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/data_processing/Numerical.cpp
@@ -2,9 +2,9 @@
 
 #include <algorithm>
 #include <cmath>
-#include <format>
 #include <limits>
 #include <numeric>
+#include <sstream>
 #include <string>
 
 namespace rnexecutorch::numerical {
@@ -44,12 +44,13 @@ void normalize(std::span<float> input) {
 std::vector<float> meanPooling(std::span<const float> modelOutput,
                                std::span<const int64_t> attnMask) {
   if (attnMask.empty() || modelOutput.size() % attnMask.size() != 0) {
-    throw std::invalid_argument(
-        std::format("Invalid dimensions for mean pooling, expected model "
-                    "output size to be divisible "
-                    "by the size of attention mask but got size: {} for model "
-                    "output and size: {} for attention mask",
-                    modelOutput.size(), attnMask.size()));
+    std::stringstream ss;
+    ss << "Invalid dimensions for mean pooling, expected model output size to "
+          "be divisible "
+       << "by the size of attention mask but got size: " << modelOutput.size()
+       << " for model output and size: " << attnMask.size()
+       << " for attention mask";
+    throw std::invalid_argument(ss.str());
   }
 
   auto attnMaskLength = attnMask.size();

--- a/packages/react-native-executorch/common/rnexecutorch/host_objects/ModelHostObject.h
+++ b/packages/react-native-executorch/common/rnexecutorch/host_objects/ModelHostObject.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <format>
 #include <ReactCommon/CallInvoker.h>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <tuple>
@@ -110,10 +110,10 @@ public:
   template <auto FnPtr> JSI_HOST_FUNCTION(synchronousHostFunction) {
     constexpr std::size_t functionArgCount = meta::getArgumentCount(FnPtr);
     if (functionArgCount != count) {
-      const auto errorMessage = std::format(
-          "Argument count mismatch, was expecting: {} but got: {}", 
-          functionArgCount, count
-      );
+      std::stringstream ss;
+      ss << "Argument count mismatch, was expecting: " << functionArgCount
+         << " but got: " << count;
+      const auto errorMessage = ss.str();
       throw jsi::JSError(runtime, errorMessage);
     }
 
@@ -156,9 +156,10 @@ public:
           constexpr std::size_t functionArgCount =
               meta::getArgumentCount(FnPtr);
           if (functionArgCount != count) {
-            const auto errorMessage = std::format(
-                "Argument count mismatch, was expecting: {} but got: {}",
-                functionArgCount, count);
+            std::stringstream ss;
+            ss << "Argument count mismatch, was expecting: " << functionArgCount
+               << " but got: " << count;
+            const auto errorMessage = ss.str();
             promise->reject(errorMessage);
             return;
           }


### PR DESCRIPTION
## Description

the c++ 20  `std::format` relies on c++ 17 `std::to_char` which was introduced later in libc++ effectively meaning that no build with target < iOS 16.3 can use `std::format`, (see [this](https://developer.apple.com/xcode/cpp/#c++17))

The simplest solution is to basically remove all `std::format` for now. 

The more future-realistic solutions could be considered. 
To see the more verbose discussion  go to #570.
### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
