### PR TITLE
docs: Fix overlap of accordion component with text

### DIFF
--- a/docs/src/css/overrides.css
+++ b/docs/src/css/overrides.css
@@ -162,7 +162,7 @@ table thead tr {
 }
 
 [class*='details'] + p {
-  margin-top: 15px;
+  margin-top: 1rem;
 }
 
 [class*='theme-doc-sidebar-item-category-level-'] {


### PR DESCRIPTION
## Description

As in the title, this PR fixes overlap of accordion component with text below. Refer to this issue:  https://github.com/software-mansion-labs/t-rex-ui/issues/42

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

Build documentation and check the page from linked issue above

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
