### PR TITLE
chore: Get rid of compiler warnings

### DIFF
--- a/packages/react-native-executorch/android/CMakeLists.txt
+++ b/packages/react-native-executorch/android/CMakeLists.txt
@@ -14,4 +14,7 @@ set(COMMON_CPP_DIR "${CMAKE_SOURCE_DIR}/../common")
 set(LIBS_DIR "${CMAKE_SOURCE_DIR}/../third-party/android/libs")
 set(INCLUDE_DIR "${CMAKE_SOURCE_DIR}/../third-party/include")
 
+# Treat third-party headers as system headers to suppress deprecation warnings
+include_directories(SYSTEM "${INCLUDE_DIR}")
+
 add_subdirectory("${ANDROID_CPP_DIR}")

--- a/packages/react-native-executorch/common/rnexecutorch/TokenizerModule.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/TokenizerModule.cpp
@@ -8,9 +8,9 @@ using namespace facebook;
 
 TokenizerModule::TokenizerModule(
     std::string source, std::shared_ptr<react::CallInvoker> callInvoker)
-    : memorySizeLowerBound(std::filesystem::file_size(source)),
-      tokenizer(tokenizers::Tokenizer::FromBlobJSON(
-          file_utils::loadBytesFromFile(source))) {}
+    : tokenizer(tokenizers::Tokenizer::FromBlobJSON(
+          file_utils::loadBytesFromFile(source))),
+      memorySizeLowerBound(std::filesystem::file_size(source)) {}
 
 void TokenizerModule::ensureTokenizerLoaded(
     const std::string &methodName) const {

--- a/packages/react-native-executorch/common/rnexecutorch/models/ocr/CTCLabelConverter.h
+++ b/packages/react-native-executorch/common/rnexecutorch/models/ocr/CTCLabelConverter.h
@@ -23,7 +23,7 @@ public:
                                         size_t length);
 
 private:
-  std::vector<std::string> character;
   int32_t ignoreIdx;
+  std::vector<std::string> character;
 };
 } // namespace rnexecutorch::models::ocr

--- a/packages/react-native-executorch/common/rnexecutorch/models/ocr/utils/RecognitionHandlerUtils.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/ocr/utils/RecognitionHandlerUtils.cpp
@@ -60,16 +60,19 @@ cv::Mat cropImage(types::DetectorBBox box, cv::Mat &image,
   cv::warpAffine(image, rotatedImage, rotationMatrix, image.size(),
                  cv::INTER_LINEAR);
 
-  cv::Mat rectMat(4, 2, CV_32FC2);
+  constexpr int32_t rows = 4;
+  constexpr int32_t cols = 2;
+  cv::Mat rectMat(rows, cols, CV_32FC2);
 #pragma unroll
-  for (int32_t i = 0; i < rectMat.rows; ++i) {
+  for (int32_t i = 0; i < rows; ++i) {
     rectMat.at<cv::Vec2f>(i, 0) = cv::Vec2f(rectPoints[i].x, rectPoints[i].y);
   }
   cv::transform(rectMat, rectMat, rotationMatrix);
 
-  std::vector<cv::Point2f> transformedPoints(4);
+  constexpr size_t transformedPointsSize = 4;
+  std::vector<cv::Point2f> transformedPoints(transformedPointsSize);
 #pragma unroll
-  for (std::size_t i = 0; i < transformedPoints.size(); ++i) {
+  for (std::size_t i = 0; i < transformedPointsSize; ++i) {
     cv::Vec2f point = rectMat.at<cv::Vec2f>(i, 0);
     transformedPoints[i] = cv::Point2f(point[0], point[1]);
   }

--- a/packages/react-native-executorch/common/rnexecutorch/models/text_to_image/Scheduler.h
+++ b/packages/react-native-executorch/common/rnexecutorch/models/text_to_image/Scheduler.h
@@ -30,7 +30,6 @@ private:
   std::vector<float> tempFirstSample;
   std::vector<std::vector<float>> ets;
   float finalAlphaCumprod{1.0f};
-  float initNoiseSigma{1.0f};
 
   size_t numInferenceSteps{0};
 

--- a/packages/react-native-executorch/common/rnexecutorch/models/text_to_image/TextToImage.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/text_to_image/TextToImage.cpp
@@ -62,7 +62,6 @@ TextToImage::generate(std::string input, int32_t imageSize,
   auto embeddingsTensor =
       make_tensor_ptr(embeddingsShape, embeddings.data(), ScalarType::Float);
 
-  constexpr int32_t latentDownsample = 8;
   int32_t latentsSize = numChannels * latentImageSize * latentImageSize;
   std::vector<float> latents(latentsSize);
   std::mt19937 gen(seed);

--- a/packages/react-native-executorch/common/runner/irunner.h
+++ b/packages/react-native-executorch/common/runner/irunner.h
@@ -21,7 +21,7 @@ namespace executorch {
 namespace extension {
 namespace llm {
 
-class ET_EXPERIMENTAL IRunner {
+class IRunner {
 public:
   virtual ~IRunner() = default;
 

--- a/packages/react-native-executorch/common/runner/runner.cpp
+++ b/packages/react-native-executorch/common/runner/runner.cpp
@@ -39,7 +39,6 @@ std::string loadBytesFromFile(const std::string &path) {
 
 namespace {
 static constexpr auto kEnableDynamicShape = "enable_dynamic_shape";
-static constexpr auto kBosId = "get_bos_id";
 static constexpr auto kEosIds = "get_eos_ids";
 static constexpr auto kMaxSeqLen = "get_max_seq_len";
 static constexpr auto kMaxContextLen = "get_max_context_len";
@@ -175,10 +174,7 @@ Error Runner::generate(const std::string &prompt,
   stats_.inference_start_ms = llm::time_in_ms();
   shouldStop_ = false;
 
-  // Set the sequence length to the max seq length if not provided
-  int32_t seq_len = (seq_len > 0 && seq_len <= metadata_.at(kMaxSeqLen))
-                        ? seq_len
-                        : metadata_.at(kMaxSeqLen);
+  int32_t seq_len = metadata_.at(kMaxSeqLen);
 
   std::vector<int32_t> prompt_tokens = tokenizer_->Encode(prompt);
   std::vector<uint64_t> prompt_tokens_uint64(prompt_tokens.begin(),

--- a/packages/react-native-executorch/common/runner/runner.h
+++ b/packages/react-native-executorch/common/runner/runner.h
@@ -27,7 +27,7 @@
 
 namespace example {
 
-class ET_EXPERIMENTAL Runner : public executorch::extension::llm::IRunner {
+class Runner : public executorch::extension::llm::IRunner {
 public:
   explicit Runner(const std::string &model_path,
                   const std::string &tokenizer_path,

--- a/packages/react-native-executorch/common/runner/sampler.h
+++ b/packages/react-native-executorch/common/runner/sampler.h
@@ -26,12 +26,12 @@ namespace extension {
 namespace llm {
 // A simple llama2 sampler.
 
-template <typename T> struct ET_EXPERIMENTAL ProbIndex {
+template <typename T> struct ProbIndex {
   T prob;
   int32_t index;
 }; // struct used when sorting probabilities during top-p sampling
 
-class ET_EXPERIMENTAL Sampler {
+class Sampler {
 public:
   Sampler(int32_t vocab_size, float temperature, float topp,
           unsigned long long rng_seed);

--- a/packages/react-native-executorch/common/runner/stats.h
+++ b/packages/react-native-executorch/common/runner/stats.h
@@ -18,7 +18,7 @@ namespace executorch {
 namespace extension {
 namespace llm {
 
-struct ET_EXPERIMENTAL Stats {
+struct Stats {
   // Scaling factor for timestamps - in this case, we use ms.
   const long SCALING_FACTOR_UNITS_PER_SECOND = 1000;
   // Time stamps for the different stages of the execution

--- a/packages/react-native-executorch/common/runner/text_decoder_runner.h
+++ b/packages/react-native-executorch/common/runner/text_decoder_runner.h
@@ -20,7 +20,7 @@ namespace executorch {
 namespace extension {
 namespace llm {
 
-class ET_EXPERIMENTAL TextDecoderRunner {
+class TextDecoderRunner {
 public:
   TextDecoderRunner(Module *module, bool use_kv_cache, int32_t vocab_size,
                     float temperature);

--- a/packages/react-native-executorch/common/runner/text_prefiller.h
+++ b/packages/react-native-executorch/common/runner/text_prefiller.h
@@ -17,7 +17,7 @@ namespace executorch {
 namespace extension {
 namespace llm {
 
-class ET_EXPERIMENTAL TextPrefiller {
+class TextPrefiller {
 public:
   TextPrefiller(TextDecoderRunner *text_decoder_runner, bool use_kv_cache_,
                 bool enable_parallel_prefill);

--- a/packages/react-native-executorch/common/runner/text_token_generator.h
+++ b/packages/react-native-executorch/common/runner/text_token_generator.h
@@ -19,7 +19,7 @@ namespace executorch {
 namespace extension {
 namespace llm {
 
-class ET_EXPERIMENTAL TextTokenGenerator {
+class TextTokenGenerator {
 public:
   TextTokenGenerator(tokenizers::Tokenizer *tokenizer,
                      TextDecoderRunner *text_decoder_runner, bool use_kv_cache,
@@ -52,7 +52,6 @@ public:
 
     // Token after prefill
     uint64_t cur_token = tokens.back();
-    uint64_t prev_token;
     // cache to keep tokens if they were decoded into illegal character
     std::vector<int32_t> token_cache;
     // if first token after prefill was part of multi-token character we need to
@@ -88,8 +87,6 @@ public:
 
       ET_CHECK_OK_OR_RETURN_ERROR(logits_res.error());
       executorch::aten::Tensor &logits_tensor = logits_res.get();
-
-      prev_token = cur_token;
 
       stats_->on_sampling_begin();
       cur_token = text_decoder_runner_->logits_to_token(logits_tensor);

--- a/packages/react-native-executorch/common/runner/util.h
+++ b/packages/react-native-executorch/common/runner/util.h
@@ -41,7 +41,7 @@ namespace executorch {
 namespace extension {
 namespace llm {
 
-ET_EXPERIMENTAL void inline safe_printf(const char *piece) {
+void inline safe_printf(const char *piece) {
   // piece might be a raw byte token, and we only want to print printable chars
   // or whitespace because some of the other bytes can be various control codes,
   // backspace, etc.
@@ -63,7 +63,7 @@ ET_EXPERIMENTAL void inline safe_printf(const char *piece) {
 // ----------------------------------------------------------------------------
 // utilities: time
 
-ET_EXPERIMENTAL long inline time_in_ms() {
+long inline time_in_ms() {
   // return time in milliseconds, for benchmarking the model speed
   struct timespec time;
   clock_gettime(CLOCK_REALTIME, &time);
@@ -77,7 +77,7 @@ ET_EXPERIMENTAL long inline time_in_ms() {
 // RSS: Resident Set Size, the amount of memory currently in the RAM for this
 // process. These values are approximate, and are only used for logging
 // purposes.
-ET_EXPERIMENTAL size_t inline get_rss_bytes() {
+size_t inline get_rss_bytes() {
 #if defined(__linux__) || defined(__ANDROID__) || defined(__unix__)
   struct rusage r_usage;
   if (getrusage(RUSAGE_SELF, &r_usage) == 0) {


### PR DESCRIPTION
## Description

Fixes to remove warnings when compiling react-native-executorch:
- removed `ET_EXPERIMENTAL` markings from classes in `/packages/react-native-executorch/common/runner`
- suppressed deprecation warnings from third-party headers
- eliminated unused variables
- untangled recursive variable initialization

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Related issues

Closes #498

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
