### PR TITLE
Allow passing options to useSpeechToText model.stream()

### DIFF
--- a/packages/react-native-executorch/src/hooks/natural_language_processing/useSpeechToText.ts
+++ b/packages/react-native-executorch/src/hooks/natural_language_processing/useSpeechToText.ts
@@ -65,24 +65,29 @@ export const useSpeechToText = ({
     [isReady, isGenerating, modelInstance]
   );
 
-  const stream = useCallback(async (options?: DecodingOptions) => {
-    if (!isReady) throw new Error(getError(ETError.ModuleNotLoaded));
-    if (isGenerating) throw new Error(getError(ETError.ModelGenerating));
-    setIsGenerating(true);
-    setCommittedTranscription('');
-    setNonCommittedTranscription('');
-    let transcription = '';
-    try {
-      for await (const { committed, nonCommitted } of modelInstance.stream(options)) {
-        setCommittedTranscription((prev) => prev + committed);
-        setNonCommittedTranscription(nonCommitted);
-        transcription += committed;
+  const stream = useCallback(
+    async (options?: DecodingOptions) => {
+      if (!isReady) throw new Error(getError(ETError.ModuleNotLoaded));
+      if (isGenerating) throw new Error(getError(ETError.ModelGenerating));
+      setIsGenerating(true);
+      setCommittedTranscription('');
+      setNonCommittedTranscription('');
+      let transcription = '';
+      try {
+        for await (const { committed, nonCommitted } of modelInstance.stream(
+          options
+        )) {
+          setCommittedTranscription((prev) => prev + committed);
+          setNonCommittedTranscription(nonCommitted);
+          transcription += committed;
+        }
+      } finally {
+        setIsGenerating(false);
       }
-    } finally {
-      setIsGenerating(false);
-    }
-    return transcription;
-  }, [isReady, isGenerating, modelInstance]);
+      return transcription;
+    },
+    [isReady, isGenerating, modelInstance]
+  );
 
   const wrapper = useCallback(
     <T extends (...args: any[]) => any>(fn: T) => {


### PR DESCRIPTION
## Description

When using multilingual transcription model (e.g. `WHISPER_TINY`) language is expected, but there's no way to pass it to the `model.stream()` method:

Encountered error:

```
[Error: Model is multilingual, provide a language]
```

IDE:

<img width="578" height="220" alt="Screenshot 2025-10-14 at 22 21 32" src="https://github.com/user-attachments/assets/9f9ff6d1-ea4a-4571-8a64-4aed7a4200a5" />

It looks like `SpeechToTextModule.stream()` does accept options with language, but the wrapper function in `useSpeechToText()` does not, making it impossible to use the multilingual model.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
