### PR TITLE
bug: fix to corrupted utf-8 encoding for special characters in transcription

### DIFF
--- a/packages/react-native-executorch/common/rnexecutorch/host_objects/JsiConversions.h
+++ b/packages/react-native-executorch/common/rnexecutorch/host_objects/JsiConversions.h
@@ -66,7 +66,8 @@ inline JSTensorViewIn getValue<JSTensorViewIn>(const jsi::Value &val,
   tensorView.sizes.reserve(numShapeDims);
 
   for (size_t i = 0; i < numShapeDims; ++i) {
-    int32_t dim = getValue<int32_t>(shapeArray.getValueAtIndex(runtime, i), runtime);
+    int32_t dim =
+        getValue<int32_t>(shapeArray.getValueAtIndex(runtime, i), runtime);
     tensorView.sizes.push_back(dim);
   }
 
@@ -173,23 +174,24 @@ inline std::vector<T> getArrayAsVector(const jsi::Value &val,
   return result;
 }
 
-
 // Template specializations for std::vector<T> types
 template <>
-inline std::vector<JSTensorViewIn> getValue<std::vector<JSTensorViewIn>>(const jsi::Value &val,
-                                                       jsi::Runtime &runtime) {
+inline std::vector<JSTensorViewIn>
+getValue<std::vector<JSTensorViewIn>>(const jsi::Value &val,
+                                      jsi::Runtime &runtime) {
   return getArrayAsVector<JSTensorViewIn>(val, runtime);
 }
 
 template <>
-inline std::vector<std::string> getValue<std::vector<std::string>>(const jsi::Value &val,
-                                                       jsi::Runtime &runtime) {
+inline std::vector<std::string>
+getValue<std::vector<std::string>>(const jsi::Value &val,
+                                   jsi::Runtime &runtime) {
   return getArrayAsVector<std::string>(val, runtime);
 }
 
 template <>
-inline std::vector<int32_t> getValue<std::vector<int32_t>>(const jsi::Value &val,
-                                                       jsi::Runtime &runtime) {
+inline std::vector<int32_t>
+getValue<std::vector<int32_t>>(const jsi::Value &val, jsi::Runtime &runtime) {
   return getArrayAsVector<int32_t>(val, runtime);
 }
 
@@ -284,7 +286,7 @@ inline jsi::Value getJsiValue(const std::vector<char> &vec,
                               jsi::Runtime &runtime) {
   jsi::Array array(runtime, vec.size());
   for (size_t i = 0; i < vec.size(); i++) {
-    array.setValueAtIndex(runtime, i, jsi::Value(static_cast<char>(vec[i])));
+    array.setValueAtIndex(runtime, i, jsi::Value(vec[i]));
   }
   return {runtime, array};
 }

--- a/packages/react-native-executorch/common/rnexecutorch/models/speech_to_text/SpeechToText.h
+++ b/packages/react-native-executorch/common/rnexecutorch/models/speech_to_text/SpeechToText.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "rnexecutorch/models/speech_to_text/stream/OnlineASRProcessor.h"
+#include <span>
+#include <string>
 #include <vector>
 
 namespace rnexecutorch {
@@ -19,7 +21,7 @@ public:
   std::shared_ptr<OwningArrayBuffer>
   decode(std::span<int32_t> tokens, std::span<float> encoderOutput) const;
   std::vector<char> transcribe(std::span<float> waveform,
-                         std::string languageOption) const;
+                               std::string languageOption) const;
 
   size_t getMemoryLowerBound() const noexcept;
 

--- a/packages/react-native-executorch/src/modules/natural_language_processing/SpeechToTextModule.ts
+++ b/packages/react-native-executorch/src/modules/natural_language_processing/SpeechToTextModule.ts
@@ -7,9 +7,9 @@ export class SpeechToTextModule {
 
   private modelConfig!: SpeechToTextModelConfig;
 
-  private textDecoder = new TextDecoder("utf-8", {
-      fatal: false,
-      ignoreBOM: true,
+  private textDecoder = new TextDecoder('utf-8', {
+    fatal: false,
+    ignoreBOM: true,
   });
 
   public async load(
@@ -92,7 +92,10 @@ export class SpeechToTextModule {
       );
       waveform = new Float32Array(waveform);
     }
-    const transcriptionBytes = await this.nativeModule.transcribe(waveform, options.language || '');
+    const transcriptionBytes = await this.nativeModule.transcribe(
+      waveform,
+      options.language || ''
+    );
     return this.textDecoder.decode(new Uint8Array(transcriptionBytes));
   }
 
@@ -117,7 +120,9 @@ export class SpeechToTextModule {
           (committed: number[], nonCommitted: number[], isDone: boolean) => {
             queue.push({
               committed: this.textDecoder.decode(new Uint8Array(committed)),
-              nonCommitted: this.textDecoder.decode(new Uint8Array(nonCommitted))
+              nonCommitted: this.textDecoder.decode(
+                new Uint8Array(nonCommitted)
+              ),
             });
             if (isDone) {
               finished = true;


### PR DESCRIPTION
## Description

Fix for issue #651. The problem was the serialization of cpp string into jsi::Value and then back to a string, causing invalid characters and bytes. Now cpp returns array of bytes and the decoding is done on the JS side.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
