### PR TITLE
Remove CocoaPods cache step from iOS build workflow

### DIFF
--- a/.github/workflows/build-ios-llm-example.yml
+++ b/.github/workflows/build-ios-llm-example.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install CocoaPods dependencies
         working-directory: apps/llm/ios
         run: |
-            pod install
+          pod install
       - name: Build app
         working-directory: apps/llm/ios
         run: |


### PR DESCRIPTION
## Description

Removed CocoaPods caching step from CI workflow. This will fix CI for iOS example

### Introduces a breaking change?

- [ ] Yes
- [X] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
