### PR TITLE
bug: fix to a bug where sometimes threadpool could be configured to 0 workers

### DIFF
--- a/packages/react-native-executorch/common/rnexecutorch/threads/GlobalThreadPool.h
+++ b/packages/react-native-executorch/common/rnexecutorch/threads/GlobalThreadPool.h
@@ -33,6 +33,7 @@ public:
             ::executorch::extension::cpuinfo::get_num_performant_cores();
       }
 
+      numThreads = std::max(numThreads.value(), 2u);
       log(rnexecutorch::LOG_LEVEL::Info, "Initializing global thread pool with",
           numThreads, "threads");
       instance = std::make_unique<HighPerformanceThreadPool>(numThreads.value(),


### PR DESCRIPTION
## Description

In some cases global thread pool was configured to a single thread

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
