### PR TITLE
Remove redundant packages in CI 

### DIFF
--- a/.github/workflows/build-android-llm-example.yml
+++ b/.github/workflows/build-android-llm-example.yml
@@ -23,19 +23,13 @@ jobs:
       group: android-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space-action@v1.3.1
-        with:
-            # ⚠️ IMPORTANT: If your job builds the Android app, set 'android: false'
-            # to prevent deleting the Android SDK/NDK.
-            android: false 
-            
-            # Delete tools unlikely to be used in a React Native/C++ repo
-            dotnet: true
-            haskell: true
-            large-packages: true
-            docker-images: true
-            swap-storage: true
+      - name: Free Disk Space (Manual)
+        run: |
+              sudo rm -rf /usr/share/dotnet
+              sudo rm -rf /opt/ghc
+              sudo rm -rf /opt/hostedtoolcache/CodeQL
+              sudo docker system prune -af
+    
       - name: Check out Git repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

Currently, CI for Android fails because machine is bloated with not needed code. After adding step in CI that unbloats machine the ci works: 
https://github.com/software-mansion/react-native-executorch/actions/runs/21036801074

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
