### PR TITLE
fix: deduplicate state in number of diffusion steps in example app

### DIFF
--- a/apps/computer-vision/app/text_to_image/index.tsx
+++ b/apps/computer-vision/app/text_to_image/index.tsx
@@ -18,7 +18,7 @@ export default function TextToImageScreen() {
   const [inferenceStepIdx, setInferenceStepIdx] = useState<number>(0);
   const [imageTitle, setImageTitle] = useState<string | null>(null);
   const [image, setImage] = useState<string | null>(null);
-  const [steps, setSteps] = useState<number>(10);
+  const [steps, setSteps] = useState<number>(40);
   const [showTextInput, setShowTextInput] = useState(false);
   const [keyboardVisible, setKeyboardVisible] = useState(false);
 
@@ -115,6 +115,8 @@ export default function TextToImageScreen() {
         <View style={styles.bottomContainer}>
           <BottomBarWithTextInput
             runModel={runForward}
+            numSteps={steps}
+            setSteps={setSteps}
             stopModel={model.interrupt}
             isGenerating={model.isGenerating}
             isReady={model.isReady}

--- a/apps/computer-vision/components/BottomBarWithTextInput.tsx
+++ b/apps/computer-vision/components/BottomBarWithTextInput.tsx
@@ -14,6 +14,8 @@ import ColorPalette from '../colors';
 interface BottomBarProps {
   runModel: (input: string, numSteps: number) => void;
   stopModel: () => void;
+  numSteps: number;
+  setSteps: React.Dispatch<React.SetStateAction<number>>;
   isGenerating?: boolean;
   isReady?: boolean;
   showTextInput: boolean;
@@ -24,6 +26,8 @@ interface BottomBarProps {
 export const BottomBarWithTextInput = ({
   runModel,
   stopModel,
+  numSteps,
+  setSteps,
   isGenerating,
   isReady,
   showTextInput,
@@ -31,10 +35,9 @@ export const BottomBarWithTextInput = ({
   keyboardVisible,
 }: BottomBarProps) => {
   const [input, setInput] = useState('');
-  const [numSteps, setNumSteps] = useState(10);
 
-  const decreaseSteps = () => setNumSteps((prev) => Math.max(5, prev - 5));
-  const increaseSteps = () => setNumSteps((prev) => Math.min(50, prev + 5));
+  const decreaseSteps = () => setSteps((prev) => Math.max(5, prev - 5));
+  const increaseSteps = () => setSteps((prev) => Math.min(50, prev + 5));
 
   if (!showTextInput) {
     if (isGenerating) {


### PR DESCRIPTION
## Description

Currently the TTI example app passes wrong number of diffusion steps to the native side, due to duplicated React state. This PR fixes that. 

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
