### PR TITLE
fix: correct base64 data URI segment count validation in readImage

### DIFF
--- a/packages/react-native-executorch/common/rnexecutorch/data_processing/ImageProcessing.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/data_processing/ImageProcessing.cpp
@@ -86,7 +86,7 @@ cv::Mat readImage(const std::string &imageURI) {
     while (std::getline(uriStream, stringData, ',')) {
       ++segmentIndex;
     }
-    if (segmentIndex != 1) {
+    if (segmentIndex != 2) {
       throw RnExecutorchError(RnExecutorchErrorCode::FileReadFailed,
                               "Read image error: invalid base64 URI");
     }


### PR DESCRIPTION
## Description

A base64 data URI (e.g. data:image/png;base64,iVBOR...) splits into 2 segments by ,, but the check was comparing against 1, causing all valid base64 image inputs to be rejected.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

- Pass a base64-encoded image data URI to a model that calls readImage and verify it is decoded and processed correctly
- Verify that malformed URIs (no comma, multiple commas) are still correctly rejected

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
