### PR TITLE
fix: Make package.json accept newer versions of libs, e.g. Expo

### DIFF
--- a/docs/docs/06-api-reference/classes/TextToImageModule.md
+++ b/docs/docs/06-api-reference/classes/TextToImageModule.md
@@ -178,7 +178,7 @@ The input shape as an array of numbers.
 
 > **interrupt**(): `void`
 
-Defined in: [modules/computer_vision/TextToImageModule.ts:133](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/modules/computer_vision/TextToImageModule.ts#L133)
+Defined in: [modules/computer_vision/TextToImageModule.ts:138](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/modules/computer_vision/TextToImageModule.ts#L138)
 
 Interrupts model generation. The model is stopped in the nearest step.
 

--- a/packages/bare-resource-fetcher/package.json
+++ b/packages/bare-resource-fetcher/package.json
@@ -26,8 +26,8 @@
     "clean": "del-cli lib"
   },
   "peerDependencies": {
-    "@dr.pogodin/react-native-fs": "^2.0.0",
-    "@kesha-antonov/react-native-background-downloader": "^4.0.0",
+    "@dr.pogodin/react-native-fs": ">=2.0.0",
+    "@kesha-antonov/react-native-background-downloader": ">=4.0.0",
     "react-native": "*",
     "react-native-executorch": "*"
   },

--- a/packages/bare-resource-fetcher/package.json
+++ b/packages/bare-resource-fetcher/package.json
@@ -26,8 +26,8 @@
     "clean": "del-cli lib"
   },
   "peerDependencies": {
-    "@dr.pogodin/react-native-fs": ">=2.0.0",
-    "@kesha-antonov/react-native-background-downloader": ">=4.0.0",
+    "@dr.pogodin/react-native-fs": "^2.0.0",
+    "@kesha-antonov/react-native-background-downloader": "^4.0.0",
     "react-native": "*",
     "react-native-executorch": "*"
   },

--- a/packages/expo-resource-fetcher/package.json
+++ b/packages/expo-resource-fetcher/package.json
@@ -27,8 +27,8 @@
   },
   "peerDependencies": {
     "expo": ">=54.0.0",
-    "expo-asset": "^12.0.0",
-    "expo-file-system": "^19.0.0",
+    "expo-asset": ">=12.0.0",
+    "expo-file-system": ">=19.0.0",
     "react-native": "*",
     "react-native-executorch": "*"
   },

--- a/packages/react-native-executorch/src/modules/computer_vision/TextToImageModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/TextToImageModule.ts
@@ -1,7 +1,7 @@
 import { ResourceFetcher } from '../../utils/ResourceFetcher';
 import { ResourceSource } from '../../types/common';
 import { BaseModule } from '../BaseModule';
-import { Buffer } from 'buffer';
+
 import { PNG } from 'pngjs/browser';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
 import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
@@ -121,10 +121,15 @@ export class TextToImageModule extends BaseModule {
       return '';
     }
     const png = new PNG({ width: imageSize, height: imageSize });
-    png.data = Buffer.from(outputArray);
+    png.data = outputArray as unknown as Buffer;
     const pngBuffer = PNG.sync.write(png, { colorType: 6 });
-    const pngString = pngBuffer.toString('base64');
-    return pngString;
+    const pngArray = new Uint8Array(pngBuffer as unknown as ArrayBufferLike);
+    let binary = '';
+    const chunkSize = 8192;
+    for (let i = 0; i < pngArray.length; i += chunkSize) {
+      binary += String.fromCharCode(...pngArray.subarray(i, i + chunkSize));
+    }
+    return btoa(binary);
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4429,8 +4429,8 @@ __metadata:
     react-native-executorch: "workspace:*"
     typescript: "npm:~5.9.2"
   peerDependencies:
-    "@dr.pogodin/react-native-fs": ^2.0.0
-    "@kesha-antonov/react-native-background-downloader": ^4.0.0
+    "@dr.pogodin/react-native-fs": ">=2.0.0"
+    "@kesha-antonov/react-native-background-downloader": ">=4.0.0"
     react-native: "*"
     react-native-executorch: "*"
   languageName: unknown
@@ -4450,8 +4450,8 @@ __metadata:
     typescript: "npm:~5.9.2"
   peerDependencies:
     expo: ">=54.0.0"
-    expo-asset: ^12.0.0
-    expo-file-system: ^19.0.0
+    expo-asset: ">=12.0.0"
+    expo-file-system: ">=19.0.0"
     react-native: "*"
     react-native-executorch: "*"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -4429,8 +4429,8 @@ __metadata:
     react-native-executorch: "workspace:*"
     typescript: "npm:~5.9.2"
   peerDependencies:
-    "@dr.pogodin/react-native-fs": ">=2.0.0"
-    "@kesha-antonov/react-native-background-downloader": ">=4.0.0"
+    "@dr.pogodin/react-native-fs": ^2.0.0
+    "@kesha-antonov/react-native-background-downloader": ^4.0.0
     react-native: "*"
     react-native-executorch: "*"
   languageName: unknown


### PR DESCRIPTION
## Description

This PR fixes package.json in both expo and bare resource fetchers.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

* Run minimal app that utilizes this version of our library with expo 55 (pack react native executorch and expo resource fetchers into tgz and install in template app) and check if everything works correctly.
* Run text to image example as this PR introduces changes in this package and check if everything works ok.

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

Closes #882 

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
