### PR TITLE
fix: off-by-one in Kokoro::synthesize voice index causes crash

### DIFF
--- a/packages/react-native-executorch/common/rnexecutorch/models/text_to_speech/kokoro/Kokoro.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/text_to_speech/kokoro/Kokoro.cpp
@@ -198,7 +198,7 @@ std::vector<float> Kokoro::synthesize(const std::u32string &phonemes,
   const auto tokens = utils::tokenize(phonemes, {noTokens});
 
   // Select the appropriate voice vector
-  size_t voiceID = std::min(phonemes.size() - 1, noTokens);
+  size_t voiceID = std::min(phonemes.size() - 1, noTokens - 1);
   auto &voice = voice_[voiceID];
 
   // Initialize text mask


### PR DESCRIPTION
(Larger fix that includes this here: https://github.com/software-mansion/react-native-executorch/pull/943)

Broke this out in case you don't want the other change. If you merge #943 you can close this one.

`Kokoro::synthesize` computes `voiceID` as:

```cpp
size_t voiceID = std::min(phonemes.size() - 1, noTokens);
```

`voice_` is `std::array<std::array<float, kVoiceRefSize>, kMaxInputTokens>` — 128 elements with valid indices 0–127.

When `noTokens` equals `context_.inputTokensLimit` (which can be `kMaxInputTokens` = 128), and `phonemes.size() - 1 >= 128`, `voiceID` becomes **128** — one past the end of the array. This causes an out-of-bounds access that aborts on the `RN_ET_Worker0` thread.

### Crash stack trace

```
Thread 14 Crashed:: RN_ET_Worker0
0   libsystem_kernel.dylib    __pthread_kill + 8
1   libsystem_pthread.dylib   pthread_kill + 264
2   libsystem_c.dylib         abort + 100
3   Phasma.debug.dylib        std::array<std::array<float, 256>, 128>::operator[] + 52 (array:269)
4   Phasma.debug.dylib        Kokoro::synthesize(...) + 232 (Kokoro.cpp:202)
5   Phasma.debug.dylib        Kokoro::generate(...) + 448 (Kokoro.cpp:94)
```

### Fix

Cap `voiceID` at `noTokens - 1` instead of `noTokens`:

```cpp
size_t voiceID = std::min(phonemes.size() - 1, noTokens - 1);
```

This keeps the index within the valid range of `voice_`.