### PR TITLE
fix: expose unload() JSI binding for TextToImageModule

### DIFF
--- a/packages/react-native-executorch/common/rnexecutorch/host_objects/ModelHostObject.h
+++ b/packages/react-native-executorch/common/rnexecutorch/host_objects/ModelHostObject.h
@@ -148,6 +148,8 @@ public:
     }
 
     if constexpr (meta::SameAs<Model, models::text_to_image::TextToImage>) {
+      addFunctions(
+          JSI_EXPORT_FUNCTION(ModelHostObject<Model>, unload, "unload"));
       addFunctions(JSI_EXPORT_FUNCTION(
           ModelHostObject<Model>, synchronousHostFunction<&Model::interrupt>,
           "interrupt"));


### PR DESCRIPTION
## Summary

`TextToImage::unload()` is implemented in C++ and correctly delegates to its sub-components (encoder, unet, decoder), but the JSI binding was never registered in `ModelHostObject`. This causes a `TypeError: this.nativeModule.unload is not a function` when calling `BaseModule.delete()` from JavaScript.

Every other composite model (OCR, VerticalOCR, Kokoro, LLM) already registers `unload` in its `if constexpr` block — this adds the same one-liner for TextToImage.

## Changes

- Added `unload` JSI export to the `TextToImage` block in `ModelHostObject.h`, matching the existing pattern used by other models

## Test plan

- [x] Call `module.delete()` on a loaded `TextToImageModule` — should no longer throw
- [x] Verify model memory is released after `delete()` (encoder, unet, decoder sub-models are unloaded)