### PR TITLE
fix(kokoro): register streamStop on JSI host object

### DIFF
--- a/packages/react-native-executorch/common/rnexecutorch/host_objects/ModelHostObject.h
+++ b/packages/react-native-executorch/common/rnexecutorch/host_objects/ModelHostObject.h
@@ -173,6 +173,10 @@ public:
                                        "stream"));
       addFunctions(JSI_EXPORT_FUNCTION(
           ModelHostObject<Model>,
+          synchronousHostFunction<&Model::streamStop>,
+          "streamStop"));
+      addFunctions(JSI_EXPORT_FUNCTION(
+          ModelHostObject<Model>,
           promiseHostFunction<&Model::generateFromPhonemes>,
           "generateFromPhonemes"));
       addFunctions(JSI_EXPORT_FUNCTION(


### PR DESCRIPTION
## Summary

`Kokoro::streamStop()` exists in C++ (`Kokoro.cpp:205`) and is called from the JS `TextToSpeechModule.streamStop()` via `this.nativeModule.streamStop()`, but it's never registered on the JSI host object in `ModelHostObject.h`.

This causes a runtime error when stopping TTS streaming:

```
TypeError: this.nativeModule.streamStop is not a function (it is undefined)
```

The fix registers `streamStop` as a `synchronousHostFunction` in the Kokoro `if constexpr` block, matching the existing pattern used for `SpeechToText`.

## Changes

- `ModelHostObject.h`: Add `streamStop` JSI registration for Kokoro model type