### PR TITLE
chore: build core lib before using adapters

### DIFF
--- a/.github/workflows/npm-publish-bare-resource-fetcher.yml
+++ b/.github/workflows/npm-publish-bare-resource-fetcher.yml
@@ -81,6 +81,10 @@ jobs:
           NIGHTLY_UNIQUE_NAME="${GIT_COMMIT:0:7}-$DATE"
           sed -i "3s/.*/  \"version\": \"$MAJOR.$MINOR.$PATCH-nightly-$NIGHTLY_UNIQUE_NAME\",/" package.json
 
+      - name: Build core package
+        working-directory: packages/react-native-executorch
+        run: yarn prepare
+
       - name: Build package
         working-directory: ${{ env.PACKAGE_DIR }}
         run: yarn prepare

--- a/.github/workflows/npm-publish-expo-resource-fetcher.yml
+++ b/.github/workflows/npm-publish-expo-resource-fetcher.yml
@@ -81,6 +81,10 @@ jobs:
           NIGHTLY_UNIQUE_NAME="${GIT_COMMIT:0:7}-$DATE"
           sed -i "3s/.*/  \"version\": \"$MAJOR.$MINOR.$PATCH-nightly-$NIGHTLY_UNIQUE_NAME\",/" package.json
 
+      - name: Build core package
+        working-directory: packages/react-native-executorch
+        run: yarn prepare
+
       - name: Build package
         working-directory: ${{ env.PACKAGE_DIR }}
         run: yarn prepare


### PR DESCRIPTION
## Description

Forget to add building core package before resource fetchers which failed the build.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
