### PR TITLE
chore: Make adapters prublic so publishing on npm work

### DIFF
--- a/.github/workflows/npm-publish-bare-resource-fetcher.yml
+++ b/.github/workflows/npm-publish-bare-resource-fetcher.yml
@@ -114,4 +114,4 @@ jobs:
         run: mv ${{ env.PACKAGE_DIR }}/${{ env.PACKAGE_NAME }} .
 
       - name: Publish package to npm
-        run: npm publish $PACKAGE_NAME --tag ${{ env.TAG }} --provenance
+        run: npm publish $PACKAGE_NAME --tag ${{ env.TAG }} --provenance --access public

--- a/.github/workflows/npm-publish-expo-resource-fetcher.yml
+++ b/.github/workflows/npm-publish-expo-resource-fetcher.yml
@@ -114,4 +114,4 @@ jobs:
         run: mv ${{ env.PACKAGE_DIR }}/${{ env.PACKAGE_NAME }} .
 
       - name: Publish package to npm
-        run: npm publish $PACKAGE_NAME --tag ${{ env.TAG }} --provenance
+        run: npm publish $PACKAGE_NAME --tag ${{ env.TAG }} --provenance --access public


### PR DESCRIPTION
## Description

The package is scoped (@react-native-executorch/...) so npm treats it as private by default. Need to add `--access public` to the publish command in both workflows.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
