### PR TITLE
fix: add missing dep to package.json

### DIFF
--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -119,6 +119,7 @@
     "@huggingface/jinja": "^0.5.0",
     "jsonrepair": "^3.12.0",
     "jsonschema": "^1.5.0",
+    "pngjs": "^7.0.0",
     "zod": "^4.3.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13889,6 +13889,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pngjs@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "pngjs@npm:7.0.0"
+  checksum: 10/e843ebbb0df092ee0f3a3e7dbd91ff87a239a4e4c4198fff202916bfb33b67622f4b83b3c29f3ccae94fcb97180c289df06068624554f61686fe6b9a4811f7db
+  languageName: node
+  linkType: hard
+
 "possible-typed-array-names@npm:^1.0.0":
   version: 1.1.0
   resolution: "possible-typed-array-names@npm:1.1.0"
@@ -14372,6 +14379,7 @@ __metadata:
     jsonrepair: "npm:^3.12.0"
     jsonschema: "npm:^1.5.0"
     metro-react-native-babel-preset: "npm:^0.77.0"
+    pngjs: "npm:^7.0.0"
     react: "npm:19.1.0"
     react-native: "npm:0.81.5"
     react-native-builder-bob: "npm:^0.40.12"


### PR DESCRIPTION
## Description

There is a missing dep, namely "pngjs" that is utilized in `TextToImageModule.ts` file but not enforced in package.json. This fix adds it

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

Check that our files indeed depends on this package (`TextToImageModule.ts`)

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
