### PR TITLE
chore: Fix bounding box annotation

### DIFF
--- a/apps/computer-vision/components/BoundingBoxes.tsx
+++ b/apps/computer-vision/components/BoundingBoxes.tsx
@@ -1,25 +1,27 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { Detection } from 'react-native-executorch';
+import { Detection, LabelEnum } from 'react-native-executorch';
 import { labelColor, labelColorBg } from './utils/colors';
 
-interface Props {
-  detections: Detection[];
+interface Props<L extends LabelEnum> {
+  detections: Detection<L>[];
   scaleX: number;
   scaleY: number;
   offsetX: number;
   offsetY: number;
   mirrorLabels?: boolean;
+  containerWidth?: number;
 }
 
-export default function BoundingBoxes({
+export default function BoundingBoxes<L extends LabelEnum>({
   detections,
   scaleX,
   scaleY,
   offsetX,
   offsetY,
   mirrorLabels = false,
-}: Props) {
+  containerWidth,
+}: Props<L>) {
   return (
     <>
       {detections.map((det, i) => {
@@ -39,7 +41,7 @@ export default function BoundingBoxes({
                   top,
                   width,
                   height,
-                  borderColor: labelColor(det.label),
+                  borderColor: labelColor(det.label as string),
                 },
               ]}
             />
@@ -49,13 +51,16 @@ export default function BoundingBoxes({
                 {
                   left,
                   top: labelTop,
-                  backgroundColor: labelColorBg(det.label),
+                  backgroundColor: labelColorBg(det.label as string),
+                  ...(containerWidth !== undefined && {
+                    maxWidth: containerWidth - left,
+                  }),
                 },
                 mirrorLabels && { transform: [{ scaleX: -1 }] },
               ]}
             >
               <Text style={styles.labelText} numberOfLines={1}>
-                {det.label} ({(det.score * 100).toFixed(1)}%)
+                {String(det.label)} ({(det.score * 100).toFixed(1)}%)
               </Text>
             </View>
           </React.Fragment>

--- a/apps/computer-vision/components/ImageWithBboxes.tsx
+++ b/apps/computer-vision/components/ImageWithBboxes.tsx
@@ -66,6 +66,7 @@ export default function ImageWithBboxes({
         scaleY={scaleY}
         offsetX={offsetX}
         offsetY={offsetY}
+        containerWidth={layout.width}
       />
     </View>
   );

--- a/apps/computer-vision/components/vision_camera/tasks/InstanceSegmentationTask.tsx
+++ b/apps/computer-vision/components/vision_camera/tasks/InstanceSegmentationTask.tsx
@@ -11,7 +11,7 @@ import {
   CocoLabelYolo,
 } from 'react-native-executorch';
 import { Canvas, Image as SkiaImage } from '@shopify/react-native-skia';
-import { labelColor, labelColorBg } from '../utils/colors';
+import { labelColor, labelColorBg } from '../../utils/colors';
 import { TaskProps } from './types';
 import {
   buildDisplayInstances,

--- a/apps/computer-vision/components/vision_camera/tasks/ObjectDetectionTask.tsx
+++ b/apps/computer-vision/components/vision_camera/tasks/ObjectDetectionTask.tsx
@@ -128,6 +128,7 @@ export default function ObjectDetectionTask({
         scaleY={scale}
         offsetX={offsetX}
         offsetY={offsetY}
+        containerWidth={canvasSize.width}
       />
     </View>
   );

--- a/apps/computer-vision/components/vision_camera/tasks/SegmentationTask.tsx
+++ b/apps/computer-vision/components/vision_camera/tasks/SegmentationTask.tsx
@@ -20,7 +20,7 @@ import {
   Skia,
   SkImage,
 } from '@shopify/react-native-skia';
-import { CLASS_COLORS } from '../utils/colors';
+import { CLASS_COLORS } from '../../utils/colors';
 import { TaskProps } from './types';
 
 type SegModelId =

--- a/apps/computer-vision/components/vision_camera/utils/colors.ts
+++ b/apps/computer-vision/components/vision_camera/utils/colors.ts
@@ -1,1 +1,0 @@
-export * from '../../utils/colors';


### PR DESCRIPTION
## Description

This PR fixes the problem in demo apps where bounding boxes were utilized. For small objects annotation width was set to width of the bounding box since they were in the same view. Fix is to make these two be in relation child - parent components.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

- [ ] Compare result of annotation for apps that utilizes bounding boxes for small detected objects. 

### Screenshots

Now bounding boxes on small objects looks correct (in the #975 was the original result for the same image):
<img width="553" height="432" alt="image" src="https://github.com/user-attachments/assets/2598df7e-351e-4441-ac32-7272c9519a89" />

### Related issues

Closes #975

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
