### PR TITLE
chore: add an error log when adapter is missing

### DIFF
--- a/packages/react-native-executorch/src/utils/ResourceFetcher.ts
+++ b/packages/react-native-executorch/src/utils/ResourceFetcher.ts
@@ -104,11 +104,11 @@ export class ResourceFetcher {
    * **INTERNAL**: Used internally by all resource fetching operations.
    */
   static getAdapter(): ResourceFetcherAdapter {
-    const errorMessage =
-      'ResourceFetcher adapter is not initialized. Please call initExecutorch({ resourceFetcher: ... }) with a valid adapter, e.g., from react-native-executorch-expo-resource-fetcher or react-native-executorch-bare-resource-fetcher. For more details please refer: https://docs.swmansion.com/react-native-executorch/docs/next/fundamentals/loading-models';
-    // for sanity :)
-    Logger.error(errorMessage);
     if (!this.adapter) {
+      const errorMessage =
+        'ResourceFetcher adapter is not initialized. Please call initExecutorch({ resourceFetcher: ... }) with a valid adapter, e.g., from react-native-executorch-expo-resource-fetcher or react-native-executorch-bare-resource-fetcher. For more details please refer: https://docs.swmansion.com/react-native-executorch/docs/next/fundamentals/loading-models';
+      // for sanity :)
+      Logger.error(errorMessage);
       throw new RnExecutorchError(
         RnExecutorchErrorCode.ResourceFetcherAdapterNotInitialized,
         errorMessage


### PR DESCRIPTION
## Description

This PR introduces more discoverability to a potential common pitfall of user not calling initExecutorch, before using the resource fetcher. 

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
