### PR TITLE
fix: pass `capabilities` to `LLMController.load` in `LLMModule.fromModelName`

### DIFF
--- a/packages/react-native-executorch/src/modules/natural_language_processing/LLMModule.ts
+++ b/packages/react-native-executorch/src/modules/natural_language_processing/LLMModule.ts
@@ -62,6 +62,7 @@ export class LLMModule {
         modelSource: namedSources.modelSource,
         tokenizerSource: namedSources.tokenizerSource,
         tokenizerConfigSource: namedSources.tokenizerConfigSource,
+        capabilities: namedSources.capabilities,
         onDownloadProgressCallback: onDownloadProgress,
       });
       return instance;


### PR DESCRIPTION
## Description

Fixes the arguments passed to `LLMController.load` in `LLMModule.fromModelName` to make loading VLMs work correctly.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

Use this simple screen to test
```ts
import { useEffect } from 'react';
import { LLMModule, LFM2_VL_1_6B_QUANTIZED } from 'react-native-executorch';

export default function LLMModuleExample() {
  useEffect(() => {
    const run = async () => {
      const llm = await LLMModule.fromModelName(
        LFM2_VL_1_6B_QUANTIZED,
        undefined,
        (token) => console.log(token)
      );

      await llm.sendMessage('Hello!');
      llm.delete();
    };

    run().catch(console.error);
  }, []);

  return null;
}
```

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->
Closes #998 

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
