### PR TITLE
feat: added emulator detection (#1021)

### DIFF
--- a/packages/react-native-executorch/android/src/main/cpp/ETInstallerModule.cpp
+++ b/packages/react-native-executorch/android/src/main/cpp/ETInstallerModule.cpp
@@ -2,6 +2,8 @@
 
 #include <rnexecutorch/RnExecutorchInstaller.h>
 
+#include "EmulatorDetection.h"
+
 #include <jni.h>
 #include <jsi/jsi.h>
 
@@ -64,8 +66,10 @@ void ETInstallerModule::injectJSIBindings() {
     return std::vector<std::byte>(dataBytePtr, dataBytePtr + size);
   };
 
+  auto _isEmulator = isEmulator();
+
   RnExecutorchInstaller::injectJSIBindings(jsiRuntime_, jsCallInvoker_,
-                                           fetchDataByUrl);
+                                           fetchDataByUrl, _isEmulator);
 }
 } // namespace rnexecutorch
 

--- a/packages/react-native-executorch/android/src/main/cpp/EmulatorDetection.h
+++ b/packages/react-native-executorch/android/src/main/cpp/EmulatorDetection.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <string>
+#include <sys/system_properties.h>
+
+namespace rnexecutorch {
+
+inline bool isEmulator() {
+  auto readProp = [](const char *key) -> std::string {
+#if __ANDROID_API__ >= 26
+    const prop_info *pi = __system_property_find(key);
+    if (pi == nullptr) {
+      return "";
+    }
+    std::string result;
+    __system_property_read_callback(
+        pi,
+        [](void *cookie, const char * /*__name*/, const char *value,
+           uint32_t /*__serial*/) {
+          *static_cast<std::string *>(cookie) = value;
+        },
+        &result);
+    return result;
+#else
+    char value[PROP_VALUE_MAX] = {0};
+    __system_property_get(key, value);
+    return {value};
+#endif
+  };
+
+  std::string fp = readProp("ro.build.fingerprint");
+  std::string hw = readProp("ro.hardware");
+  return fp.find("generic") == 0 || hw == "goldfish" || hw == "ranchu";
+}
+
+} // namespace rnexecutorch

--- a/packages/react-native-executorch/common/rnexecutorch/RnExecutorchInstaller.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/RnExecutorchInstaller.cpp
@@ -10,9 +10,9 @@
 #include <rnexecutorch/models/object_detection/ObjectDetection.h>
 #include <rnexecutorch/models/ocr/OCR.h>
 #include <rnexecutorch/models/speech_to_text/SpeechToText.h>
-#include <rnexecutorch/models/text_to_speech/TextToSpeech.h>
 #include <rnexecutorch/models/style_transfer/StyleTransfer.h>
 #include <rnexecutorch/models/text_to_image/TextToImage.h>
+#include <rnexecutorch/models/text_to_speech/TextToSpeech.h>
 #include <rnexecutorch/models/vertical_ocr/VerticalOCR.h>
 #include <rnexecutorch/models/voice_activity_detection/VoiceActivityDetection.h>
 #include <rnexecutorch/threads/GlobalThreadPool.h>
@@ -33,8 +33,11 @@ FetchUrlFunc_t fetchUrlFunc;
 
 void RnExecutorchInstaller::injectJSIBindings(
     jsi::Runtime *jsiRuntime, std::shared_ptr<react::CallInvoker> jsCallInvoker,
-    FetchUrlFunc_t fetchDataFromUrl) {
+    FetchUrlFunc_t fetchDataFromUrl, bool isEmulator) {
   fetchUrlFunc = fetchDataFromUrl;
+
+  jsiRuntime->global().setProperty(*jsiRuntime, "__rne_isEmulator",
+                                   jsi::Value(isEmulator));
 
   jsiRuntime->global().setProperty(
       *jsiRuntime, "loadStyleTransfer",

--- a/packages/react-native-executorch/common/rnexecutorch/RnExecutorchInstaller.h
+++ b/packages/react-native-executorch/common/rnexecutorch/RnExecutorchInstaller.h
@@ -22,7 +22,7 @@ public:
   static void
   injectJSIBindings(jsi::Runtime *jsiRuntime,
                     std::shared_ptr<react::CallInvoker> jsCallInvoker,
-                    FetchUrlFunc_t fetchDataFromUrl);
+                    FetchUrlFunc_t fetchDataFromUrl, bool isEmulator);
 
 private:
   template <typename ModelT>

--- a/packages/react-native-executorch/ios/RnExecutorch/ETInstaller.mm
+++ b/packages/react-native-executorch/ios/RnExecutorch/ETInstaller.mm
@@ -4,6 +4,7 @@
 
 #import <React/RCTCallInvoker.h>
 #import <ReactCommon/RCTTurboModule.h>
+#import <TargetConditionals.h>
 #include <rnexecutorch/RnExecutorchInstaller.h>
 #include <stdexcept>
 
@@ -41,8 +42,9 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
       throw std::runtime_error("Error fetching data from a url");
     }
   };
+  bool isEmulator = TARGET_OS_SIMULATOR;
   rnexecutorch::RnExecutorchInstaller::injectJSIBindings(
-      jsiRuntime, jsCallInvoker, fetchUrl);
+      jsiRuntime, jsCallInvoker, fetchUrl, isEmulator);
 
   NSLog(@"Successfully installed JSI bindings for react-native-executorch!");
   return @true;

--- a/packages/react-native-executorch/src/index.ts
+++ b/packages/react-native-executorch/src/index.ts
@@ -46,6 +46,8 @@ declare global {
     symbols: string,
     independentCharacters?: boolean
   ) => any;
+  // eslint-disable-next-line camelcase
+  var __rne_isEmulator: boolean;
 }
 // eslint-disable no-var
 if (
@@ -63,7 +65,8 @@ if (
   global.loadSpeechToText == null ||
   global.loadTextToSpeechKokoro == null ||
   global.loadOCR == null ||
-  global.loadVerticalOCR == null
+  global.loadVerticalOCR == null ||
+  global.__rne_isEmulator == null
 ) {
   if (!ETInstallerNativeModule) {
     throw new Error(

--- a/packages/react-native-executorch/src/utils/ResourceFetcherUtils.ts
+++ b/packages/react-native-executorch/src/utils/ResourceFetcherUtils.ts
@@ -176,6 +176,10 @@ export namespace ResourceFetcherUtils {
     }
   }
 
+  export function isEmulator(): boolean {
+    return global.__rne_isEmulator;
+  }
+
   export async function checkFileExists(fileUri: string) {
     const fileInfo = await getInfoAsync(fileUri);
     return fileInfo.exists;
@@ -214,6 +218,7 @@ export namespace ResourceFetcherUtils {
         body: JSON.stringify({
           modelName: getModelNameFromUri(uri),
           countryCode: getCountryCode(),
+          isEmulator: isEmulator(),
           libVersion: LIB_VERSION,
         }),
       });


### PR DESCRIPTION
Added emulator/simulator detection for logging purposes

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

1. Launch any example app (i.e. apps/computer-vision)
2. Connect to Ru machine via ssh, then `cd telemetry && docker compose logs --follow api`
3. Download any model (make sure the model is not currently downloaded)
4. You should see a log looking something like this:
```
api-1  | /downloads {
api-1  |   modelName: 'efficientnet-v2-s-quantized',
api-1  |   countryCode: 'US',
api-1  |   isEmulator: true,
api-1  |   libVersion: '0.9.0'
api-1  | }
```