### PR TITLE
chore(docs): change color palette in code snippets for darmode in documentation

### DIFF
--- a/docs/src/theme/CodeBlock/highlighting-dark.js
+++ b/docs/src/theme/CodeBlock/highlighting-dark.js
@@ -3,14 +3,14 @@ const darkTheme = require('prism-react-renderer').themes.github;
 module.exports = {
   ...darkTheme,
   plain: {
-    color: 'var(--swm-navy-light-40)',
+    color: 'var(--swm-navy-light-10)',
   },
   styles: [
     ...darkTheme.styles,
     {
       types: ['comment', 'prolog', 'doctype', 'cdata'],
       style: {
-        color: 'var(--swm-navy-light-60)',
+        color: 'var(--swm-navy-light-40)',
         fontStyle: 'italic',
       },
     },
@@ -24,13 +24,13 @@ module.exports = {
       // eslint-disable-next-line @cspell/spellchecker
       types: ['string', 'property', 'atrule', 'selector', 'tag'],
       style: {
-        color: 'var(--swm-navy-light-40)',
+        color: 'var(--swm-green-dark-80)',
       },
     },
     {
       types: ['punctuation'],
       style: {
-        color: 'var(--swm-green-light-80)',
+        color: 'var(--swm-navy-light-20)',
       },
     },
     {
@@ -48,19 +48,19 @@ module.exports = {
         'attr-value',
       ],
       style: {
-        color: 'var(--swm-red-light-80)',
+        color: 'var(--swm-red-dark-80)',
       },
     },
     {
       types: ['function', 'function-variable', 'deleted'],
       style: {
-        color: 'var(--swm-purple-light-80)',
+        color: 'var(--swm-purple-dark-80)',
       },
     },
     {
       types: ['property', 'module', 'attr-name', 'keyword'],
       style: {
-        color: 'var(--swm-blue-light-80)',
+        color: 'var(--swm-blue-dark-80)',
       },
     },
   ],


### PR DESCRIPTION
## Description

This PR changes color palette to the brighter one for dark-mode documentation.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

Build documentation locally, and check that is more contrast and easy-to-read

### Screenshots

Before:
<img width="585" height="516" alt="image" src="https://github.com/user-attachments/assets/0460ff3f-8a58-4888-bbcc-26c5135bcf06" />


After:
<img width="585" height="516" alt="image" src="https://github.com/user-attachments/assets/1dff695c-16e1-4b19-824e-7f2a639b094d" />


### Related issues

Closes #979 

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
