### PR TITLE
feat: add LFM2.5-VL-450M quantized model

### DIFF
--- a/docs/docs/03-hooks/01-natural-language-processing/useLLM.md
+++ b/docs/docs/03-hooks/01-natural-language-processing/useLLM.md
@@ -564,4 +564,5 @@ const handleGenerate = async () => {
 | [SmolLM 2](https://huggingface.co/software-mansion/react-native-executorch-smolLm-2)                               |  135M, 360M, 1.7B   |    ✅     |      -       |
 | [LLaMA 3.2](https://huggingface.co/software-mansion/react-native-executorch-llama-3.2)                             |       1B, 3B        |    ✅     |      -       |
 | [LFM2.5](https://huggingface.co/software-mansion/react-native-executorch-lfm-2.5)                                  | 350M, 1.2B, 1.6B-VL |    ✅     |      -       |
+| [LFM2.5-VL-450M](https://huggingface.co/software-mansion/react-native-executorch-lfm-2.5/tree/main/lfm2.5-VL-450M) |        450M         |    ✅     |    vision    |
 | [LFM2.5-VL-1.6B](https://huggingface.co/software-mansion/react-native-executorch-lfm-2.5/tree/main/lfm2.5-VL-1.6B) |        1.6B         |    ✅     |    vision    |

--- a/docs/versioned_docs/version-0.8.x/03-hooks/01-natural-language-processing/useLLM.md
+++ b/docs/versioned_docs/version-0.8.x/03-hooks/01-natural-language-processing/useLLM.md
@@ -564,4 +564,5 @@ const handleGenerate = async () => {
 | [SmolLM 2](https://huggingface.co/software-mansion/react-native-executorch-smolLm-2)                                 |  135M, 360M, 1.7B   |    ✅     |      -       |
 | [LLaMA 3.2](https://huggingface.co/software-mansion/react-native-executorch-llama-3.2)                               |       1B, 3B        |    ✅     |      -       |
 | [LFM2.5](https://huggingface.co/software-mansion/react-native-executorch-lfm-2.5)                                    | 350M, 1.2B, 1.6B-VL |    ✅     |      -       |
+| [LFM2.5-VL-450M](https://huggingface.co/software-mansion/react-native-executorch-lfm-2.5/tree/v0.8.0/lfm2.5-VL-450M) |        450M         |    ✅     |    vision    |
 | [LFM2.5-VL-1.6B](https://huggingface.co/software-mansion/react-native-executorch-lfm-2.5/tree/v0.8.0/lfm2.5-VL-1.6B) |        1.6B         |    ✅     |    vision    |

--- a/packages/react-native-executorch/src/constants/modelUrls.ts
+++ b/packages/react-native-executorch/src/constants/modelUrls.ts
@@ -433,9 +433,13 @@ export const LFM2_5_350M_QUANTIZED = {
 
 // LFM2.5-VL-1.6B
 const LFM2_VL_1_6B_QUANTIZED_MODEL = `${URL_PREFIX}-lfm-2.5/${VERSION_TAG}/lfm2.5-VL-1.6B/quantized/lfm2_5_vl_1_6b_8da4w_xnnpack.pte`;
-const LFM2_VL_450M_QUANTIZED_MODEL = `${URL_PREFIX}-lfm2.5-VL-1.6B/${VERSION_TAG}/quantized/lfm2_5_vl_450m_8da4w_xnnpack.pte`;
-const LFM2_VL_TOKENIZER = `${URL_PREFIX}-lfm-2.5/${VERSION_TAG}/lfm2.5-VL-1.6B/tokenizer.json`;
-const LFM2_VL_TOKENIZER_CONFIG = `${URL_PREFIX}-lfm-2.5/${VERSION_TAG}/lfm2.5-VL-1.6B/tokenizer_config.json`;
+const LFM2_VL_1_6B_TOKENIZER = `${URL_PREFIX}-lfm-2.5/${VERSION_TAG}/lfm2.5-VL-1.6B/tokenizer.json`;
+const LFM2_VL_1_6B_TOKENIZER_CONFIG = `${URL_PREFIX}-lfm-2.5/${VERSION_TAG}/lfm2.5-VL-1.6B/tokenizer_config.json`;
+
+// LFM2.5-VL-450M
+const LFM2_VL_450M_QUANTIZED_MODEL = `${URL_PREFIX}-lfm-2.5/${VERSION_TAG}/lfm2.5-VL-450M/lfm2_5_vl_450m_8da4w_xnnpack.pte`;
+const LFM2_VL_450M_TOKENIZER = `${URL_PREFIX}-lfm-2.5/${VERSION_TAG}/lfm2.5-VL-450M/tokenizer.json`;
+const LFM2_VL_450M_TOKENIZER_CONFIG = `${URL_PREFIX}-lfm-2.5/${VERSION_TAG}/lfm2.5-VL-450M/tokenizer_config.json`;
 
 /**
  * @category Models - VLM
@@ -444,8 +448,8 @@ export const LFM2_VL_1_6B_QUANTIZED = {
   modelName: 'lfm2.5-vl-1.6b-quantized',
   capabilities: ['vision'],
   modelSource: LFM2_VL_1_6B_QUANTIZED_MODEL,
-  tokenizerSource: LFM2_VL_TOKENIZER,
-  tokenizerConfigSource: LFM2_VL_TOKENIZER_CONFIG,
+  tokenizerSource: LFM2_VL_1_6B_TOKENIZER,
+  tokenizerConfigSource: LFM2_VL_1_6B_TOKENIZER_CONFIG,
 } as const;
 
 /**
@@ -455,8 +459,8 @@ export const LFM2_VL_450M_QUANTIZED = {
   modelName: 'lfm2.5-vl-450m-quantized',
   capabilities: ['vision'],
   modelSource: LFM2_VL_450M_QUANTIZED_MODEL,
-  tokenizerSource: LFM2_VL_TOKENIZER,
-  tokenizerConfigSource: LFM2_VL_TOKENIZER_CONFIG,
+  tokenizerSource: LFM2_VL_450M_TOKENIZER,
+  tokenizerConfigSource: LFM2_VL_450M_TOKENIZER_CONFIG,
 } as const;
 
 // Classification

--- a/packages/react-native-executorch/src/constants/modelUrls.ts
+++ b/packages/react-native-executorch/src/constants/modelUrls.ts
@@ -433,6 +433,7 @@ export const LFM2_5_350M_QUANTIZED = {
 
 // LFM2.5-VL-1.6B
 const LFM2_VL_1_6B_QUANTIZED_MODEL = `${URL_PREFIX}-lfm-2.5/${VERSION_TAG}/lfm2.5-VL-1.6B/quantized/lfm2_5_vl_1_6b_8da4w_xnnpack.pte`;
+const LFM2_VL_450M_QUANTIZED_MODEL = `${URL_PREFIX}-lfm2.5-VL-1.6B/${VERSION_TAG}/quantized/lfm2_5_vl_450m_8da4w_xnnpack.pte`;
 const LFM2_VL_TOKENIZER = `${URL_PREFIX}-lfm-2.5/${VERSION_TAG}/lfm2.5-VL-1.6B/tokenizer.json`;
 const LFM2_VL_TOKENIZER_CONFIG = `${URL_PREFIX}-lfm-2.5/${VERSION_TAG}/lfm2.5-VL-1.6B/tokenizer_config.json`;
 
@@ -443,6 +444,17 @@ export const LFM2_VL_1_6B_QUANTIZED = {
   modelName: 'lfm2.5-vl-1.6b-quantized',
   capabilities: ['vision'],
   modelSource: LFM2_VL_1_6B_QUANTIZED_MODEL,
+  tokenizerSource: LFM2_VL_TOKENIZER,
+  tokenizerConfigSource: LFM2_VL_TOKENIZER_CONFIG,
+} as const;
+
+/**
+ * @category Models - VLM
+ */
+export const LFM2_VL_450M_QUANTIZED = {
+  modelName: 'lfm2.5-vl-450m-quantized',
+  capabilities: ['vision'],
+  modelSource: LFM2_VL_450M_QUANTIZED_MODEL,
   tokenizerSource: LFM2_VL_TOKENIZER,
   tokenizerConfigSource: LFM2_VL_TOKENIZER_CONFIG,
 } as const;
@@ -1112,6 +1124,7 @@ export const MODEL_REGISTRY = {
     LFM2_5_1_2B_INSTRUCT,
     LFM2_5_1_2B_INSTRUCT_QUANTIZED,
     LFM2_VL_1_6B_QUANTIZED,
+    LFM2_VL_450M_QUANTIZED,
     EFFICIENTNET_V2_S,
     EFFICIENTNET_V2_S_QUANTIZED,
     SSDLITE_320_MOBILENET_V3_LARGE,


### PR DESCRIPTION
## Description

Adds the `LFM2_VL_450M_QUANTIZED` model constant for the new 450M quantized LFM2.5-VL variant. Reuses the existing LFM2.5-VL tokenizer and tokenizer config, and registers the model in `MODEL_REGISTRY`.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

1. Import `LFM2_VL_450M_QUANTIZED` from `react-native-executorch`.
2. Pass it to `useLLM` and verify the model downloads and runs inference with image input.

### Screenshots

### Related issues

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

Tokenizer and tokenizer config are shared with `LFM2_VL_1_6B_QUANTIZED`.
