### PR TITLE
fix: graceful degradation when native libraries are unavailable (Android)

### DIFF
--- a/packages/react-native-executorch/android/src/main/java/com/swmansion/rnexecutorch/ETInstallerUnavailable.kt
+++ b/packages/react-native-executorch/android/src/main/java/com/swmansion/rnexecutorch/ETInstallerUnavailable.kt
@@ -1,0 +1,27 @@
+package com.swmansion.rnexecutorch
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.common.annotations.FrameworkAPI
+import com.facebook.react.module.annotations.ReactModule
+
+/**
+ * Fallback TurboModule returned when native ExecuTorch libraries cannot be
+ * loaded (e.g. 32-bit Android devices where only arm64-v8a binaries are
+ * shipped). Extends the same spec as ETInstaller so JS sees a real linked
+ * module, but install() returns false to signal unavailability.
+ */
+@OptIn(FrameworkAPI::class)
+@ReactModule(name = ETInstallerUnavailable.NAME)
+class ETInstallerUnavailable(
+  reactContext: ReactApplicationContext,
+) : NativeETInstallerSpec(reactContext) {
+  companion object {
+    const val NAME = NativeETInstallerSpec.NAME
+  }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  override fun install(): Boolean {
+    return false
+  }
+}

--- a/packages/react-native-executorch/android/src/main/java/com/swmansion/rnexecutorch/RnExecutorchPackage.kt
+++ b/packages/react-native-executorch/android/src/main/java/com/swmansion/rnexecutorch/RnExecutorchPackage.kt
@@ -15,7 +15,18 @@ class RnExecutorchPackage : TurboReactPackage() {
     reactContext: ReactApplicationContext,
   ): NativeModule? =
     if (name == ETInstaller.NAME) {
-      ETInstaller(reactContext)
+      try {
+        ETInstaller(reactContext)
+      } catch (e: RuntimeException) {
+        if (e.cause is UnsatisfiedLinkError) {
+          // Native library not available (e.g. 32-bit device without arm64-v8a .so).
+          // Return a fallback module whose install() returns false so JS can
+          // distinguish "unsupported ABI" from "package not linked."
+          ETInstallerUnavailable(reactContext)
+        } else {
+          throw e
+        }
+      }
     } else {
       null
     }

--- a/packages/react-native-executorch/src/index.ts
+++ b/packages/react-native-executorch/src/index.ts
@@ -134,8 +134,19 @@ if (
       `Failed to install react-native-executorch: The native module could not be found.`
     );
   }
+  // install() returns false when the native library is intentionally unavailable
+  // (e.g. ETInstallerUnavailable on unsupported ABIs). In that case, JSI
+  // bindings are not injected and globals remain unset.
   ETInstallerNativeModule.install();
 }
+
+/**
+ * Whether the native ExecuTorch runtime is available on this device.
+ * Returns `false` when native libraries cannot be loaded (e.g. 32-bit Android
+ * devices where only arm64-v8a binaries are shipped).
+ * @category Utilities - General
+ */
+export const isAvailable = typeof global.loadExecutorchModule === 'function';
 
 // hooks
 export * from './hooks/computer_vision/useClassification';


### PR DESCRIPTION
## Description

On 32-bit Android devices (or devices with 64-bit CPUs running 32-bit userspace), the `arm64-v8a` native `.so` files are not found. `ETInstaller.init` throws `RuntimeException` wrapping `UnsatisfiedLinkError`, crashing the app at startup with no consumer-side escape hatch.

This PR adds a fallback TurboModule (`ETInstallerUnavailable`) whose `install()` returns `false`. `RnExecutorchPackage` returns it only when the native library fails to load, so JS sees a real linked module but JSI bindings are never injected. This preserves the existing linking-error Proxy for genuinely mislinked installs on supported devices.

**Unsupported ABI**: real module exists → `install()` returns `false` → globals not set → `isAvailable` is `false`
**Supported but mislinked**: module is `null` → existing Proxy throws linking error (unchanged)

No public API break; preserves existing mislink failure behavior. `isAvailable` is a new additive export.

### Introduces a breaking change?

- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)

### Tested on

- [x] Android

### Testing instructions

1. Build and run on a 32-bit Android device (e.g. Galaxy A13, Moto G Play 2023)
2. App should start without crashing
3. `isAvailable` should be `false`
4. Verify on a supported 64-bit device that everything works as before

### Related issues

Fixes #1065