### PR TITLE
Fix: yarn command for installing dependencies

### DIFF
--- a/docs/docs/01-fundamentals/01-getting-started.md
+++ b/docs/docs/01-fundamentals/01-getting-started.md
@@ -68,9 +68,9 @@ Installation is pretty straightforward, use your package manager of choice to in
     ```bash
     yarn add react-native-executorch
     # For Expo projects
-    yarn install react-native-executorch-expo-resource-fetcher
+    yarn add react-native-executorch-expo-resource-fetcher
     # For bare React Native projects
-    yarn install react-native-executorch-bare-resource-fetcher
+    yarn add react-native-executorch-bare-resource-fetcher
     ```
 
   </TabItem>

--- a/docs/versioned_docs/version-0.8.x/01-fundamentals/01-getting-started.md
+++ b/docs/versioned_docs/version-0.8.x/01-fundamentals/01-getting-started.md
@@ -68,9 +68,9 @@ Installation is pretty straightforward, use your package manager of choice to in
     ```bash
     yarn add react-native-executorch
     # For Expo projects
-    yarn install react-native-executorch-expo-resource-fetcher
+    yarn add react-native-executorch-expo-resource-fetcher
     # For bare React Native projects
-    yarn install react-native-executorch-bare-resource-fetcher
+    yarn add react-native-executorch-bare-resource-fetcher
     ```
 
   </TabItem>


### PR DESCRIPTION
## Summary
Fixes incorrect Yarn installation command in the documentation.

### Changes
- Replaced `yarn install <package>` with `yarn add <package>`
- Ensured consistency with standard Yarn usage across docs

### Reason
The current documentation incorrectly suggests using `yarn install <package>`, which does not add new dependencies. The correct command is `yarn add <package>`.

### Impact
- Prevents confusion for developers using Yarn
- Aligns documentation with actual Yarn behavior

## Description

<!-- Provide a concise and descriptive summary of the changes implemented in this PR. -->

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

###  Tested on
 - [ ] iOS
 - [ ] Android
 
### Testing instructions
- Build documentation locally via yarn start and check if everything is corrected.

### Screenshots
### Related issues

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes
Checked versioned documentation files; the issue does not exist there.
<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
