### PR TITLE
chore: exclude **/build/ from eslint ignorePatterns

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -106,7 +106,7 @@ module.exports = {
       },
     },
   ],
-  ignorePatterns: ['node_modules/', 'lib/'],
+  ignorePatterns: ['node_modules/', 'lib/', '**/build/'],
   settings: {
     jsdoc: {
       tagNamePreference: {


### PR DESCRIPTION
## Summary
- Add `**/build/` to ESLint's `ignorePatterns` so local CMake build artifacts don't trip the linter.
- CMake-generated `compiler_depend.ts` timestamp files (the `.ts` here means "timestamp", not TypeScript) are written into `packages/react-native-executorch/common/rnexecutorch/tests/build/` when the native test suite is built locally. The root lint glob `"**/*.{js,ts,tsx}"` picks them up and fails with `Parsing error: Invalid character`.
- These files are already gitignored, so this only affects local developer runs — but aligning ESLint with `.gitignore` avoids confusing noise.

## Test plan
- [ ] `yarn lint` passes cleanly on a workspace with the CMake test build present (so you need to build tests in `packages/react-native-executorch/common/rnexecutorch/tests` first)
- [ ] pre-commit hooks (format-js, lint, types) green