### PR TITLE
chore: clean up root peer deps and drop ignored resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   },
   "private": true,
   "devDependencies": {
+    "@babel/core": "^7.25.1",
+    "@babel/eslint-parser": "^7.25.1",
     "@cspell/eslint-plugin": "^8.19.0",
     "@evilmartians/lefthook": "^2.1.1",
     "@react-native/eslint-config": "^0.79.0",
@@ -25,7 +27,6 @@
     "eslint-plugin-jsdoc": "^62.7.1",
     "eslint-plugin-markdown": "^5.1.0",
     "eslint-plugin-prettier": "^5.0.1",
-    "expo-router": "~6.0.17",
     "prettier": "^3.3.3",
     "prettier-plugin-jsdoc": "^1.3.0",
     "typescript": "~5.9.2"

--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -81,9 +81,6 @@
     "react-native-builder-bob": "^0.40.12",
     "typescript": "~5.9.2"
   },
-  "resolutions": {
-    "@types/react": "^18.2.44"
-  },
   "workspaces": [
     "example"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,7 +60,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.20.0, @babel/core@npm:^7.21.3, @babel/core@npm:^7.23.9, @babel/core@npm:^7.25.2, @babel/core@npm:^7.27.4, @babel/core@npm:^7.29.0":
+"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.20.0, @babel/core@npm:^7.21.3, @babel/core@npm:^7.23.9, @babel/core@npm:^7.25.1, @babel/core@npm:^7.25.2, @babel/core@npm:^7.27.4, @babel/core@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/core@npm:7.29.0"
   dependencies:
@@ -14472,6 +14472,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-native-executorch-monorepo@workspace:."
   dependencies:
+    "@babel/core": "npm:^7.25.1"
+    "@babel/eslint-parser": "npm:^7.25.1"
     "@cspell/eslint-plugin": "npm:^8.19.0"
     "@evilmartians/lefthook": "npm:^2.1.1"
     "@react-native/eslint-config": "npm:^0.79.0"
@@ -14481,7 +14483,6 @@ __metadata:
     eslint-plugin-jsdoc: "npm:^62.7.1"
     eslint-plugin-markdown: "npm:^5.1.0"
     eslint-plugin-prettier: "npm:^5.0.1"
-    expo-router: "npm:~6.0.17"
     prettier: "npm:^3.3.3"
     prettier-plugin-jsdoc: "npm:^1.3.0"
     typescript: "npm:~5.9.2"


### PR DESCRIPTION
## Summary
Silences the peer-dep and `resolutions` warnings that show up on every root `yarn install`:

- Remove `expo-router` from root `devDependencies` — it's only consumed by the Expo apps (`apps/llm`, `apps/computer-vision`, `apps/text-embeddings`), each of which already declares it. At the root it pulled in a chain of unmet peer warnings (`expo`, `expo-constants`, `expo-linking`, `react`, `react-native`, `react-native-safe-area-context`, `react-native-screens`).
- Add `@babel/eslint-parser` and its own peer `@babel/core` to root `devDependencies` to satisfy `eslint-plugin-ft-flow`'s peer requirement.
- Delete the `resolutions` field inside `packages/react-native-executorch/package.json`. Yarn 4 only honors `resolutions` at the workspace root, so it was being ignored (`YN0057`), and it pinned `@types/react` to `^18.2.44` while every workspace already uses `~19.x` — dead config.

Before:
```
➤ YN0057: react-native-executorch: Resolutions field will be ignored
➤ YN0002: ...doesn't provide @babel/eslint-parser (requested by eslint-plugin-ft-flow)
➤ YN0002: ...doesn't provide expo (requested by expo-router)
➤ YN0002: ...doesn't provide expo-constants (requested by expo-router)
➤ YN0002: ...doesn't provide expo-linking (requested by expo-router)
➤ YN0002: ...doesn't provide react (requested by expo-router)
➤ YN0002: ...doesn't provide react-native (requested by expo-router)
➤ YN0002: ...doesn't provide react-native-safe-area-context (requested by expo-router)
➤ YN0002: ...doesn't provide react-native-screens (requested by expo-router)
➤ YN0086: Some peer dependencies are incorrectly met
```

After: `yarn` completes without any warning lines.

## Test plan
- [ ] `yarn` at repo root completes without `YN0002` / `YN0057` / `YN0086` warnings
- [ ] `yarn lint` passes
- [ ] `yarn typecheck` passes
- [ ] Expo apps (`apps/llm`, `apps/computer-vision`, `apps/text-embeddings`) still resolve `expo-router` from their own `dependencies`