### PR TITLE
chore: silence docs yarn install warnings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,4 +4,19 @@ enableGlobalCache: false
 
 nodeLinker: node-modules
 
+# Workaround for @signalwire/docusaurus-theme-llms-txt@1.0.0-alpha.9:
+# the package declares `react`/`react-dom` ^18 as peerDependencies, but
+# docs runs React 19. At runtime it works fine — the peer range is just
+# stale in the published alpha. Yarn prints two YN0060 warnings on every
+# install; the pattern below silences only those two lines, scoped to
+# this package (not a global YN0060 mute).
+#
+# TODO: when a newer @signalwire/docusaurus-theme-llms-txt ships with
+# a React 19-compatible peer range, bump it in docs/package.json and
+# remove this filter — we'd rather follow upstream than carry a local
+# suppression.
+logFilters:
+  - pattern: '*@signalwire/docusaurus-theme-llms-txt*'
+    level: discard
+
 yarnPath: .yarn/releases/yarn-4.1.1.cjs

--- a/docs/package.json
+++ b/docs/package.json
@@ -37,11 +37,13 @@
     "prism-react-renderer": "^2.1.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "react-icons": "^5.5.0",
     "swiper": "^12.1.2"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.9.2",
     "@docusaurus/tsconfig": "^3.9.2",
+    "@types/react": "~19.2.0",
     "docusaurus-plugin-typedoc": "^1.4.2",
     "typedoc": "^0.28.17",
     "typedoc-plugin-markdown": "^4.10.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -4507,6 +4507,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react@npm:~19.2.0":
+  version: 19.2.14
+  resolution: "@types/react@npm:19.2.14"
+  dependencies:
+    csstype: "npm:^3.2.2"
+  checksum: 10/fbff239089ee64b6bd9b00543594db498278b06de527ef1b0f71bb0eb09cc4445a71b5dd3c0d3d0257255c4eed94406be40a74ad4a987ade8a8d5dd65c82bc5f
+  languageName: node
+  linkType: hard
+
 "@types/retry@npm:0.12.2":
   version: 0.12.2
   resolution: "@types/retry@npm:0.12.2"
@@ -6503,12 +6512,14 @@ __metadata:
     "@signalwire/docusaurus-plugin-llms-txt": "npm:2.0.0-alpha.7"
     "@signalwire/docusaurus-theme-llms-txt": "npm:1.0.0-alpha.9"
     "@swmansion/t-rex-ui": "npm:^1.3.2"
+    "@types/react": "npm:~19.2.0"
     clsx: "npm:^2.1.0"
     copy-text-to-clipboard: "npm:^3.2.2"
     docusaurus-plugin-typedoc: "npm:^1.4.2"
     prism-react-renderer: "npm:^2.1.0"
     react: "npm:^19.2.3"
     react-dom: "npm:^19.2.3"
+    react-icons: "npm:^5.5.0"
     swiper: "npm:^12.1.2"
     typedoc: "npm:^0.28.17"
     typedoc-plugin-markdown: "npm:^4.10.0"


### PR DESCRIPTION
## Summary
Three warnings that `yarn` printed on every install inside the `docs` workspace:

- `YN0002` — `@mdx-js/react` peer `@types/react` not provided.
- `YN0002` — `@swmansion/t-rex-ui` peer `react-icons` not provided.
- `YN0060` (×2) — `@signalwire/docusaurus-theme-llms-txt@1.0.0-alpha.9` declares `react`/`react-dom` `^18.0.0`, but docs uses React 19.

## Changes
- Add `react-icons@^5.5.0` to `docs/package.json` dependencies. `@swmansion/t-rex-ui`'s icon-rendering components need it at runtime.
- Add `@types/react@~19.2.0` to `docs/package.json` devDependencies. Legitimate either way since `docs` runs `tsc` for typecheck.
- Add a per-package `logFilters` entry in [.yarnrc.yml](.yarnrc.yml) scoped to `@signalwire/docusaurus-theme-llms-txt`. Its declared peer range is stale — the plugin works with React 19, and its latest published alpha (`1.0.0-alpha.9`) doesn't fix the range. `packageExtensions` can't widen an existing peer range in Yarn Berry, so `logFilters` with a package-name pattern is the minimal non-global suppression. Comment includes a TODO to remove the filter once upstream publishes a fix.

Before:
```
➤ YN0060: react is listed by your project with version 19.2.3, which doesn't satisfy what @signalwire/docusaurus-theme-llms-txt ... request (^18.0.0)
➤ YN0060: react-dom is listed by your project with version 19.2.3, which doesn't satisfy what @signalwire/docusaurus-theme-llms-txt ... request (^18.0.0)
➤ YN0002: docs@workspace:. doesn't provide @types/react, requested by @mdx-js/react
➤ YN0002: docs@workspace:. doesn't provide react-icons, requested by @swmansion/t-rex-ui
➤ YN0086: Some peer dependencies are incorrectly met
```

After: `yarn` in `docs/` completes without warning lines.

## Test plan
- [ ] `yarn` inside `docs/` completes without `YN0002` / `YN0060` / `YN0086` warnings
- [ ] `yarn typecheck` (workspace-wide) passes
- [ ] Filter is scoped to signalwire's package name — other `YN0060` warnings (e.g., from future peer mismatches) would still surface