### PR TITLE
fix(llm): normalize multimodal image paths to file:// URIs

### DIFF
--- a/packages/react-native-executorch/src/controllers/LLMController.ts
+++ b/packages/react-native-executorch/src/controllers/LLMController.ts
@@ -254,7 +254,7 @@ export class LLMController {
         imagePaths && imagePaths.length > 0
           ? await this.nativeModule.generateMultimodal(
               input,
-              imagePaths,
+              imagePaths.map(normalizeImagePath),
               this.getImageToken(),
               this.onToken
             )
@@ -455,4 +455,16 @@ export class LLMController {
     });
     return result;
   }
+}
+
+/**
+ * The native multimodal pipeline expects image paths to be `file://` URIs.
+ * `ResourceFetcher.fetch` and most platform file APIs return raw filesystem
+ * paths without that prefix, so callers routinely pass either form. Accept
+ * both and normalize to the prefixed form here.
+ * @param path - Local image path, either with or without the `file://` prefix.
+ * @returns The same path with a `file://` prefix.
+ */
+function normalizeImagePath(path: string): string {
+  return path.startsWith('file://') ? path : `file://${path}`;
 }

--- a/packages/react-native-executorch/src/modules/natural_language_processing/LLMModule.ts
+++ b/packages/react-native-executorch/src/modules/natural_language_processing/LLMModule.ts
@@ -139,7 +139,7 @@ export class LLMModule {
    * It doesn't manage conversation context. It is intended for users that need access to the model itself without any wrapper.
    * If you want a simple chat with model the consider using `sendMessage`
    * @param input - Raw input string containing the prompt and conversation history.
-   * @param imagePaths - Optional array of local image paths for multimodal inference.
+   * @param imagePaths - Optional array of local image paths for multimodal inference. Each entry may be either `file:///absolute/path` or `/absolute/path` — the controller normalizes the path before passing it to native code.
    * @returns The generated response as a string.
    */
   async forward(input: string, imagePaths?: string[]): Promise<string> {

--- a/packages/react-native-executorch/src/types/llm.ts
+++ b/packages/react-native-executorch/src/types/llm.ts
@@ -270,6 +270,8 @@ export interface Message {
   /**
    * Optional local file path to media (image, audio, etc.).
    * Only valid on `user` messages.
+   * Either `file:///absolute/path` or `/absolute/path` is accepted; the
+   * controller normalizes the path before passing it to native code.
    */
   mediaPath?: string;
 }


### PR DESCRIPTION
## Description

`LLMController.forward` passed `imagePaths` straight through to `nativeModule.generateMultimodal` with no normalization. The native side requires the `file://` prefix; without it, native throws `"Read image error: invalid argument"` with no further context. Callers can plausibly arrive with either form:

- `ResourceFetcher.fetch` returns raw paths *without* `file://` (per its own docstring on the `fetch` method).
- Platform image-picker APIs (e.g. `expo-image-picker`) typically return `file:///...` URIs.
- The same path string passed to a vision module's `forward(...)` works either way; the asymmetry between vision modules and multimodal LLM is undocumented.

This PR normalizes each image path inside `LLMController.forward` so both forms work, and updates the JSDoc on `Message.mediaPath` and `LLMModule.forward.imagePaths` to document the new contract.

### Introduces a breaking change?

- [ ] Yes
- [x] No

Strictly additive: previously-working calls (paths with `file://`) keep working unchanged. Previously-failing calls (paths without `file://`) now succeed.

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature
- [ ] Documentation update
- [ ] Other

### Tested on

- [ ] iOS
- [ ] Android

The bare-path failure was reproduced on Android (Samsung Galaxy S24 Ultra) with LFM2-VL-1.6B while building a downstream consumer; both forms tested manually post-fix on the same device. Re-verification of both forms on iOS is recommended.

### Testing instructions

```ts
import { LLMModule, LFM2_VL_1_6B_QUANTIZED } from 'react-native-executorch';
const llm = await LLMModule.fromModelName(LFM2_VL_1_6B_QUANTIZED);

// Both should now work; previously only the first did.
await llm.generate([
  { role: 'user', content: 'Describe.', mediaPath: 'file:///absolute/path/to/img.jpg' },
]);
await llm.generate([
  { role: 'user', content: 'Describe.', mediaPath: '/absolute/path/to/img.jpg' },
]);
```

### Related issues

Addresses item 3 of #1086.

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

The normalizer is module-scope (matching `messagesForChatTemplate` from #1089) rather than a class method because it doesn't depend on controller state.