### PR TITLE
feat(resource-fetcher): add /auto side-effect entry points

### DIFF
--- a/apps/bare-rn/App.tsx
+++ b/apps/bare-rn/App.tsx
@@ -1,3 +1,4 @@
+import 'react-native-executorch-bare-resource-fetcher/auto';
 import React, { useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
@@ -13,12 +14,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
-import {
-  initExecutorch,
-  useLLM,
-  LLAMA3_2_1B_SPINQUANT,
-} from 'react-native-executorch';
-import { BareResourceFetcher } from 'react-native-executorch-bare-resource-fetcher';
+import { useLLM, LLAMA3_2_1B_SPINQUANT } from 'react-native-executorch';
 import { setConfig } from '@kesha-antonov/react-native-background-downloader';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
@@ -28,11 +24,6 @@ setConfig({
   logCallback: log => {
     console.log('[BackgroundDownloader]', log);
   },
-});
-
-// Initialize Executorch with bare adapter
-initExecutorch({
-  resourceFetcher: BareResourceFetcher,
 });
 
 const ColorPalette = {

--- a/apps/computer-vision/app/_layout.tsx
+++ b/apps/computer-vision/app/_layout.tsx
@@ -1,6 +1,5 @@
+import 'react-native-executorch-expo-resource-fetcher/auto';
 import { Drawer } from 'expo-router/drawer';
-import { initExecutorch } from 'react-native-executorch';
-import { ExpoResourceFetcher } from 'react-native-executorch-expo-resource-fetcher';
 
 import ColorPalette from '../colors';
 import React, { useState } from 'react';
@@ -12,10 +11,6 @@ import {
   DrawerItemList,
 } from '@react-navigation/drawer';
 import { GeneratingContext } from '../context';
-
-initExecutorch({
-  resourceFetcher: ExpoResourceFetcher,
-});
 
 interface CustomDrawerProps extends DrawerContentComponentProps {
   isGenerating: boolean;

--- a/apps/llm/app/_layout.tsx
+++ b/apps/llm/app/_layout.tsx
@@ -1,6 +1,5 @@
+import 'react-native-executorch-expo-resource-fetcher/auto';
 import { Drawer } from 'expo-router/drawer';
-import { initExecutorch } from 'react-native-executorch';
-import { ExpoResourceFetcher } from 'react-native-executorch-expo-resource-fetcher';
 import ColorPalette from '../colors';
 import React, { useState } from 'react';
 import { Text, StyleSheet, View } from 'react-native';
@@ -11,10 +10,6 @@ import {
   DrawerToggleButton,
 } from '@react-navigation/drawer';
 import { GeneratingContext } from '../context';
-
-initExecutorch({
-  resourceFetcher: ExpoResourceFetcher,
-});
 
 interface CustomDrawerProps extends DrawerContentComponentProps {
   isGenerating: boolean;

--- a/apps/speech/App.tsx
+++ b/apps/speech/App.tsx
@@ -1,3 +1,4 @@
+import 'react-native-executorch-expo-resource-fetcher/auto';
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { TextToSpeechScreen } from './screens/TextToSpeechScreen';
@@ -6,12 +7,6 @@ import ColorPalette from './colors';
 import ExecutorchLogo from './assets/executorch.svg';
 import { Quiz } from './screens/Quiz';
 import { TextToSpeechLLMScreen } from './screens/TextToSpeechLLMScreen';
-import { initExecutorch } from 'react-native-executorch';
-import { ExpoResourceFetcher } from 'react-native-executorch-expo-resource-fetcher';
-
-initExecutorch({
-  resourceFetcher: ExpoResourceFetcher,
-});
 
 export default function App() {
   const [currentScreen, setCurrentScreen] = useState<

--- a/apps/text-embeddings/app/_layout.tsx
+++ b/apps/text-embeddings/app/_layout.tsx
@@ -1,6 +1,5 @@
+import 'react-native-executorch-expo-resource-fetcher/auto';
 import { Drawer } from 'expo-router/drawer';
-import { initExecutorch } from 'react-native-executorch';
-import { ExpoResourceFetcher } from 'react-native-executorch-expo-resource-fetcher';
 import ColorPalette from '../colors';
 import React, { useState } from 'react';
 import { Text, StyleSheet, View } from 'react-native';
@@ -11,10 +10,6 @@ import {
   DrawerItemList,
 } from '@react-navigation/drawer';
 import { GeneratingContext } from '../context';
-
-initExecutorch({
-  resourceFetcher: ExpoResourceFetcher,
-});
 
 interface CustomDrawerProps extends DrawerContentComponentProps {
   isGenerating: boolean;

--- a/docs/docs/01-fundamentals/01-getting-started.md
+++ b/docs/docs/01-fundamentals/01-getting-started.md
@@ -77,12 +77,20 @@ Installation is pretty straightforward, use your package manager of choice to in
 </Tabs>
 
 :::warning
-Before using any other API, you must call `initExecutorch` with a resource fetcher adapter at the entry point of your app:
+Before using any other API, you must register a resource fetcher adapter at the entry point of your app. The simplest way is a side-effect import:
+
+```js
+// For Expo projects:
+import 'react-native-executorch-expo-resource-fetcher/auto';
+// Or, for bare React Native projects:
+import 'react-native-executorch-bare-resource-fetcher/auto';
+```
+
+If you need more control — registering a custom adapter, swapping adapters at runtime, or ordering registration relative to other side effects — call `initExecutorch` directly instead:
 
 ```js
 import { initExecutorch } from 'react-native-executorch';
 import { ExpoResourceFetcher } from 'react-native-executorch-expo-resource-fetcher';
-// or BareResourceFetcher for Expo projects
 
 initExecutorch({ resourceFetcher: ExpoResourceFetcher });
 ```

--- a/docs/docs/01-fundamentals/02-loading-models.md
+++ b/docs/docs/01-fundamentals/02-loading-models.md
@@ -15,7 +15,13 @@ yarn add react-native-executorch-expo-resource-fetcher
 yarn add expo-file-system expo-asset
 ```
 
-and then add the following code in your React Native app:
+and then add a single side-effect import at the entry point of your React Native app:
+
+```typescript
+import 'react-native-executorch-expo-resource-fetcher/auto';
+```
+
+If you need more control — registering a custom adapter, swapping adapters at runtime, or ordering registration relative to other side effects — call `initExecutorch` directly instead:
 
 ```typescript
 import { initExecutorch } from 'react-native-executorch';
@@ -36,8 +42,14 @@ yarn add @dr.pogodin/react-native-fs @kesha-antonov/react-native-background-down
 and
 
 ```typescript
+import 'react-native-executorch-bare-resource-fetcher/auto';
+```
+
+The same `initExecutorch(...)` escape hatch applies for the bare adapter:
+
+```typescript
 import { initExecutorch } from 'react-native-executorch';
-import { BareResourceFetcher } from '@react-native-executorch/bare-adapter';
+import { BareResourceFetcher } from 'react-native-executorch-bare-resource-fetcher';
 
 initExecutorch({
   resourceFetcher: BareResourceFetcher,

--- a/packages/bare-resource-fetcher/package.json
+++ b/packages/bare-resource-fetcher/package.json
@@ -8,6 +8,10 @@
     ".": {
       "import": "./lib/index.js",
       "types": "./lib/index.d.ts"
+    },
+    "./auto": {
+      "import": "./lib/auto.js",
+      "types": "./lib/auto.d.ts"
     }
   },
   "files": [

--- a/packages/bare-resource-fetcher/src/auto.ts
+++ b/packages/bare-resource-fetcher/src/auto.ts
@@ -1,0 +1,15 @@
+// Side-effect import that registers the bare React Native resource
+// fetcher with react-native-executorch on import. Saves the boilerplate
+// `initExecutorch({ resourceFetcher: BareResourceFetcher })` call at
+// app entry. Use this when you have nothing custom to configure:
+//
+//     import 'react-native-executorch-bare-resource-fetcher/auto';
+//
+// Stick with the explicit `initExecutorch(...)` call from the package's
+// main entry if you need to register a different adapter, swap adapters
+// at runtime, or order the registration relative to other side effects.
+
+import { initExecutorch } from 'react-native-executorch';
+import { BareResourceFetcher } from './ResourceFetcher';
+
+initExecutorch({ resourceFetcher: BareResourceFetcher });

--- a/packages/expo-resource-fetcher/package.json
+++ b/packages/expo-resource-fetcher/package.json
@@ -8,6 +8,10 @@
     ".": {
       "import": "./lib/index.js",
       "types": "./lib/index.d.ts"
+    },
+    "./auto": {
+      "import": "./lib/auto.js",
+      "types": "./lib/auto.d.ts"
     }
   },
   "files": [

--- a/packages/expo-resource-fetcher/src/auto.ts
+++ b/packages/expo-resource-fetcher/src/auto.ts
@@ -1,0 +1,15 @@
+// Side-effect import that registers the Expo resource fetcher with
+// react-native-executorch on import. Saves the boilerplate
+// `initExecutorch({ resourceFetcher: ExpoResourceFetcher })` call at
+// app entry. Use this when you have nothing custom to configure:
+//
+//     import 'react-native-executorch-expo-resource-fetcher/auto';
+//
+// Stick with the explicit `initExecutorch(...)` call from the package's
+// main entry if you need to register a different adapter, swap adapters
+// at runtime, or order the registration relative to other side effects.
+
+import { initExecutorch } from 'react-native-executorch';
+import { ExpoResourceFetcher } from './ResourceFetcher';
+
+initExecutorch({ resourceFetcher: ExpoResourceFetcher });

--- a/packages/react-native-executorch/src/utils/ResourceFetcher.ts
+++ b/packages/react-native-executorch/src/utils/ResourceFetcher.ts
@@ -107,7 +107,7 @@ export class ResourceFetcher {
   static getAdapter(): ResourceFetcherAdapter {
     if (!this.adapter) {
       const errorMessage =
-        'ResourceFetcher adapter is not initialized. Please call initExecutorch({ resourceFetcher: ... }) with a valid adapter, e.g., from react-native-executorch-expo-resource-fetcher or react-native-executorch-bare-resource-fetcher. For more details please refer to: https://docs.swmansion.com/react-native-executorch/docs/next/fundamentals/loading-models';
+        "ResourceFetcher adapter is not initialized. The simplest fix is a side-effect import at your app entry point: `import 'react-native-executorch-expo-resource-fetcher/auto'` (Expo) or `import 'react-native-executorch-bare-resource-fetcher/auto'` (bare React Native). For full control over registration, call `initExecutorch({ resourceFetcher: ... })` directly. See: https://docs.swmansion.com/react-native-executorch/docs/next/fundamentals/loading-models";
       // for sanity :)
       Logger.error(errorMessage);
       throw new RnExecutorchError(


### PR DESCRIPTION
## Description

Forgetting `initExecutorch({ resourceFetcher: ExpoResourceFetcher })` (or its `BareResourceFetcher` counterpart) before the first model call is a runtime footgun every Expo / bare consumer has to remember. The error message we throw is good — it directs users to the right packages — but the boilerplate itself shouldn't be needed.

This PR adds an opt-in side-effect entry point in each adapter package:

```ts
// at the top of App.tsx / app/_layout.tsx — once
import 'react-native-executorch-expo-resource-fetcher/auto';

// or, for bare React Native:
import 'react-native-executorch-bare-resource-fetcher/auto';
```

The new entries live in the adapter packages (rather than in `react-native-executorch` itself) so the main package doesn't need a hard dependency on either adapter implementation — bare-RN consumers don't get Expo bloat and vice versa.

### Introduces a breaking change?

- [ ] Yes
- [x] No

Strictly additive. The manual `initExecutorch({ resourceFetcher: ... })` API stays exactly as is — same module export, same signature. Existing consumers are unaffected. Use the manual API when you need to register a different adapter, swap adapters at runtime, or order the registration relative to other side effects; use the new `/auto` entry when you have nothing custom to configure.

### Type of change

- [ ] Bug fix
- [x] New feature (change which adds functionality)
- [ ] Documentation update
- [ ] Other

### Tested on

- [ ] iOS
- [ ] Android

Pure JS plumbing — no native code touched. Verified locally that:
- `yarn workspace ... run prepare` produces `lib/auto.{js,d.ts}` artifacts in both adapter packages.
- `yarn typecheck` passes across all workspaces.
- `eslint` and `prettier --check` pass on the new files.

### Testing instructions

In any RNE consumer:

- [ ] 1. Replace the existing `initExecutorch({ resourceFetcher: ExpoResourceFetcher })` call with a single side-effect import at app entry: `import 'react-native-executorch-expo-resource-fetcher/auto';`.
- [ ] 2. Boot the app and load any model. The `ResourceFetcher adapter is not initialized` error should not surface (which it would have if you'd just deleted the `initExecutorch` call without the new import).
- [ ] 3. Optionally verify the manual `initExecutorch(...)` flow still works by running an app that uses it — output should be identical.

### Related issues

Addresses item 5 of #1086.

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

- A reasonable follow-up (out of scope for this PR) is a docs update that recommends the `/auto` entry as the default for new projects.
- Naming: I went with `/auto` for brevity (consistent with the `expo-router/entry` reference pointed at in the issue). Open to alternatives like `/register` or `/init` if you prefer.