### PR TITLE
chore: add Qwen3.5 and Bielik v3.0 models

### DIFF
--- a/.cspell-wordlist.txt
+++ b/.cspell-wordlist.txt
@@ -183,3 +183,4 @@ Synchronizable
 stringifying
 hɛloʊ
 wɜːld
+bielik

--- a/apps/llm/components/llmModels.ts
+++ b/apps/llm/components/llmModels.ts
@@ -39,6 +39,7 @@ import {
   QWEN3_5_0_8B_QUANTIZED,
   QWEN3_5_2B_QUANTIZED,
   BIELIK_V3_0_1_5B_QUANTIZED,
+  BIELIK_V3_0_1_5B,
 } from 'react-native-executorch';
 import { ModelOption } from './ModelPicker';
 
@@ -95,6 +96,6 @@ export const LLM_MODELS: ModelOption<LLMModelSources>[] = [
     value: LFM2_5_1_2B_INSTRUCT_QUANTIZED,
   },
   // Bielik v3.0
-  { label: 'Bielik v3.0 1.5B', value: BIELIK_V3_0_1_5B_QUANTIZED },
+  { label: 'Bielik v3.0 1.5B', value: BIELIK_V3_0_1_5B },
   { label: 'Bielik v3.0 1.5B Quantized', value: BIELIK_V3_0_1_5B_QUANTIZED },
 ];

--- a/apps/llm/components/llmModels.ts
+++ b/apps/llm/components/llmModels.ts
@@ -36,6 +36,9 @@ import {
   LFM2_5_1_2B_INSTRUCT,
   LFM2_5_1_2B_INSTRUCT_QUANTIZED,
   LLMProps,
+  QWEN3_5_0_8B_QUANTIZED,
+  QWEN3_5_2B_QUANTIZED,
+  BIELIK_V3_0_1_5B_QUANTIZED,
 } from 'react-native-executorch';
 import { ModelOption } from './ModelPicker';
 
@@ -77,6 +80,9 @@ export const LLM_MODELS: ModelOption<LLMModelSources>[] = [
   { label: 'Qwen2.5 1.5B Quantized', value: QWEN2_5_1_5B_QUANTIZED },
   { label: 'Qwen2.5 3B', value: QWEN2_5_3B },
   { label: 'Qwen2.5 3B Quantized', value: QWEN2_5_3B_QUANTIZED },
+  // Qwen3.5
+  { label: 'Qwen3.5 0.8B Quantized', value: QWEN3_5_0_8B_QUANTIZED },
+  { label: 'Qwen3.5 2B Quantized', value: QWEN3_5_2B_QUANTIZED },
   // Phi-4
   { label: 'Phi-4 Mini 4B', value: PHI_4_MINI_4B },
   { label: 'Phi-4 Mini 4B Quantized', value: PHI_4_MINI_4B_QUANTIZED },
@@ -88,4 +94,7 @@ export const LLM_MODELS: ModelOption<LLMModelSources>[] = [
     label: 'LFM2.5 1.2B Instruct Quantized',
     value: LFM2_5_1_2B_INSTRUCT_QUANTIZED,
   },
+  // Bielik v3.0
+  { label: 'Bielik v3.0 1.5B', value: BIELIK_V3_0_1_5B_QUANTIZED },
+  { label: 'Bielik v3.0 1.5B Quantized', value: BIELIK_V3_0_1_5B_QUANTIZED },
 ];

--- a/packages/react-native-executorch/src/constants/modelUrls.ts
+++ b/packages/react-native-executorch/src/constants/modelUrls.ts
@@ -1,5 +1,5 @@
 import { Platform } from 'react-native';
-import { URL_PREFIX, VERSION_TAG } from './versions';
+import { URL_PREFIX, VERSION_TAG, NEXT_VERSION_TAG } from './versions';
 
 // LLMs
 
@@ -353,6 +353,36 @@ export const QWEN2_5_3B_QUANTIZED = {
   tokenizerConfigSource: QWEN2_5_TOKENIZER_CONFIG,
 } as const;
 
+// QWEN3.5-0.8B
+const QWEN3_5_0_8B_QUANTIZED_MODEL = `${URL_PREFIX}-qwen-3.5/${NEXT_VERSION_TAG}/Qwen3.5-0.8B/qwen3_5_0_8b_xnnpack_8da4w.pte`;
+const QWEN3_5_0_8B_TOKENIZER = `${URL_PREFIX}-qwen-3.5/${NEXT_VERSION_TAG}/Qwen3.5-0.8B/tokenizer.json`;
+const QWEN3_5_0_8B_TOKENIZER_CONFIG = `${URL_PREFIX}-qwen-3.5/${NEXT_VERSION_TAG}/Qwen3.5-0.8B/tokenizer_config.json`;
+
+/**
+ * @category Models - LLM
+ */
+export const QWEN3_5_0_8B_QUANTIZED = {
+  modelName: 'qwen3.5-0.8b-quantized',
+  modelSource: QWEN3_5_0_8B_QUANTIZED_MODEL,
+  tokenizerSource: QWEN3_5_0_8B_TOKENIZER,
+  tokenizerConfigSource: QWEN3_5_0_8B_TOKENIZER_CONFIG,
+} as const;
+
+// QWEN3.5-2B
+const QWEN3_5_2B_QUANTIZED_MODEL = `${URL_PREFIX}-qwen-3.5/${NEXT_VERSION_TAG}/Qwen3.5-2B/qwen3_5_2b_xnnpack_8da4w.pte`;
+const QWEN3_5_2B_TOKENIZER = `${URL_PREFIX}-qwen-3.5/${NEXT_VERSION_TAG}/Qwen3.5-2B/tokenizer.json`;
+const QWEN3_5_2B_TOKENIZER_CONFIG = `${URL_PREFIX}-qwen-3.5/${NEXT_VERSION_TAG}/Qwen3.5-2B/tokenizer_config.json`;
+
+/**
+ * @category Models - LLM
+ */
+export const QWEN3_5_2B_QUANTIZED = {
+  modelName: 'qwen3.5-2b-quantized',
+  modelSource: QWEN3_5_2B_QUANTIZED_MODEL,
+  tokenizerSource: QWEN3_5_2B_TOKENIZER,
+  tokenizerConfigSource: QWEN3_5_2B_TOKENIZER_CONFIG,
+} as const;
+
 // PHI 4
 const PHI_4_MINI_4B_MODEL = `${URL_PREFIX}-phi-4-mini/${VERSION_TAG}/original/phi-4-mini_bf16.pte`;
 const PHI_4_MINI_4B_QUANTIZED_MODEL = `${URL_PREFIX}-phi-4-mini/${VERSION_TAG}/quantized/phi-4-mini_8da4w.pte`;
@@ -429,6 +459,32 @@ export const LFM2_5_350M_QUANTIZED = {
   modelSource: LFM2_5_350M_QUANTIZED_MODEL,
   tokenizerSource: LFM2_5_350M_TOKENIZER,
   tokenizerConfigSource: LFM2_5_350M_TOKENIZER_CONFIG,
+} as const;
+
+// Bielik-v3.0
+const BIELIK_V3_0_1_5B_MODEL = `${URL_PREFIX}-bielik-v3.0/${VERSION_TAG}/bielik-v3.0-1.5B/original/bielik_1_5b_v3_0_instruct_xnnpack_fp16.pte`;
+const BIELIK_V3_0_1_5B_QUANTIZED_MODEL = `${URL_PREFIX}-bielik-v3.0/${VERSION_TAG}/bielik-v3.0-1.5B/quantized/bielik_1_5b_v3_0_instruct_xnnpack_8da4w.pte`;
+const BIELIK_V3_0_TOKENIZER = `${URL_PREFIX}-bielik-v3.0/${VERSION_TAG}/tokenizer.json`;
+const BIELIK_V3_0_TOKENIZER_CONFIG = `${URL_PREFIX}-bielik-v3.0/${VERSION_TAG}/tokenizer_config.json`;
+
+/**
+ * @category Models - LLM
+ */
+export const BIELIK_V3_0_1_5B = {
+  modelName: 'bielik-v3.0-1.5b',
+  modelSource: BIELIK_V3_0_1_5B_MODEL,
+  tokenizerSource: BIELIK_V3_0_TOKENIZER,
+  tokenizerConfigSource: BIELIK_V3_0_TOKENIZER_CONFIG,
+} as const;
+
+/**
+ * @category Models - LLM
+ */
+export const BIELIK_V3_0_1_5B_QUANTIZED = {
+  modelName: 'bielik-v3.0-1.5b-quantized',
+  modelSource: BIELIK_V3_0_1_5B_QUANTIZED_MODEL,
+  tokenizerSource: BIELIK_V3_0_TOKENIZER,
+  tokenizerConfigSource: BIELIK_V3_0_TOKENIZER_CONFIG,
 } as const;
 
 // LFM2.5-VL-1.6B
@@ -1103,6 +1159,8 @@ export const MODEL_REGISTRY = {
     QWEN3_1_7B_QUANTIZED,
     QWEN3_4B,
     QWEN3_4B_QUANTIZED,
+    QWEN3_5_0_8B_QUANTIZED,
+    QWEN3_5_2B_QUANTIZED,
     HAMMER2_1_0_5B,
     HAMMER2_1_0_5B_QUANTIZED,
     HAMMER2_1_1_5B,
@@ -1129,6 +1187,8 @@ export const MODEL_REGISTRY = {
     LFM2_5_1_2B_INSTRUCT_QUANTIZED,
     LFM2_VL_1_6B_QUANTIZED,
     LFM2_VL_450M_QUANTIZED,
+    BIELIK_V3_0_1_5B,
+    BIELIK_V3_0_1_5B_QUANTIZED,
     EFFICIENTNET_V2_S,
     EFFICIENTNET_V2_S_QUANTIZED,
     SSDLITE_320_MOBILENET_V3_LARGE,

--- a/packages/react-native-executorch/src/types/llm.ts
+++ b/packages/react-native-executorch/src/types/llm.ts
@@ -56,7 +56,11 @@ export type LLMModelName =
   | 'lfm2.5-1.2b-instruct'
   | 'lfm2.5-1.2b-instruct-quantized'
   | 'lfm2.5-vl-1.6b-quantized'
-  | 'lfm2.5-vl-450m-quantized';
+  | 'lfm2.5-vl-450m-quantized'
+  | 'qwen3.5-0.8b-quantized'
+  | 'qwen3.5-2b-quantized'
+  | 'bielik-v3.0-1.5b'
+  | 'bielik-v3.0-1.5b-quantized';
 
 /**
  * Properties for initializing and configuring a Large Language Model (LLM) instance.


### PR DESCRIPTION
## Description

Adds symbols for Qwen3.5 and Bielik models.

NOTE: The support for Qwen3.5 is experimental right now since due to architectural constraints (namely the GatedDeltaNet implementation) model requires sequential prefill fallback which results in very slow prefill.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

- [x] Run example LLM app and test new models:
       - `QWEN3_5_2B_QUANTIZED`
       - `QWEN3_5_0_8B_QUANTIZED`
       - `BIELIK_V3_0_1_5B`
       - `BIELIK_V3_0_1_5B_QUANTIZED`
- [x] Check HF pages for the added models:
       - https://huggingface.co/software-mansion/react-native-executorch-qwen-3.5 
       - https://huggingface.co/software-mansion/react-native-executorch-bielik-v3.0  

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->
Closes #935 
Closes #1097 

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
