### PR TITLE
feat(llm): min_p and repetition_penalty sampling, per-model defaults, letterbox vision

### DIFF
--- a/apps/llm/app/multimodal_llm/index.tsx
+++ b/apps/llm/app/multimodal_llm/index.tsx
@@ -14,7 +14,7 @@ import {
 import { launchImageLibrary } from 'react-native-image-picker';
 import { useIsFocused } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useLLM, LFM2_VL_1_6B_QUANTIZED } from 'react-native-executorch';
+import { useLLM, LFM2_5_VL_1_6B_QUANTIZED } from 'react-native-executorch';
 import SendIcon from '../../assets/icons/send_icon.svg';
 import PauseIcon from '../../assets/icons/pause_icon.svg';
 import ColorPalette from '../../colors';
@@ -50,7 +50,7 @@ function MultimodalLLMScreen() {
   const [error, setError] = useState<string | null>(null);
 
   const vlm = useLLM({
-    model: LFM2_VL_1_6B_QUANTIZED,
+    model: LFM2_5_VL_1_6B_QUANTIZED,
   });
   const tokenCount = vlm.isReady ? vlm.getGeneratedTokenCount() : 0;
   const { stats, onMessageSend } = useLLMStats(

--- a/docs/docs/03-hooks/01-natural-language-processing/useLLM.md
+++ b/docs/docs/03-hooks/01-natural-language-processing/useLLM.md
@@ -501,9 +501,9 @@ Some models support multimodal input — text and images together. To use them, 
 ### Loading a VLM
 
 ```tsx
-import { useLLM, LFM2_VL_1_6B_QUANTIZED } from 'react-native-executorch';
+import { useLLM, LFM2_5_VL_1_6B_QUANTIZED } from 'react-native-executorch';
 
-const llm = useLLM({ model: LFM2_VL_1_6B_QUANTIZED });
+const llm = useLLM({ model: LFM2_5_VL_1_6B_QUANTIZED });
 ```
 
 The `capabilities` field is already set on the model constant. You can also construct the model object explicitly:
@@ -524,7 +524,7 @@ Passing `capabilities` unlocks the typed `media` argument on `sendMessage`.
 ### Sending a message with an image
 
 ```tsx
-const llm = useLLM({ model: LFM2_VL_1_6B_QUANTIZED });
+const llm = useLLM({ model: LFM2_5_VL_1_6B_QUANTIZED });
 
 const send = () => {
   llm.sendMessage('What is in this image?', {
@@ -547,7 +547,7 @@ The `imagePath` should be a local file path on the device.
 You can also use `generate` directly by setting `mediaPath` on user messages:
 
 ```tsx
-const llm = useLLM({ model: LFM2_VL_1_6B_QUANTIZED });
+const llm = useLLM({ model: LFM2_5_VL_1_6B_QUANTIZED });
 
 const handleGenerate = async () => {
   const chat: Message[] = [

--- a/docs/docs/03-hooks/01-natural-language-processing/useLLM.md
+++ b/docs/docs/03-hooks/01-natural-language-processing/useLLM.md
@@ -211,9 +211,9 @@ To configure model (i.e. change system prompt, load initial conversation history
 
   - [`temperature`](../../06-api-reference/interfaces/GenerationConfig.md#temperature) - Scales output logits by the inverse of temperature. Controls the randomness / creativity of text generation.
 
-  - [`topp`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topp. Range `[0, 1]`. Values of `0` or `1` disable top-p filtering.
+  - [`topP`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topP. Range `[0, 1]`. Values of `0` or `1` disable top-p filtering.
 
-  - [`minP`](../../06-api-reference/interfaces/GenerationConfig.md#minp) - Minimum-probability threshold applied after softmax: tokens whose probability is below `minP * max_prob` are excluded from sampling. Range `[0, 1]`. Default `0` disables the filter. Stacks with `topp` when both are set.
+  - [`minP`](../../06-api-reference/interfaces/GenerationConfig.md#minp) - Minimum-probability threshold applied after softmax: tokens whose probability is below `minP * max_prob` are excluded from sampling. Range `[0, 1]`. Default `0` disables the filter. Stacks with `topP` when both are set.
 
   - [`repetitionPenalty`](../../06-api-reference/interfaces/GenerationConfig.md#repetitionpenalty) - Multiplicative penalty applied to logits of tokens that already appeared in the prompt or the generated text. Values greater than `1` discourage repetition; default `1` disables the penalty.
 
@@ -290,7 +290,7 @@ useEffect(() => {
       outputTokenBatchSize: 15,
       batchTimeInterval: 100,
       temperature: 0.7,
-      topp: 0.9,
+      topP: 0.9,
       minP: 0.05,
       repetitionPenalty: 1.05,
     },

--- a/docs/docs/03-hooks/01-natural-language-processing/useLLM.md
+++ b/docs/docs/03-hooks/01-natural-language-processing/useLLM.md
@@ -211,7 +211,15 @@ To configure model (i.e. change system prompt, load initial conversation history
 
   - [`temperature`](../../06-api-reference/interfaces/GenerationConfig.md#temperature) - Scales output logits by the inverse of temperature. Controls the randomness / creativity of text generation.
 
-  - [`topp`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topp.
+  - [`topp`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topp. Range `[0, 1]`. Values of `0` or `1` disable top-p filtering.
+
+  - [`minP`](../../06-api-reference/interfaces/GenerationConfig.md#minp) - Minimum-probability threshold applied after softmax: tokens whose probability is below `minP * max_prob` are excluded from sampling. Range `[0, 1]`. Default `0` disables the filter. Stacks with `topp` when both are set.
+
+  - [`repetitionPenalty`](../../06-api-reference/interfaces/GenerationConfig.md#repetitionpenalty) - Multiplicative penalty applied to logits of tokens that already appeared in the prompt or the generated text. Values greater than `1` discourage repetition; default `1` disables the penalty.
+
+:::info[Built-in models ship with sampling defaults]
+Model presets expose an optional [`generationConfig`](../../06-api-reference/interfaces/LLMProps.md) on the `model` prop. Whenever the upstream model card publishes recommended values (currently Qwen3 and LFM2-VL) the preset carries them and `useLLM` applies them automatically before `isReady` flips — you don't need to call `configure` just to get sensible defaults. Any fields you then pass to `configure` still override on a per-field basis.
+:::
 
 ### Model configuration example
 
@@ -283,6 +291,8 @@ useEffect(() => {
       batchTimeInterval: 100,
       temperature: 0.7,
       topp: 0.9,
+      minP: 0.05,
+      repetitionPenalty: 1.05,
     },
   });
 }, [configure]);

--- a/docs/docs/04-typescript-api/01-natural-language-processing/LLMModule.md
+++ b/docs/docs/04-typescript-api/01-natural-language-processing/LLMModule.md
@@ -107,9 +107,9 @@ To configure model (i.e. change system prompt, load initial conversation history
 
   - [`temperature`](../../06-api-reference/interfaces/GenerationConfig.md#temperature) - Scales output logits by the inverse of temperature. Controls the randomness / creativity of text generation.
 
-  - [`topp`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topp. Range `[0, 1]`. Values of `0` or `1` disable top-p filtering.
+  - [`topP`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topP. Range `[0, 1]`. Values of `0` or `1` disable top-p filtering.
 
-  - [`minP`](../../06-api-reference/interfaces/GenerationConfig.md#minp) - Minimum-probability threshold applied after softmax: tokens whose probability is below `minP * max_prob` are excluded from sampling. Range `[0, 1]`. Default `0` disables the filter. Stacks with `topp` when both are set.
+  - [`minP`](../../06-api-reference/interfaces/GenerationConfig.md#minp) - Minimum-probability threshold applied after softmax: tokens whose probability is below `minP * max_prob` are excluded from sampling. Range `[0, 1]`. Default `0` disables the filter. Stacks with `topP` when both are set.
 
   - [`repetitionPenalty`](../../06-api-reference/interfaces/GenerationConfig.md#repetitionpenalty) - Multiplicative penalty applied to logits of tokens that already appeared in the prompt or the generated text. Values greater than `1` discourage repetition; default `1` disables the penalty.
 

--- a/docs/docs/04-typescript-api/01-natural-language-processing/LLMModule.md
+++ b/docs/docs/04-typescript-api/01-natural-language-processing/LLMModule.md
@@ -107,7 +107,15 @@ To configure model (i.e. change system prompt, load initial conversation history
 
   - [`temperature`](../../06-api-reference/interfaces/GenerationConfig.md#temperature) - Scales output logits by the inverse of temperature. Controls the randomness / creativity of text generation.
 
-  - [`topp`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topp.
+  - [`topp`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topp. Range `[0, 1]`. Values of `0` or `1` disable top-p filtering.
+
+  - [`minP`](../../06-api-reference/interfaces/GenerationConfig.md#minp) - Minimum-probability threshold applied after softmax: tokens whose probability is below `minP * max_prob` are excluded from sampling. Range `[0, 1]`. Default `0` disables the filter. Stacks with `topp` when both are set.
+
+  - [`repetitionPenalty`](../../06-api-reference/interfaces/GenerationConfig.md#repetitionpenalty) - Multiplicative penalty applied to logits of tokens that already appeared in the prompt or the generated text. Values greater than `1` discourage repetition; default `1` disables the penalty.
+
+:::info[Built-in models ship with sampling defaults]
+Model presets expose an optional `generationConfig` that `LLMModule.fromModelName` applies automatically when available — for Qwen3 and LFM2-VL this means the model-card recommended sampling settings are in effect without any explicit `configure` call. Any fields you pass to `configure` still override on a per-field basis.
+:::
 
 ## Vision-Language Models (VLM)
 

--- a/docs/docs/04-typescript-api/01-natural-language-processing/LLMModule.md
+++ b/docs/docs/04-typescript-api/01-natural-language-processing/LLMModule.md
@@ -122,10 +122,10 @@ Model presets expose an optional `generationConfig` that `LLMModule.fromModelNam
 Some models support multimodal input — text and images together. To use them, pass `capabilities` in the model object when calling [`fromModelName`](../../06-api-reference/classes/LLMModule.md#frommodelname):
 
 ```typescript
-import { LLMModule, LFM2_VL_1_6B_QUANTIZED } from 'react-native-executorch';
+import { LLMModule, LFM2_5_VL_1_6B_QUANTIZED } from 'react-native-executorch';
 
 const llm = await LLMModule.fromModelName(
-  LFM2_VL_1_6B_QUANTIZED,
+  LFM2_5_VL_1_6B_QUANTIZED,
   undefined,
   (token) => console.log(token)
 );

--- a/docs/versioned_docs/version-0.8.x/03-hooks/01-natural-language-processing/useLLM.md
+++ b/docs/versioned_docs/version-0.8.x/03-hooks/01-natural-language-processing/useLLM.md
@@ -501,9 +501,9 @@ Some models support multimodal input — text and images together. To use them, 
 ### Loading a VLM
 
 ```tsx
-import { useLLM, LFM2_VL_1_6B_QUANTIZED } from 'react-native-executorch';
+import { useLLM, LFM2_5_VL_1_6B_QUANTIZED } from 'react-native-executorch';
 
-const llm = useLLM({ model: LFM2_VL_1_6B_QUANTIZED });
+const llm = useLLM({ model: LFM2_5_VL_1_6B_QUANTIZED });
 ```
 
 The `capabilities` field is already set on the model constant. You can also construct the model object explicitly:
@@ -524,7 +524,7 @@ Passing `capabilities` unlocks the typed `media` argument on `sendMessage`.
 ### Sending a message with an image
 
 ```tsx
-const llm = useLLM({ model: LFM2_VL_1_6B_QUANTIZED });
+const llm = useLLM({ model: LFM2_5_VL_1_6B_QUANTIZED });
 
 const send = () => {
   llm.sendMessage('What is in this image?', {
@@ -547,7 +547,7 @@ The `imagePath` should be a local file path on the device.
 You can also use `generate` directly by setting `mediaPath` on user messages:
 
 ```tsx
-const llm = useLLM({ model: LFM2_VL_1_6B_QUANTIZED });
+const llm = useLLM({ model: LFM2_5_VL_1_6B_QUANTIZED });
 
 const handleGenerate = async () => {
   const chat: Message[] = [

--- a/docs/versioned_docs/version-0.8.x/03-hooks/01-natural-language-processing/useLLM.md
+++ b/docs/versioned_docs/version-0.8.x/03-hooks/01-natural-language-processing/useLLM.md
@@ -211,9 +211,9 @@ To configure model (i.e. change system prompt, load initial conversation history
 
   - [`temperature`](../../06-api-reference/interfaces/GenerationConfig.md#temperature) - Scales output logits by the inverse of temperature. Controls the randomness / creativity of text generation.
 
-  - [`topp`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topp. Range `[0, 1]`. Values of `0` or `1` disable top-p filtering.
+  - [`topP`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topP. Range `[0, 1]`. Values of `0` or `1` disable top-p filtering.
 
-  - [`minP`](../../06-api-reference/interfaces/GenerationConfig.md#minp) - Minimum-probability threshold applied after softmax: tokens whose probability is below `minP * max_prob` are excluded from sampling. Range `[0, 1]`. Default `0` disables the filter. Stacks with `topp` when both are set.
+  - [`minP`](../../06-api-reference/interfaces/GenerationConfig.md#minp) - Minimum-probability threshold applied after softmax: tokens whose probability is below `minP * max_prob` are excluded from sampling. Range `[0, 1]`. Default `0` disables the filter. Stacks with `topP` when both are set.
 
   - [`repetitionPenalty`](../../06-api-reference/interfaces/GenerationConfig.md#repetitionpenalty) - Multiplicative penalty applied to logits of tokens that already appeared in the prompt or the generated text. Values greater than `1` discourage repetition; default `1` disables the penalty.
 
@@ -290,7 +290,7 @@ useEffect(() => {
       outputTokenBatchSize: 15,
       batchTimeInterval: 100,
       temperature: 0.7,
-      topp: 0.9,
+      topP: 0.9,
       minP: 0.05,
       repetitionPenalty: 1.05,
     },

--- a/docs/versioned_docs/version-0.8.x/03-hooks/01-natural-language-processing/useLLM.md
+++ b/docs/versioned_docs/version-0.8.x/03-hooks/01-natural-language-processing/useLLM.md
@@ -211,7 +211,15 @@ To configure model (i.e. change system prompt, load initial conversation history
 
   - [`temperature`](../../06-api-reference/interfaces/GenerationConfig.md#temperature) - Scales output logits by the inverse of temperature. Controls the randomness / creativity of text generation.
 
-  - [`topp`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topp.
+  - [`topp`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topp. Range `[0, 1]`. Values of `0` or `1` disable top-p filtering.
+
+  - [`minP`](../../06-api-reference/interfaces/GenerationConfig.md#minp) - Minimum-probability threshold applied after softmax: tokens whose probability is below `minP * max_prob` are excluded from sampling. Range `[0, 1]`. Default `0` disables the filter. Stacks with `topp` when both are set.
+
+  - [`repetitionPenalty`](../../06-api-reference/interfaces/GenerationConfig.md#repetitionpenalty) - Multiplicative penalty applied to logits of tokens that already appeared in the prompt or the generated text. Values greater than `1` discourage repetition; default `1` disables the penalty.
+
+:::info[Built-in models ship with sampling defaults]
+Model presets expose an optional [`generationConfig`](../../06-api-reference/interfaces/LLMProps.md) on the `model` prop. Whenever the upstream model card publishes recommended values (currently Qwen3 and LFM2-VL) the preset carries them and `useLLM` applies them automatically before `isReady` flips — you don't need to call `configure` just to get sensible defaults. Any fields you then pass to `configure` still override on a per-field basis.
+:::
 
 ### Model configuration example
 
@@ -283,6 +291,8 @@ useEffect(() => {
       batchTimeInterval: 100,
       temperature: 0.7,
       topp: 0.9,
+      minP: 0.05,
+      repetitionPenalty: 1.05,
     },
   });
 }, [configure]);

--- a/docs/versioned_docs/version-0.8.x/03-hooks/01-natural-language-processing/useLLM.md
+++ b/docs/versioned_docs/version-0.8.x/03-hooks/01-natural-language-processing/useLLM.md
@@ -211,15 +211,7 @@ To configure model (i.e. change system prompt, load initial conversation history
 
   - [`temperature`](../../06-api-reference/interfaces/GenerationConfig.md#temperature) - Scales output logits by the inverse of temperature. Controls the randomness / creativity of text generation.
 
-  - [`topP`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topP. Range `[0, 1]`. Values of `0` or `1` disable top-p filtering.
-
-  - [`minP`](../../06-api-reference/interfaces/GenerationConfig.md#minp) - Minimum-probability threshold applied after softmax: tokens whose probability is below `minP * max_prob` are excluded from sampling. Range `[0, 1]`. Default `0` disables the filter. Stacks with `topP` when both are set.
-
-  - [`repetitionPenalty`](../../06-api-reference/interfaces/GenerationConfig.md#repetitionpenalty) - Multiplicative penalty applied to logits of tokens that already appeared in the prompt or the generated text. Values greater than `1` discourage repetition; default `1` disables the penalty.
-
-:::info[Built-in models ship with sampling defaults]
-Model presets expose an optional [`generationConfig`](../../06-api-reference/interfaces/LLMProps.md) on the `model` prop. Whenever the upstream model card publishes recommended values (currently Qwen3 and LFM2-VL) the preset carries them and `useLLM` applies them automatically before `isReady` flips — you don't need to call `configure` just to get sensible defaults. Any fields you then pass to `configure` still override on a per-field basis.
-:::
+  - [`topp`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topp.
 
 ### Model configuration example
 
@@ -290,9 +282,7 @@ useEffect(() => {
       outputTokenBatchSize: 15,
       batchTimeInterval: 100,
       temperature: 0.7,
-      topP: 0.9,
-      minP: 0.05,
-      repetitionPenalty: 1.05,
+      topp: 0.9,
     },
   });
 }, [configure]);
@@ -501,9 +491,9 @@ Some models support multimodal input — text and images together. To use them, 
 ### Loading a VLM
 
 ```tsx
-import { useLLM, LFM2_5_VL_1_6B_QUANTIZED } from 'react-native-executorch';
+import { useLLM, LFM2_VL_1_6B_QUANTIZED } from 'react-native-executorch';
 
-const llm = useLLM({ model: LFM2_5_VL_1_6B_QUANTIZED });
+const llm = useLLM({ model: LFM2_VL_1_6B_QUANTIZED });
 ```
 
 The `capabilities` field is already set on the model constant. You can also construct the model object explicitly:
@@ -524,7 +514,7 @@ Passing `capabilities` unlocks the typed `media` argument on `sendMessage`.
 ### Sending a message with an image
 
 ```tsx
-const llm = useLLM({ model: LFM2_5_VL_1_6B_QUANTIZED });
+const llm = useLLM({ model: LFM2_VL_1_6B_QUANTIZED });
 
 const send = () => {
   llm.sendMessage('What is in this image?', {
@@ -547,7 +537,7 @@ The `imagePath` should be a local file path on the device.
 You can also use `generate` directly by setting `mediaPath` on user messages:
 
 ```tsx
-const llm = useLLM({ model: LFM2_5_VL_1_6B_QUANTIZED });
+const llm = useLLM({ model: LFM2_VL_1_6B_QUANTIZED });
 
 const handleGenerate = async () => {
   const chat: Message[] = [

--- a/docs/versioned_docs/version-0.8.x/04-typescript-api/01-natural-language-processing/LLMModule.md
+++ b/docs/versioned_docs/version-0.8.x/04-typescript-api/01-natural-language-processing/LLMModule.md
@@ -107,9 +107,9 @@ To configure model (i.e. change system prompt, load initial conversation history
 
   - [`temperature`](../../06-api-reference/interfaces/GenerationConfig.md#temperature) - Scales output logits by the inverse of temperature. Controls the randomness / creativity of text generation.
 
-  - [`topp`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topp. Range `[0, 1]`. Values of `0` or `1` disable top-p filtering.
+  - [`topP`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topP. Range `[0, 1]`. Values of `0` or `1` disable top-p filtering.
 
-  - [`minP`](../../06-api-reference/interfaces/GenerationConfig.md#minp) - Minimum-probability threshold applied after softmax: tokens whose probability is below `minP * max_prob` are excluded from sampling. Range `[0, 1]`. Default `0` disables the filter. Stacks with `topp` when both are set.
+  - [`minP`](../../06-api-reference/interfaces/GenerationConfig.md#minp) - Minimum-probability threshold applied after softmax: tokens whose probability is below `minP * max_prob` are excluded from sampling. Range `[0, 1]`. Default `0` disables the filter. Stacks with `topP` when both are set.
 
   - [`repetitionPenalty`](../../06-api-reference/interfaces/GenerationConfig.md#repetitionpenalty) - Multiplicative penalty applied to logits of tokens that already appeared in the prompt or the generated text. Values greater than `1` discourage repetition; default `1` disables the penalty.
 

--- a/docs/versioned_docs/version-0.8.x/04-typescript-api/01-natural-language-processing/LLMModule.md
+++ b/docs/versioned_docs/version-0.8.x/04-typescript-api/01-natural-language-processing/LLMModule.md
@@ -107,25 +107,17 @@ To configure model (i.e. change system prompt, load initial conversation history
 
   - [`temperature`](../../06-api-reference/interfaces/GenerationConfig.md#temperature) - Scales output logits by the inverse of temperature. Controls the randomness / creativity of text generation.
 
-  - [`topP`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topP. Range `[0, 1]`. Values of `0` or `1` disable top-p filtering.
-
-  - [`minP`](../../06-api-reference/interfaces/GenerationConfig.md#minp) - Minimum-probability threshold applied after softmax: tokens whose probability is below `minP * max_prob` are excluded from sampling. Range `[0, 1]`. Default `0` disables the filter. Stacks with `topP` when both are set.
-
-  - [`repetitionPenalty`](../../06-api-reference/interfaces/GenerationConfig.md#repetitionpenalty) - Multiplicative penalty applied to logits of tokens that already appeared in the prompt or the generated text. Values greater than `1` discourage repetition; default `1` disables the penalty.
-
-:::info[Built-in models ship with sampling defaults]
-Model presets expose an optional `generationConfig` that `LLMModule.fromModelName` applies automatically when available — for Qwen3 and LFM2-VL this means the model-card recommended sampling settings are in effect without any explicit `configure` call. Any fields you pass to `configure` still override on a per-field basis.
-:::
+  - [`topp`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topp.
 
 ## Vision-Language Models (VLM)
 
 Some models support multimodal input — text and images together. To use them, pass `capabilities` in the model object when calling [`fromModelName`](../../06-api-reference/classes/LLMModule.md#frommodelname):
 
 ```typescript
-import { LLMModule, LFM2_5_VL_1_6B_QUANTIZED } from 'react-native-executorch';
+import { LLMModule, LFM2_VL_1_6B_QUANTIZED } from 'react-native-executorch';
 
 const llm = await LLMModule.fromModelName(
-  LFM2_5_VL_1_6B_QUANTIZED,
+  LFM2_VL_1_6B_QUANTIZED,
   undefined,
   (token) => console.log(token)
 );

--- a/docs/versioned_docs/version-0.8.x/04-typescript-api/01-natural-language-processing/LLMModule.md
+++ b/docs/versioned_docs/version-0.8.x/04-typescript-api/01-natural-language-processing/LLMModule.md
@@ -107,7 +107,15 @@ To configure model (i.e. change system prompt, load initial conversation history
 
   - [`temperature`](../../06-api-reference/interfaces/GenerationConfig.md#temperature) - Scales output logits by the inverse of temperature. Controls the randomness / creativity of text generation.
 
-  - [`topp`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topp.
+  - [`topp`](../../06-api-reference/interfaces/GenerationConfig.md#topp) - Only samples from the smallest set of tokens whose cumulative probability exceeds topp. Range `[0, 1]`. Values of `0` or `1` disable top-p filtering.
+
+  - [`minP`](../../06-api-reference/interfaces/GenerationConfig.md#minp) - Minimum-probability threshold applied after softmax: tokens whose probability is below `minP * max_prob` are excluded from sampling. Range `[0, 1]`. Default `0` disables the filter. Stacks with `topp` when both are set.
+
+  - [`repetitionPenalty`](../../06-api-reference/interfaces/GenerationConfig.md#repetitionpenalty) - Multiplicative penalty applied to logits of tokens that already appeared in the prompt or the generated text. Values greater than `1` discourage repetition; default `1` disables the penalty.
+
+:::info[Built-in models ship with sampling defaults]
+Model presets expose an optional `generationConfig` that `LLMModule.fromModelName` applies automatically when available — for Qwen3 and LFM2-VL this means the model-card recommended sampling settings are in effect without any explicit `configure` call. Any fields you pass to `configure` still override on a per-field basis.
+:::
 
 ## Vision-Language Models (VLM)
 

--- a/docs/versioned_docs/version-0.8.x/04-typescript-api/01-natural-language-processing/LLMModule.md
+++ b/docs/versioned_docs/version-0.8.x/04-typescript-api/01-natural-language-processing/LLMModule.md
@@ -122,10 +122,10 @@ Model presets expose an optional `generationConfig` that `LLMModule.fromModelNam
 Some models support multimodal input — text and images together. To use them, pass `capabilities` in the model object when calling [`fromModelName`](../../06-api-reference/classes/LLMModule.md#frommodelname):
 
 ```typescript
-import { LLMModule, LFM2_VL_1_6B_QUANTIZED } from 'react-native-executorch';
+import { LLMModule, LFM2_5_VL_1_6B_QUANTIZED } from 'react-native-executorch';
 
 const llm = await LLMModule.fromModelName(
-  LFM2_VL_1_6B_QUANTIZED,
+  LFM2_5_VL_1_6B_QUANTIZED,
   undefined,
   (token) => console.log(token)
 );

--- a/packages/react-native-executorch/common/rnexecutorch/host_objects/ModelHostObject.h
+++ b/packages/react-native-executorch/common/rnexecutorch/host_objects/ModelHostObject.h
@@ -140,6 +140,15 @@ public:
                                        synchronousHostFunction<&Model::setTopp>,
                                        "setTopp"));
 
+      addFunctions(JSI_EXPORT_FUNCTION(ModelHostObject<Model>,
+                                       synchronousHostFunction<&Model::setMinP>,
+                                       "setMinP"));
+
+      addFunctions(JSI_EXPORT_FUNCTION(
+          ModelHostObject<Model>,
+          synchronousHostFunction<&Model::setRepetitionPenalty>,
+          "setRepetitionPenalty"));
+
       addFunctions(JSI_EXPORT_FUNCTION(
           ModelHostObject<Model>,
           synchronousHostFunction<&Model::getMaxContextLength>,

--- a/packages/react-native-executorch/common/rnexecutorch/models/llm/LLM.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/llm/LLM.cpp
@@ -250,6 +250,30 @@ void LLM::setTopp(float topp) {
   runner_->set_topp(topp);
 }
 
+void LLM::setMinP(float minP) {
+  if (!runner_ || !runner_->is_loaded()) {
+    throw RnExecutorchError(RnExecutorchErrorCode::ModuleNotLoaded,
+                            "Can't configure a model that's not loaded");
+  }
+  if (minP < 0.0f || minP > 1.0f) {
+    throw RnExecutorchError(RnExecutorchErrorCode::InvalidConfig,
+                            "Min-p must be between 0.0 and 1.0");
+  }
+  runner_->set_min_p(minP);
+}
+
+void LLM::setRepetitionPenalty(float repetitionPenalty) {
+  if (!runner_ || !runner_->is_loaded()) {
+    throw RnExecutorchError(RnExecutorchErrorCode::ModuleNotLoaded,
+                            "Can't configure a model that's not loaded");
+  }
+  if (repetitionPenalty < 0.0f) {
+    throw RnExecutorchError(RnExecutorchErrorCode::InvalidConfig,
+                            "Repetition penalty must be non-negative");
+  }
+  runner_->set_repetition_penalty(repetitionPenalty);
+}
+
 int32_t LLM::getMaxContextLength() const {
   if (!runner_ || !runner_->is_loaded()) {
     throw RnExecutorchError(

--- a/packages/react-native-executorch/common/rnexecutorch/models/llm/LLM.h
+++ b/packages/react-native-executorch/common/rnexecutorch/models/llm/LLM.h
@@ -38,6 +38,8 @@ public:
   void setCountInterval(size_t countInterval);
   void setTemperature(float temperature);
   void setTopp(float topp);
+  void setMinP(float minP);
+  void setRepetitionPenalty(float repetitionPenalty);
   void setTimeInterval(size_t timeInterval);
   int32_t getMaxContextLength() const;
 

--- a/packages/react-native-executorch/common/rnexecutorch/tests/CMakeLists.txt
+++ b/packages/react-native-executorch/common/rnexecutorch/tests/CMakeLists.txt
@@ -151,6 +151,12 @@ add_rn_test(RunnerTests unit/RunnerTest.cpp
         integration/stubs/jsi_stubs.cpp
     LIBS tokenizers_deps
 )
+add_rn_test(SamplerTests unit/SamplerTest.cpp
+    SOURCES
+        ${COMMON_DIR}/runner/sampler.cpp
+        ${COMMON_DIR}/runner/arange_util.cpp
+    LIBS
+)
 add_rn_test(LogTests unit/LogTest.cpp)
 add_rn_test(FileUtilsTest unit/FileUtilsTest.cpp)
 add_rn_test(ImageProcessingTest unit/ImageProcessingTest.cpp

--- a/packages/react-native-executorch/common/rnexecutorch/tests/integration/LLMTest.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/tests/integration/LLMTest.cpp
@@ -110,6 +110,31 @@ TEST_F(LLMTest, SetToppInvalidThrows) {
   EXPECT_THROW(model.setTopp(1.1f), RnExecutorchError);
 }
 
+TEST_F(LLMTest, SetMinP) {
+  LLM model(kValidModelPath, kValidTokenizerPath, {}, mockInvoker_);
+  EXPECT_NO_THROW(model.setMinP(0.0f));
+  EXPECT_NO_THROW(model.setMinP(0.15f));
+  EXPECT_NO_THROW(model.setMinP(1.0f));
+}
+
+TEST_F(LLMTest, SetMinPInvalidThrows) {
+  LLM model(kValidModelPath, kValidTokenizerPath, {}, mockInvoker_);
+  EXPECT_THROW(model.setMinP(-0.1f), RnExecutorchError);
+  EXPECT_THROW(model.setMinP(1.1f), RnExecutorchError);
+}
+
+TEST_F(LLMTest, SetRepetitionPenalty) {
+  LLM model(kValidModelPath, kValidTokenizerPath, {}, mockInvoker_);
+  EXPECT_NO_THROW(model.setRepetitionPenalty(1.0f));
+  EXPECT_NO_THROW(model.setRepetitionPenalty(1.05f));
+  EXPECT_NO_THROW(model.setRepetitionPenalty(2.0f));
+}
+
+TEST_F(LLMTest, SetRepetitionPenaltyInvalidThrows) {
+  LLM model(kValidModelPath, kValidTokenizerPath, {}, mockInvoker_);
+  EXPECT_THROW(model.setRepetitionPenalty(-0.1f), RnExecutorchError);
+}
+
 TEST_F(LLMTest, SetCountInterval) {
   LLM model(kValidModelPath, kValidTokenizerPath, {}, mockInvoker_);
   EXPECT_NO_THROW(model.setCountInterval(5));

--- a/packages/react-native-executorch/common/rnexecutorch/tests/integration/stubs/StubRunner.h
+++ b/packages/react-native-executorch/common/rnexecutorch/tests/integration/stubs/StubRunner.h
@@ -18,10 +18,6 @@ public:
     return ::executorch::runtime::Error::Ok;
   }
   void stop_impl() override {}
-  void set_temperature_impl(float t) override { last_temp_ = t; }
-  void set_topp_impl(float) override {}
-  void set_count_interval_impl(size_t) override {}
-  void set_time_interval_impl(size_t) override {}
 
   int32_t resolve_max(int32_t prompt, int32_t seq_len, int32_t ctx_len,
                       int32_t max_new = -1) const {
@@ -29,5 +25,4 @@ public:
   }
 
   bool loaded_ = false;
-  float last_temp_ = -1.f;
 };

--- a/packages/react-native-executorch/common/rnexecutorch/tests/unit/RunnerTest.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/tests/unit/RunnerTest.cpp
@@ -62,11 +62,10 @@ TEST(MultimodalInputTest, EmptyStringIsStillText) {
 // BaseLLMRunner via StubRunner
 // ============================================================================
 
-TEST(BaseLLMRunnerTest, SetTemperatureUpdatesConfigAndCallsImpl) {
+TEST(BaseLLMRunnerTest, SetTemperatureUpdatesConfig) {
   StubRunner runner(nullptr, "dummy");
   runner.set_temperature(0.42f);
   EXPECT_FLOAT_EQ(runner.config_.temperature, 0.42f);
-  EXPECT_FLOAT_EQ(runner.last_temp_, 0.42f);
 }
 
 TEST(BaseLLMRunnerTest, SetToppUpdatesConfig) {
@@ -88,4 +87,16 @@ TEST(BaseLLMRunnerTest, GenerateEmptyStringReturnsError) {
   StubRunner runner(nullptr, "dummy");
   auto err = runner.generate("", {}, {}, {});
   EXPECT_NE(err, ::executorch::runtime::Error::Ok);
+}
+
+TEST(BaseLLMRunnerTest, SetMinPUpdatesConfig) {
+  StubRunner runner(nullptr, "dummy");
+  runner.set_min_p(0.15f);
+  EXPECT_FLOAT_EQ(runner.config_.min_p, 0.15f);
+}
+
+TEST(BaseLLMRunnerTest, SetRepetitionPenaltyUpdatesConfig) {
+  StubRunner runner(nullptr, "dummy");
+  runner.set_repetition_penalty(1.05f);
+  EXPECT_FLOAT_EQ(runner.config_.repetition_penalty, 1.05f);
 }

--- a/packages/react-native-executorch/common/rnexecutorch/tests/unit/SamplerTest.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/tests/unit/SamplerTest.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <runner/sampler.h>
+#include <vector>
+
+using namespace executorch::extension::llm;
+
+// Helper: run sampler N times, count how often each index is picked.
+template <typename T>
+std::vector<int> sampleMany(Sampler &s, std::vector<T> logits,
+                            const std::vector<uint64_t> &recent, int n) {
+  std::vector<int> counts(logits.size(), 0);
+  for (int i = 0; i < n; ++i) {
+    std::vector<T> copy = logits;
+    counts[s.sample(copy.data(), recent)]++;
+  }
+  return counts;
+}
+
+// 1. Repetition penalty on positive logit: token 0 should be sampled less.
+TEST(SamplerTest, RepetitionPenaltyReducesPositiveLogit) {
+  Sampler s(2, 1.0f, 1.0f, 0, 0.0f, 1.3f);
+  std::vector<float> logits = {1.0f, 1.0f};
+  std::vector<uint64_t> recent = {0};
+  auto counts = sampleMany(s, logits, recent, 2000);
+  EXPECT_LT(counts[0], 1200);
+}
+
+// 2. Repetition penalty on negative logit: penalised token should appear even
+// less.
+TEST(SamplerTest, RepetitionPenaltyMultipliesNegativeLogit) {
+  Sampler s(2, 1.0f, 1.0f, 0, 0.0f, 1.5f);
+  std::vector<float> logits = {0.0f, -1.0f};
+  std::vector<uint64_t> recent = {1};
+  auto counts = sampleMany(s, logits, recent, 2000);
+  EXPECT_LT(counts[1], 200);
+}
+
+// 3. No recent tokens — penalty has no effect.
+TEST(SamplerTest, RepetitionPenaltyNoRecentTokensHasNoEffect) {
+  Sampler baseline(2, 1.0f, 1.0f, 0, 0.0f, 1.0f);
+  Sampler penalised(2, 1.0f, 1.0f, 0, 0.0f, 2.0f);
+  std::vector<float> logits_b = {1.0f, 1.0f};
+  std::vector<float> logits_p = {1.0f, 1.0f};
+  std::vector<uint64_t> recent = {};
+  auto cb = sampleMany(baseline, logits_b, recent, 2000);
+  auto cp = sampleMany(penalised, logits_p, recent, 2000);
+  EXPECT_NEAR(cb[0], cp[0], 300);
+}
+
+// 4. Min-p truncation: token with very low probability is excluded.
+TEST(SamplerTest, MinPFiltersTailTokens) {
+  Sampler s(3, 1.0f, 1.0f, 0, 0.1f, 1.0f);
+  std::vector<float> logits = {5.0f, -5.0f, -5.0f};
+  std::vector<uint64_t> recent = {};
+  auto counts = sampleMany(s, logits, recent, 1000);
+  EXPECT_EQ(counts[1], 0);
+  EXPECT_EQ(counts[2], 0);
+  EXPECT_EQ(counts[0], 1000);
+}
+
+// 5. Min-p = 0 disables filtering.
+TEST(SamplerTest, MinPZeroDisablesFiltering) {
+  Sampler s(3, 0.0f, 1.0f, 0, 0.0f, 1.0f);
+  std::vector<float> logits = {1.0f, -1000.0f, -1000.0f};
+  std::vector<uint64_t> recent = {};
+  EXPECT_EQ(s.sample(logits.data(), recent), 0);
+}
+
+// 6. Min-p + top-p stacked.
+TEST(SamplerTest, MinPAndToppStack) {
+  Sampler s(4, 1.0f, 0.5f, 0, 0.2f, 1.0f);
+  std::vector<float> logits = {5.0f, 2.0f, -2.0f, -5.0f};
+  std::vector<uint64_t> recent = {};
+  auto counts = sampleMany(s, logits, recent, 2000);
+  EXPECT_EQ(counts[2], 0);
+  EXPECT_EQ(counts[3], 0);
+}

--- a/packages/react-native-executorch/common/runner/base_llm_runner.cpp
+++ b/packages/react-native-executorch/common/runner/base_llm_runner.cpp
@@ -139,20 +139,22 @@ int32_t BaseLLMRunner::get_max_context_length() const {
 
 void BaseLLMRunner::set_temperature(float temperature) noexcept {
   config_.temperature = temperature;
-  set_temperature_impl(temperature);
 }
 
-void BaseLLMRunner::set_topp(float topp) noexcept {
-  config_.topp = topp;
-  set_topp_impl(topp);
+void BaseLLMRunner::set_topp(float topp) noexcept { config_.topp = topp; }
+
+void BaseLLMRunner::set_min_p(float min_p) noexcept { config_.min_p = min_p; }
+
+void BaseLLMRunner::set_repetition_penalty(float repetition_penalty) noexcept {
+  config_.repetition_penalty = repetition_penalty;
 }
 
 void BaseLLMRunner::set_count_interval(size_t count_interval) {
-  set_count_interval_impl(count_interval);
+  config_.output_token_batch_size = count_interval;
 }
 
 void BaseLLMRunner::set_time_interval(size_t time_interval) {
-  set_time_interval_impl(time_interval);
+  config_.batch_time_interval_ms = time_interval;
 }
 
 int32_t BaseLLMRunner::resolve_max_new_tokens(int32_t num_prompt_tokens,

--- a/packages/react-native-executorch/common/runner/base_llm_runner.h
+++ b/packages/react-native-executorch/common/runner/base_llm_runner.h
@@ -53,6 +53,8 @@ public:
 
   void set_temperature(float temperature) noexcept;
   void set_topp(float topp) noexcept;
+  void set_min_p(float min_p) noexcept;
+  void set_repetition_penalty(float repetition_penalty) noexcept;
   void set_count_interval(size_t count_interval);
   void set_time_interval(size_t time_interval);
 
@@ -65,10 +67,12 @@ public:
 protected:
   virtual ::executorch::runtime::Error load_subcomponents() = 0;
   virtual void stop_impl() = 0;
-  virtual void set_temperature_impl(float temperature) = 0;
-  virtual void set_topp_impl(float topp) = 0;
-  virtual void set_count_interval_impl(size_t count_interval) = 0;
-  virtual void set_time_interval_impl(size_t time_interval) = 0;
+  // Sampling values and token-batching intervals live entirely in `config_`.
+  // The TextDecoderRunner / TextTokenGenerator shared by both TextRunner and
+  // MultimodalRunner are constructed with a const reference to `config_`
+  // and read those fields on every iteration, so writes via the public
+  // set_* methods on BaseLLMRunner take effect immediately with no virtual
+  // dispatch needed.
 
   int32_t resolve_max_new_tokens(int32_t num_prompt_tokens, int32_t max_seq_len,
                                  int32_t max_context_len,

--- a/packages/react-native-executorch/common/runner/encoders/vision_encoder.cpp
+++ b/packages/react-native-executorch/common/runner/encoders/vision_encoder.cpp
@@ -77,15 +77,23 @@ Result<VisionEncoder::ImageShape> VisionEncoder::getInputShape() const {
 std::vector<float>
 VisionEncoder::preprocessImage(const std::string &path,
                                const ImageShape &targetShape) const {
-  cv::Mat mat = rnexecutorch::image_processing::readImage(path);
-  cv::resize(mat, mat, cv::Size(targetShape.width, targetShape.height));
-  cv::cvtColor(mat, mat, cv::COLOR_BGR2RGB);
+  // The bundled vision-encoder PTEs (e.g. LFM2-VL) bake rescale + normalize
+  // into the exported graph, so we hand raw 0-255 float pixel values to the
+  // module. Adding rescale / normalize here would double-apply the transform
+  // and destroy the input distribution. We reuse `resizePadded` for the
+  // aspect-ratio-preserving letterbox (it picks the pad colour from the
+  // source image corners, which blends better than a flat gray), then
+  // convert BGR->RGB and repack the raw pixels into CHW float.
+  cv::Mat src = rnexecutorch::image_processing::readImage(path);
+  cv::Mat canvas = rnexecutorch::image_processing::resizePadded(
+      src, cv::Size(targetShape.width, targetShape.height));
+  cv::cvtColor(canvas, canvas, cv::COLOR_BGR2RGB);
 
   const int32_t pixelCount = targetShape.height * targetShape.width;
   std::vector<float> chw(targetShape.channels * pixelCount);
   for (int32_t i = 0; i < pixelCount; ++i) {
     cv::Vec3b px =
-        mat.at<cv::Vec3b>(i / targetShape.width, i % targetShape.width);
+        canvas.at<cv::Vec3b>(i / targetShape.width, i % targetShape.width);
     for (int32_t c = 0; c < targetShape.channels; ++c) {
       chw[c * pixelCount + i] = static_cast<float>(px[c]);
     }

--- a/packages/react-native-executorch/common/runner/encoders/vision_encoder.cpp
+++ b/packages/react-native-executorch/common/runner/encoders/vision_encoder.cpp
@@ -77,7 +77,7 @@ Result<VisionEncoder::ImageShape> VisionEncoder::getInputShape() const {
 std::vector<float>
 VisionEncoder::preprocessImage(const std::string &path,
                                const ImageShape &targetShape) const {
-  // The bundled vision-encoder PTEs (e.g. LFM2-VL) bake rescale + normalize
+  // The bundled vision-encoder PTEs (e.g. LFM2.5-VL) bake rescale + normalize
   // into the exported graph, so we hand raw 0-255 float pixel values to the
   // module. Adding rescale / normalize here would double-apply the transform
   // and destroy the input distribution. We reuse `resizePadded` for the

--- a/packages/react-native-executorch/common/runner/irunner.h
+++ b/packages/react-native-executorch/common/runner/irunner.h
@@ -58,6 +58,21 @@ struct GenerationConfig {
   // = more deterministic, higher = more diverse generations.
   float topp = -1.F;
 
+  // Minimum probability threshold: tokens with prob < min_p * max_prob are
+  // excluded. 0.0 disables min_p filtering.
+  float min_p = 0.0f;
+
+  // Multiplicative penalty applied to logits of recently generated tokens.
+  // Values > 1.0 discourage repetition. 1.0 disables the penalty.
+  float repetition_penalty = 1.0f;
+
+  // Token-batching parameters for the streaming token callback. The
+  // generator flushes a batch when either `output_token_batch_size` tokens
+  // have accumulated or `batch_time_interval_ms` milliseconds have elapsed
+  // since the last flush, whichever comes first.
+  size_t output_token_batch_size = 10;
+  size_t batch_time_interval_ms = 120;
+
   // Enable dynamic input shapes (if implemented) or not
   // Impacts the prefill phase and causes TextPrefiller to pass all the tokens
   // at once if set to true.

--- a/packages/react-native-executorch/common/runner/multimodal_decoder_runner.h
+++ b/packages/react-native-executorch/common/runner/multimodal_decoder_runner.h
@@ -16,8 +16,9 @@
 namespace executorch::extension::llm {
 class MultimodalDecoderRunner : public TextDecoderRunner {
 public:
-  explicit MultimodalDecoderRunner(Module &module, IOManager *io_manager)
-      : TextDecoderRunner(module, io_manager) {}
+  explicit MultimodalDecoderRunner(Module &module, IOManager *io_manager,
+                                   const GenerationConfig &config)
+      : TextDecoderRunner(module, io_manager, config) {}
 
   inline ::executorch::runtime::Result<::executorch::aten::Tensor>
   step(TensorPtr &tokens, int64_t start_pos) override {

--- a/packages/react-native-executorch/common/runner/multimodal_runner.cpp
+++ b/packages/react-native-executorch/common/runner/multimodal_runner.cpp
@@ -47,8 +47,8 @@ Error MultimodalRunner::load_subcomponents() {
 
   Stats *stats_ptr = &stats_;
 
-  mm_decoder_runner_ =
-      std::make_unique<MultimodalDecoderRunner>(*module_, io_manager_.get());
+  mm_decoder_runner_ = std::make_unique<MultimodalDecoderRunner>(
+      *module_, io_manager_.get(), config_);
   IEncoder *image_encoder = nullptr;
   auto enc_it = encoders_.find(MultimodalType::Image);
   if (enc_it != encoders_.end()) {
@@ -58,7 +58,7 @@ Error MultimodalRunner::load_subcomponents() {
       *module_, *mm_decoder_runner_, *tokenizer_, image_encoder);
   mm_token_generator_ = std::make_unique<TextTokenGenerator>(
       tokenizer_.get(), mm_decoder_runner_.get(), /*use_kv_cache=*/true,
-      std::move(eos_ids_), stats_ptr);
+      std::move(eos_ids_), stats_ptr, config_);
 
   ET_CHECK_OK_OR_RETURN_ERROR(mm_prefiller_->load());
   ET_CHECK_OK_OR_RETURN_ERROR(mm_token_generator_->load());
@@ -106,7 +106,7 @@ Error MultimodalRunner::generate_internal(
   auto generate_result = mm_token_generator_->generate(
       seed_tokens, pos_,
       static_cast<uint64_t>(std::max(0, resolved_max_new - 1)),
-      config_.temperature, config_.topp, wrapped_callback);
+      wrapped_callback);
 
   if (!generate_result.ok())
     return generate_result.error();
@@ -122,18 +122,6 @@ Error MultimodalRunner::generate_internal(
 void MultimodalRunner::stop_impl() {
   if (mm_token_generator_) {
     mm_token_generator_->stop();
-  }
-}
-
-void MultimodalRunner::set_count_interval_impl(size_t count_interval) {
-  if (mm_token_generator_) {
-    mm_token_generator_->set_count_interval(count_interval);
-  }
-}
-
-void MultimodalRunner::set_time_interval_impl(size_t time_interval) {
-  if (mm_token_generator_) {
-    mm_token_generator_->set_time_interval(time_interval);
   }
 }
 

--- a/packages/react-native-executorch/common/runner/multimodal_runner.h
+++ b/packages/react-native-executorch/common/runner/multimodal_runner.h
@@ -30,10 +30,6 @@ public:
 protected:
   ::executorch::runtime::Error load_subcomponents() override;
   void stop_impl() override;
-  void set_temperature_impl(float) override {}
-  void set_topp_impl(float) override {}
-  void set_count_interval_impl(size_t count_interval) override;
-  void set_time_interval_impl(size_t time_interval) override;
 
 private:
   std::map<MultimodalType, std::unique_ptr<IEncoder>> encoders_;

--- a/packages/react-native-executorch/common/runner/sampler.cpp
+++ b/packages/react-native-executorch/common/runner/sampler.cpp
@@ -35,6 +35,7 @@
 #include "sampler.h"
 #include <algorithm>
 #include <ctime>
+#include <vector>
 
 namespace executorch {
 namespace extension {
@@ -119,16 +120,16 @@ int32_t Sampler::sample_topp(T *probabilities, float coin) {
   return probindex[last_idx].index; // in case of rounding errors
 }
 
-Sampler::Sampler(int vocab_size, float temperature, float topp,
-                 unsigned long long rng_seed)
+Sampler::Sampler(int32_t vocab_size, float temperature, float topp,
+                 unsigned long long rng_seed, float min_p,
+                 float repetition_penalty)
     : vocab_size_(vocab_size),
       inv_temperature_((temperature != 0.0f) ? (1.0f / temperature) : 0.0f),
-      topp_(topp), rng_state_(rng_seed) {}
+      topp_(topp), min_p_(min_p), repetition_penalty_(repetition_penalty),
+      rng_state_(rng_seed) {}
 
 Sampler::Sampler(int vocab_size, float temperature, float topp)
-    : vocab_size_(vocab_size),
-      inv_temperature_((temperature != 0.0f) ? (1.0f / temperature) : 0.0f),
-      topp_(topp), rng_state_(std::time(nullptr)) {}
+    : Sampler(vocab_size, temperature, topp, std::time(nullptr), 0.0f, 1.0f) {}
 
 template <typename T> static void softmax(T *x, int size) {
   // find max value (for numerical stability)
@@ -162,22 +163,25 @@ static float random_f32(unsigned long long *state) { // random float32 in [0,1)
   return (random_u32(state) >> 8) / 16777216.0f;
 }
 
-template <typename T> int32_t Sampler::sample(T *logits) {
+template <typename T>
+int32_t Sampler::sample(T *logits, const std::vector<uint64_t> &recent_tokens) {
   // sample the token given the logits and some hyperparameters
   int next;
   if (inv_temperature_ == 0.0f) {
     // greedy argmax sampling: take the token with the highest probability
     next = sample_argmax(logits);
   } else {
-    // apply the temperature to the logits
-    for (int q = 0; q < vocab_size_; q++) {
-      logits[q] *= inv_temperature_;
-    }
-    // apply softmax to the logits to get the probabilities for next token
+    // 1. apply repetition penalty to raw logits (pre-softmax)
+    apply_repetition_penalty(logits, vocab_size_, recent_tokens);
+    // 2. apply the temperature to the logits
+    apply_temperature(logits, vocab_size_);
+    // 3. apply softmax to the logits to get the probabilities for next token
     softmax(logits, vocab_size_);
+    // 4. apply min_p truncation
+    apply_min_p(logits, vocab_size_);
     // flip a (float) coin (this is our source of entropy for sampling)
     float coin = random_f32(&rng_state_);
-    // we sample from this distribution to get the next token
+    // 5. we sample from this distribution to get the next token
     if (topp_ <= 0 || topp_ >= 1) {
       // simply sample from the predicted probability distribution
       next = sample_mult(logits, coin);
@@ -189,12 +193,27 @@ template <typename T> int32_t Sampler::sample(T *logits) {
   return next;
 }
 
+template <typename T> int32_t Sampler::sample(T *logits) {
+  return sample(logits, {});
+}
+
 template int32_t Sampler::sample<float>(float *logits);
 template int32_t Sampler::sample<uint16_t>(uint16_t *logits);
 template int32_t
 Sampler::sample<executorch::aten::Half>(executorch::aten::Half *logits);
 template int32_t
 Sampler::sample<executorch::aten::BFloat16>(executorch::aten::BFloat16 *logits);
+
+template int32_t Sampler::sample<float>(float *logits,
+                                        const std::vector<uint64_t> &);
+template int32_t Sampler::sample<uint16_t>(uint16_t *logits,
+                                           const std::vector<uint64_t> &);
+template int32_t
+Sampler::sample<executorch::aten::Half>(executorch::aten::Half *logits,
+                                        const std::vector<uint64_t> &);
+template int32_t
+Sampler::sample<executorch::aten::BFloat16>(executorch::aten::BFloat16 *logits,
+                                            const std::vector<uint64_t> &);
 
 } // namespace llm
 } // namespace extension

--- a/packages/react-native-executorch/common/runner/sampler.h
+++ b/packages/react-native-executorch/common/runner/sampler.h
@@ -8,12 +8,15 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cctype>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <utility>
+#include <vector>
 #ifdef USE_ATEN_LIB
 #include <torch/torch.h>
 #endif
@@ -36,22 +39,77 @@ template <typename T> struct ProbIndex {
 class Sampler {
 public:
   Sampler(int32_t vocab_size, float temperature, float topp,
-          unsigned long long rng_seed);
+          unsigned long long rng_seed, float min_p = 0.0f,
+          float repetition_penalty = 1.0f);
 
   Sampler(int32_t vocab_size, float temperature, float topp);
 
   template <typename T> int32_t sample(T *logits);
+
+  template <typename T>
+  int32_t sample(T *logits, const std::vector<uint64_t> &recent_tokens);
 
 private:
   template <typename T> int32_t sample_topp(T *probabilities, float coin);
   template <typename T> int32_t sample_mult(T *probabilities, float coin);
   template <typename T> int32_t sample_argmax(T *probabilities);
 
+  template <typename T>
+  inline void apply_temperature(T *logits, int32_t vocab_size) {
+    for (std::size_t i = 0; std::cmp_less(i, vocab_size); ++i) {
+      logits[i] =
+          static_cast<T>(static_cast<float>(logits[i]) * inv_temperature_);
+    }
+  }
+
+  template <typename T>
+  inline void
+  apply_repetition_penalty(T *logits, int32_t vocab_size,
+                           const std::vector<uint64_t> &recent_tokens) {
+    if (repetition_penalty_ == 1.0f || recent_tokens.empty())
+      return;
+    for (uint64_t id : recent_tokens) {
+      if (!std::cmp_less(id, vocab_size)) {
+        continue;
+      }
+      T &val = logits[id];
+      if (val > T(0)) {
+        val = static_cast<T>(static_cast<float>(val) / repetition_penalty_);
+      } else {
+        val = static_cast<T>(static_cast<float>(val) * repetition_penalty_);
+      }
+    }
+  }
+
+  template <typename T>
+  inline void apply_min_p(T *probabilities, int32_t vocab_size) {
+    if (min_p_ <= 0.0f) {
+      return;
+    }
+    T max_prob = *std::max_element(probabilities, probabilities + vocab_size);
+    T threshold = static_cast<T>(min_p_ * static_cast<float>(max_prob));
+    T sum = T(0);
+    for (std::size_t i = 0; std::cmp_less(i, vocab_size); ++i) {
+      if (probabilities[i] < threshold) {
+        probabilities[i] = T(0);
+      } else {
+        sum += probabilities[i];
+      }
+    }
+    if (sum > T(0)) {
+      for (std::size_t i = 0; std::cmp_less(i, vocab_size); ++i) {
+        probabilities[i] /= sum;
+      }
+    }
+  }
+
 private:
   int32_t vocab_size_;
   // reciprocal of temperature, or 0 if temperature == 0.
   float inv_temperature_;
   float topp_;
+  float min_p_;
+  float repetition_penalty_;
   unsigned long long rng_state_;
 };
 

--- a/packages/react-native-executorch/common/runner/text_decoder_runner.cpp
+++ b/packages/react-native-executorch/common/runner/text_decoder_runner.cpp
@@ -10,6 +10,7 @@
 
 #include "text_decoder_runner.h"
 #include "arange_util.h"
+#include "irunner.h"
 #include "stats.h"
 
 #include <ctime>
@@ -22,9 +23,8 @@ namespace llm {
 // and a ~5% improvement on Galaxy S22 by switching to
 // FileDataLoader instead of MmapDataLoader + UseMlockIgnoreErrors.
 TextDecoderRunner::TextDecoderRunner(Module &module, IOManager *io_manager,
-                                     float temperature, float topp)
-    : module_(&module), io_manager_(io_manager), temperature_(temperature),
-      topp_(topp) {}
+                                     const GenerationConfig &config)
+    : module_(&module), io_manager_(io_manager), config_(config) {}
 
 // This function is functional, meaning it shouldn't modify any state of the
 // input. It should be safe to call multiple times with the same inputs. The
@@ -80,6 +80,34 @@ TextDecoderRunner::step(TensorPtr &tokens, int64_t start_pos) {
     // Return the logits tensor
     return outputs_res.get()[0].toTensor();
   }
+}
+
+int32_t TextDecoderRunner::logits_to_token(
+    const executorch::aten::Tensor &logits_tensor,
+    const std::vector<uint64_t> &recent_tokens) {
+  int32_t result = 0;
+
+  struct {
+    [[noreturn]] void fail(torch::executor::Error) {
+      ET_CHECK_MSG(false, "Unsupported dtype in logits_to_token");
+    }
+  } ctx;
+
+  ET_SWITCH_FOUR_TYPES(
+      Float, Half, BFloat16, UInt16, logits_tensor.scalar_type(), ctx,
+      "logits_to_token", CTYPE, [&]() {
+        auto *logits = logits_tensor.mutable_data_ptr<CTYPE>();
+        ssize_t vocab_size = logits_tensor.size(logits_tensor.dim() - 1);
+        if (logits_tensor.dim() == 3) {
+          auto num_tokens = logits_tensor.size(1);
+          logits += (num_tokens - 1) * vocab_size;
+        }
+        Sampler sampler(vocab_size, config_.temperature, config_.topp,
+                        static_cast<unsigned long long>(std::time(nullptr)),
+                        config_.min_p, config_.repetition_penalty);
+        result = sampler.sample(logits, recent_tokens);
+      });
+  return result;
 }
 
 } // namespace llm

--- a/packages/react-native-executorch/common/runner/text_decoder_runner.h
+++ b/packages/react-native-executorch/common/runner/text_decoder_runner.h
@@ -17,10 +17,22 @@ namespace executorch {
 namespace extension {
 namespace llm {
 
+// Forward declaration to avoid the include chain
+// irunner.h -> stats.h -> util.h -> text_prefiller.h -> text_decoder_runner.h
+// which would re-enter this header before TextDecoderRunner is defined.
+// The full GenerationConfig definition is required at use sites in
+// logits_to_token (header-inline) and the constructor (.cpp), both of which
+// transitively include irunner.h via base_llm_runner.h.
+struct GenerationConfig;
+
 class TextDecoderRunner {
 public:
+  // The runner reads sampling parameters from `config` on every call to
+  // `logits_to_token`, so updating `config.temperature` (etc.) on the owning
+  // BaseLLMRunner takes effect immediately without any sync setter on this
+  // class.
   explicit TextDecoderRunner(Module &module, IOManager *io_manager,
-                             float temperature = 0.8F, float topp = 0.9F);
+                             const GenerationConfig &config);
 
   virtual ~TextDecoderRunner() = default;
 
@@ -50,61 +62,27 @@ public:
     return module_->is_method_loaded("forward");
   }
 
-  virtual void set_temperature(float temperature) noexcept {
-    temperature_ = temperature;
-  }
-
-  virtual void set_topp(float topp) noexcept { topp_ = topp; }
-
   inline void stop() { should_stop_ = true; }
 
   /**
-   * Sample the next token from the logits tensor.
-   * @param logits_tensor The logits tensor.
-   * @param temperature The temperature parameter used to control randomness in
-   * sampling.
-   * @return The next token.
+   * Sample the next token from the logits tensor using the sampling
+   * parameters in `config_`. `recent_tokens` is the prompt-plus-generated
+   * window used by the repetition penalty. Defined out-of-line in the cpp
+   * so this header doesn't need a complete `GenerationConfig` type.
    */
-  inline int32_t logits_to_token(const executorch::aten::Tensor &logits_tensor,
-                                 float temperature = -1.F, float topp = -1.F) {
-    int32_t result = 0;
-
-    temperature = temperature < 0.F ? temperature_ : temperature;
-    topp = topp < 0.F ? topp_ : topp;
-
-    // Create a minimal context for error handling in ET_SWITCH
-    struct {
-      [[noreturn]] void fail(torch::executor::Error /* error */) {
-        ET_CHECK_MSG(false, "Unsupported dtype in logits_to_token");
-      }
-    } ctx;
-
-    ET_SWITCH_FOUR_TYPES(
-        Float, Half, BFloat16, UInt16, logits_tensor.scalar_type(), ctx,
-        "logits_to_token", CTYPE, [&]() {
-          // If the logit_tensor rank is 3, the shape is [batch, seq_length,
-          // vocab_size], get the last logits, sample and return. Else the model
-          // outputs the last logit, directly sample and return.
-          auto *logits = logits_tensor.mutable_data_ptr<CTYPE>();
-          ssize_t vocab_size = logits_tensor.size(logits_tensor.dim() - 1);
-          if (logits_tensor.dim() == 3) {
-            auto num_tokens = logits_tensor.size(1);
-            logits += (num_tokens - 1) * vocab_size;
-          }
-          // @lint-ignore CLANGTIDY facebook-hte-Deprecated
-          Sampler sampler(vocab_size, temperature, topp);
-          result = sampler.sample(logits);
-        });
-    return result;
-  }
+  int32_t logits_to_token(const executorch::aten::Tensor &logits_tensor,
+                          const std::vector<uint64_t> &recent_tokens = {});
 
 protected:
   // Non-owning. The runner (BaseLLMRunner) owns the Module and outlives this.
   Module *module_;
   IOManager *io_manager_;
   bool should_stop_{false};
-  float temperature_;
-  float topp_;
+  // Reference to the owning runner's GenerationConfig. Sampling parameters
+  // (temperature/topp/min_p/repetition_penalty) are read fresh on every
+  // logits_to_token call, so writes to BaseLLMRunner::config_ take effect
+  // immediately with no sync setter.
+  const GenerationConfig &config_;
 };
 
 } // namespace llm

--- a/packages/react-native-executorch/common/runner/text_decoder_runner.h
+++ b/packages/react-native-executorch/common/runner/text_decoder_runner.h
@@ -20,17 +20,10 @@ namespace llm {
 // Forward declaration to avoid the include chain
 // irunner.h -> stats.h -> util.h -> text_prefiller.h -> text_decoder_runner.h
 // which would re-enter this header before TextDecoderRunner is defined.
-// The full GenerationConfig definition is required at use sites in
-// logits_to_token (header-inline) and the constructor (.cpp), both of which
-// transitively include irunner.h via base_llm_runner.h.
 struct GenerationConfig;
 
 class TextDecoderRunner {
 public:
-  // The runner reads sampling parameters from `config` on every call to
-  // `logits_to_token`, so updating `config.temperature` (etc.) on the owning
-  // BaseLLMRunner takes effect immediately without any sync setter on this
-  // class.
   explicit TextDecoderRunner(Module &module, IOManager *io_manager,
                              const GenerationConfig &config);
 
@@ -78,10 +71,6 @@ protected:
   Module *module_;
   IOManager *io_manager_;
   bool should_stop_{false};
-  // Reference to the owning runner's GenerationConfig. Sampling parameters
-  // (temperature/topp/min_p/repetition_penalty) are read fresh on every
-  // logits_to_token call, so writes to BaseLLMRunner::config_ take effect
-  // immediately with no sync setter.
   const GenerationConfig &config_;
 };
 

--- a/packages/react-native-executorch/common/runner/text_runner.cpp
+++ b/packages/react-native-executorch/common/runner/text_runner.cpp
@@ -27,13 +27,13 @@ Error TextRunner::load_subcomponents() {
   Stats *stats_ptr = &stats_;
 
   text_decoder_runner_ = std::make_unique<TextDecoderRunner>(
-      *module_, io_manager_.get(), config_.temperature, config_.topp);
+      *module_, io_manager_.get(), config_);
   text_prefiller_ = std::make_unique<TextPrefiller>(
       text_decoder_runner_.get(), config_.enable_kv_cache,
       config_.enable_dynamic_shape, config_.max_seq_len);
   text_token_generator_ = std::make_unique<TextTokenGenerator>(
       tokenizer_.get(), text_decoder_runner_.get(), config_.enable_kv_cache,
-      std::move(eos_ids_), stats_ptr);
+      std::move(eos_ids_), stats_ptr, config_);
 
   return Error::Ok;
 }
@@ -112,8 +112,7 @@ Error TextRunner::generate_internal(
 
   prompt_tokens.push_back(cur_token);
   int64_t num_generated = ET_UNWRAP(text_token_generator_->generate(
-      prompt_tokens, pos_, max_new_tokens - 1, config_.temperature,
-      config_.topp, wrapped_callback));
+      prompt_tokens, pos_, max_new_tokens - 1, wrapped_callback));
 
   pos_ += num_generated;
   stats_.inference_end_ms = time_in_ms();
@@ -126,28 +125,6 @@ Error TextRunner::generate_internal(
 void TextRunner::stop_impl() {
   if (text_token_generator_)
     text_token_generator_->stop();
-}
-
-void TextRunner::set_temperature_impl(float temperature) {
-  if (text_decoder_runner_)
-    text_decoder_runner_->set_temperature(temperature);
-}
-
-void TextRunner::set_topp_impl(float topp) {
-  if (text_decoder_runner_)
-    text_decoder_runner_->set_topp(topp);
-}
-
-void TextRunner::set_count_interval_impl(size_t count_interval) {
-  if (text_token_generator_) {
-    text_token_generator_->set_count_interval(count_interval);
-  }
-}
-
-void TextRunner::set_time_interval_impl(size_t time_interval) {
-  if (text_token_generator_) {
-    text_token_generator_->set_time_interval(time_interval);
-  }
 }
 
 } // namespace executorch::extension::llm

--- a/packages/react-native-executorch/common/runner/text_runner.h
+++ b/packages/react-native-executorch/common/runner/text_runner.h
@@ -24,10 +24,6 @@ public:
 protected:
   ::executorch::runtime::Error load_subcomponents() override;
   void stop_impl() override;
-  void set_temperature_impl(float temperature) override;
-  void set_topp_impl(float topp) override;
-  void set_count_interval_impl(size_t count_interval) override;
-  void set_time_interval_impl(size_t time_interval) override;
 
 private:
   std::unique_ptr<TextDecoderRunner> text_decoder_runner_;

--- a/packages/react-native-executorch/common/runner/text_token_generator.h
+++ b/packages/react-native-executorch/common/runner/text_token_generator.h
@@ -9,6 +9,7 @@
 // Generate tokens in a loop.
 #pragma once
 
+#include "irunner.h"
 #include "stats.h"
 #include "text_decoder_runner.h"
 #include "util.h"
@@ -22,13 +23,18 @@ namespace llm {
 
 class TextTokenGenerator {
 public:
+  // Holds a const reference to the owning runner's GenerationConfig and
+  // reads `output_token_batch_size` / `batch_time_interval_ms` from it on
+  // every iteration of the generation loop, so external updates take effect
+  // mid-stream without any sync setter on this class.
   TextTokenGenerator(tokenizers::HFTokenizer *tokenizer,
                      TextDecoderRunner *text_decoder_runner, bool use_kv_cache,
                      std::unique_ptr<std::unordered_set<uint64_t>> &&eos_ids,
-                     Stats *stats)
+                     Stats *stats, const GenerationConfig &config)
       : tokenizer_(tokenizer), text_decoder_runner_(text_decoder_runner),
         eos_ids_(std::move(eos_ids)), use_kv_cache_(use_kv_cache),
-        timestamp_(std::chrono::high_resolution_clock::now()), stats_(stats) {}
+        timestamp_(std::chrono::high_resolution_clock::now()), stats_(stats),
+        config_(config) {}
 
   virtual ~TextTokenGenerator() = default;
 
@@ -48,7 +54,6 @@ public:
    */
   inline ::executorch::runtime::Result<int64_t> generate(
       std::vector<uint64_t> tokens, int64_t start_pos, uint64_t max_new_tokens,
-      float temperature, float topp,
       const std::function<void(const std::string &)> &token_callback = {}) {
     ET_CHECK_MSG(!tokens.empty(),
                  "Token generation loop shouldn't take empty tokens");
@@ -80,6 +85,7 @@ public:
     auto tokens_managed = from_blob(token_data.data(), token_shape,
                                     executorch::aten::ScalarType::Long);
 
+    std::vector<uint64_t> generated_tokens(tokens.begin(), tokens.end());
     should_stop_ = false;
     timestamp_ = std::chrono::high_resolution_clock::now();
 
@@ -94,11 +100,12 @@ public:
       prev_token = cur_token;
 
       stats_->on_sampling_begin();
-      cur_token = text_decoder_runner_->logits_to_token(logits_tensor,
-                                                        temperature, topp);
+      cur_token =
+          text_decoder_runner_->logits_to_token(logits_tensor, generated_tokens);
       stats_->on_sampling_end();
 
       pos++;
+      generated_tokens.push_back(cur_token);
 
       if (use_kv_cache_) {
         // update the token tensor. token_data will not be empty.
@@ -128,9 +135,10 @@ public:
       std::string cache_decoded = decodeResult.get();
       const auto timeIntervalElapsed =
           std::chrono::duration_cast<std::chrono::milliseconds>(
-              std::chrono::high_resolution_clock::now() - timestamp_) >
-          time_interval_;
-      const auto countIntervalElapsed = token_cache.size() > count_interval_;
+              std::chrono::high_resolution_clock::now() - timestamp_)
+              .count() > static_cast<int64_t>(config_.batch_time_interval_ms);
+      const auto countIntervalElapsed =
+          token_cache.size() > config_.output_token_batch_size;
       const auto eos_reached = eos_ids_->contains(cur_token);
 
       if (!cache_decoded.ends_with("�") &&
@@ -177,14 +185,6 @@ public:
     return text_decoder_runner_->is_method_loaded();
   }
 
-  void set_count_interval(size_t count_interval) {
-    count_interval_ = count_interval;
-  }
-
-  void set_time_interval(size_t time_interval) {
-    time_interval_ = std::chrono::milliseconds(time_interval);
-  }
-
 private:
   /**
    * Note: TextTokenGenerator does not own the tokenizer_ and
@@ -199,12 +199,14 @@ private:
 
   // state machine
   bool should_stop_ = false;
-  size_t count_interval_{10};
-  std::chrono::milliseconds time_interval_{120};
   std::chrono::high_resolution_clock::time_point timestamp_;
 
   // stats
   Stats *stats_;
+
+  // Reference to the owning runner's GenerationConfig. Token-batching
+  // intervals are read fresh on every iteration.
+  const GenerationConfig &config_;
 };
 
 } // namespace llm

--- a/packages/react-native-executorch/src/constants/modelUrls.ts
+++ b/packages/react-native-executorch/src/constants/modelUrls.ts
@@ -83,6 +83,14 @@ const QWEN3_4B_QUANTIZED_MODEL = `${URL_PREFIX}-qwen-3/${VERSION_TAG}/qwen-3-4B/
 const QWEN3_TOKENIZER = `${URL_PREFIX}-qwen-3/${VERSION_TAG}/tokenizer.json`;
 const QWEN3_TOKENIZER_CONFIG = `${URL_PREFIX}-qwen-3/${VERSION_TAG}/tokenizer_config.json`;
 
+// Qwen3's published generation_config.json recommends temperature=0.6 and
+// top_p=0.95. We propagate those to every Qwen3 preset so model quality is
+// reasonable out of the box; users can override via `configure()`.
+const QWEN3_GENERATION_CONFIG = {
+  temperature: 0.6,
+  topp: 0.95,
+} as const;
+
 /**
  * @category Models - LLM
  */
@@ -91,6 +99,7 @@ export const QWEN3_0_6B = {
   modelSource: QWEN3_0_6B_MODEL,
   tokenizerSource: QWEN3_TOKENIZER,
   tokenizerConfigSource: QWEN3_TOKENIZER_CONFIG,
+  generationConfig: QWEN3_GENERATION_CONFIG,
 } as const;
 
 /**
@@ -101,6 +110,7 @@ export const QWEN3_0_6B_QUANTIZED = {
   modelSource: QWEN3_0_6B_QUANTIZED_MODEL,
   tokenizerSource: QWEN3_TOKENIZER,
   tokenizerConfigSource: QWEN3_TOKENIZER_CONFIG,
+  generationConfig: QWEN3_GENERATION_CONFIG,
 } as const;
 
 /**
@@ -111,6 +121,7 @@ export const QWEN3_1_7B = {
   modelSource: QWEN3_1_7B_MODEL,
   tokenizerSource: QWEN3_TOKENIZER,
   tokenizerConfigSource: QWEN3_TOKENIZER_CONFIG,
+  generationConfig: QWEN3_GENERATION_CONFIG,
 } as const;
 
 /**
@@ -121,6 +132,7 @@ export const QWEN3_1_7B_QUANTIZED = {
   modelSource: QWEN3_1_7B_QUANTIZED_MODEL,
   tokenizerSource: QWEN3_TOKENIZER,
   tokenizerConfigSource: QWEN3_TOKENIZER_CONFIG,
+  generationConfig: QWEN3_GENERATION_CONFIG,
 } as const;
 
 /**
@@ -131,6 +143,7 @@ export const QWEN3_4B = {
   modelSource: QWEN3_4B_MODEL,
   tokenizerSource: QWEN3_TOKENIZER,
   tokenizerConfigSource: QWEN3_TOKENIZER_CONFIG,
+  generationConfig: QWEN3_GENERATION_CONFIG,
 } as const;
 
 /**
@@ -141,6 +154,7 @@ export const QWEN3_4B_QUANTIZED = {
   modelSource: QWEN3_4B_QUANTIZED_MODEL,
   tokenizerSource: QWEN3_TOKENIZER,
   tokenizerConfigSource: QWEN3_TOKENIZER_CONFIG,
+  generationConfig: QWEN3_GENERATION_CONFIG,
 } as const;
 
 // HAMMER 2.1
@@ -444,12 +458,21 @@ const LFM2_VL_450M_TOKENIZER_CONFIG = `${URL_PREFIX}-lfm-2.5/${VERSION_TAG}/lfm2
 /**
  * @category Models - VLM
  */
+// LiquidAI's LFM2-VL model card recommends the following sampling settings.
+// Without them the model often produces generic / repetitive responses.
+const LFM2_VL_GENERATION_CONFIG = {
+  temperature: 0.1,
+  minP: 0.15,
+  repetitionPenalty: 1.05,
+} as const;
+
 export const LFM2_VL_1_6B_QUANTIZED = {
   modelName: 'lfm2.5-vl-1.6b-quantized',
   capabilities: ['vision'],
   modelSource: LFM2_VL_1_6B_QUANTIZED_MODEL,
   tokenizerSource: LFM2_VL_1_6B_TOKENIZER,
   tokenizerConfigSource: LFM2_VL_1_6B_TOKENIZER_CONFIG,
+  generationConfig: LFM2_VL_GENERATION_CONFIG,
 } as const;
 
 /**
@@ -461,6 +484,7 @@ export const LFM2_VL_450M_QUANTIZED = {
   modelSource: LFM2_VL_450M_QUANTIZED_MODEL,
   tokenizerSource: LFM2_VL_450M_TOKENIZER,
   tokenizerConfigSource: LFM2_VL_450M_TOKENIZER_CONFIG,
+  generationConfig: LFM2_VL_GENERATION_CONFIG,
 } as const;
 
 // Classification

--- a/packages/react-native-executorch/src/constants/modelUrls.ts
+++ b/packages/react-native-executorch/src/constants/modelUrls.ts
@@ -88,7 +88,7 @@ const QWEN3_TOKENIZER_CONFIG = `${URL_PREFIX}-qwen-3/${VERSION_TAG}/tokenizer_co
 // reasonable out of the box; users can override via `configure()`.
 const QWEN3_GENERATION_CONFIG = {
   temperature: 0.6,
-  topp: 0.95,
+  topP: 0.95,
 } as const;
 
 /**

--- a/packages/react-native-executorch/src/constants/modelUrls.ts
+++ b/packages/react-native-executorch/src/constants/modelUrls.ts
@@ -460,32 +460,49 @@ const LFM2_VL_450M_TOKENIZER_CONFIG = `${URL_PREFIX}-lfm-2.5/${VERSION_TAG}/lfm2
  */
 // LiquidAI's LFM2-VL model card recommends the following sampling settings.
 // Without them the model often produces generic / repetitive responses.
-const LFM2_VL_GENERATION_CONFIG = {
+const LFM2_5_VL_GENERATION_CONFIG = {
   temperature: 0.1,
   minP: 0.15,
   repetitionPenalty: 1.05,
 } as const;
 
-export const LFM2_VL_1_6B_QUANTIZED = {
+/**
+ * @category Models - VLM
+ */
+export const LFM2_5_VL_1_6B_QUANTIZED = {
   modelName: 'lfm2.5-vl-1.6b-quantized',
   capabilities: ['vision'],
   modelSource: LFM2_VL_1_6B_QUANTIZED_MODEL,
   tokenizerSource: LFM2_VL_1_6B_TOKENIZER,
   tokenizerConfigSource: LFM2_VL_1_6B_TOKENIZER_CONFIG,
-  generationConfig: LFM2_VL_GENERATION_CONFIG,
+  generationConfig: LFM2_5_VL_GENERATION_CONFIG,
 } as const;
 
 /**
  * @category Models - VLM
  */
-export const LFM2_VL_450M_QUANTIZED = {
+export const LFM2_5_VL_450M_QUANTIZED = {
   modelName: 'lfm2.5-vl-450m-quantized',
   capabilities: ['vision'],
   modelSource: LFM2_VL_450M_QUANTIZED_MODEL,
   tokenizerSource: LFM2_VL_450M_TOKENIZER,
   tokenizerConfigSource: LFM2_VL_450M_TOKENIZER_CONFIG,
-  generationConfig: LFM2_VL_GENERATION_CONFIG,
+  generationConfig: LFM2_5_VL_GENERATION_CONFIG,
 } as const;
+
+/**
+ * @deprecated Use `LFM2_5_VL_1_6B_QUANTIZED` instead — the model is from the
+ * LFM2.5 family. This alias will be removed in a future major release.
+ * @category Models - VLM
+ */
+export const LFM2_VL_1_6B_QUANTIZED = LFM2_5_VL_1_6B_QUANTIZED;
+
+/**
+ * @deprecated Use `LFM2_5_VL_450M_QUANTIZED` instead — the model is from the
+ * LFM2.5 family. This alias will be removed in a future major release.
+ * @category Models - VLM
+ */
+export const LFM2_VL_450M_QUANTIZED = LFM2_5_VL_450M_QUANTIZED;
 
 // Classification
 const EFFICIENTNET_V2_S_MODEL =
@@ -1151,8 +1168,8 @@ export const MODEL_REGISTRY = {
     LFM2_5_350M_QUANTIZED,
     LFM2_5_1_2B_INSTRUCT,
     LFM2_5_1_2B_INSTRUCT_QUANTIZED,
-    LFM2_VL_1_6B_QUANTIZED,
-    LFM2_VL_450M_QUANTIZED,
+    LFM2_5_VL_1_6B_QUANTIZED,
+    LFM2_5_VL_450M_QUANTIZED,
     EFFICIENTNET_V2_S,
     EFFICIENTNET_V2_S_QUANTIZED,
     SSDLITE_320_MOBILENET_V3_LARGE,

--- a/packages/react-native-executorch/src/controllers/LLMController.ts
+++ b/packages/react-native-executorch/src/controllers/LLMController.ts
@@ -193,14 +193,18 @@ export class LLMController {
     if (generationConfig.temperature !== undefined) {
       this.nativeModule.setTemperature(generationConfig.temperature);
     }
-    if (generationConfig.topp !== undefined) {
-      if (generationConfig.topp < 0 || generationConfig.topp > 1) {
+    // `topp` is the legacy spelling kept for backwards compatibility — `topP`
+    // wins when both are set so callers migrating to the new name don't get
+    // surprised by stale values. Reading the deprecated alias is intentional.
+    const topP = generationConfig.topP ?? generationConfig.topp;
+    if (topP !== undefined) {
+      if (topP < 0 || topP > 1) {
         throw new RnExecutorchError(
           RnExecutorchErrorCode.InvalidConfig,
           'Top P has to be in range [0, 1]'
         );
       }
-      this.nativeModule.setTopp(generationConfig.topp);
+      this.nativeModule.setTopp(topP);
     }
     if (generationConfig.minP !== undefined) {
       if (generationConfig.minP < 0 || generationConfig.minP > 1) {

--- a/packages/react-native-executorch/src/controllers/LLMController.ts
+++ b/packages/react-native-executorch/src/controllers/LLMController.ts
@@ -76,12 +76,14 @@ export class LLMController {
     tokenizerSource,
     tokenizerConfigSource,
     capabilities,
+    defaultGenerationConfig,
     onDownloadProgressCallback,
   }: {
     modelSource: ResourceSource;
     tokenizerSource: ResourceSource;
     tokenizerConfigSource: ResourceSource;
     capabilities?: readonly LLMCapability[];
+    defaultGenerationConfig?: GenerationConfig;
     onDownloadProgressCallback?: (downloadProgress: number) => void;
   }) {
     // reset inner state when loading new model
@@ -130,6 +132,12 @@ export class LLMController {
         tokenizerPath,
         capabilities ?? []
       );
+      if (defaultGenerationConfig) {
+        // Apply model-specific recommended sampling defaults before flipping
+        // isReady so callers that react to it see the right config on first
+        // send. User-provided `configure()` calls still override these.
+        this.applyGenerationConfig(defaultGenerationConfig);
+      }
       this.isReadyCallback(true);
       this.onToken = (data: string) => {
         if (!data) {
@@ -166,16 +174,26 @@ export class LLMController {
     this.chatConfig = { ...DEFAULT_CHAT_CONFIG, ...chatConfig };
     this.toolsConfig = toolsConfig;
 
-    if (generationConfig?.outputTokenBatchSize) {
+    if (generationConfig) {
+      this.applyGenerationConfig(generationConfig);
+    }
+
+    // reset inner state when loading new configuration
+    this.messageHistoryCallback(this.chatConfig.initialMessageHistory);
+    this.isGeneratingCallback(false);
+  }
+
+  private applyGenerationConfig(generationConfig: GenerationConfig) {
+    if (generationConfig.outputTokenBatchSize) {
       this.nativeModule.setCountInterval(generationConfig.outputTokenBatchSize);
     }
-    if (generationConfig?.batchTimeInterval) {
+    if (generationConfig.batchTimeInterval) {
       this.nativeModule.setTimeInterval(generationConfig.batchTimeInterval);
     }
-    if (generationConfig?.temperature) {
+    if (generationConfig.temperature !== undefined) {
       this.nativeModule.setTemperature(generationConfig.temperature);
     }
-    if (generationConfig?.topp) {
+    if (generationConfig.topp !== undefined) {
       if (generationConfig.topp < 0 || generationConfig.topp > 1) {
         throw new RnExecutorchError(
           RnExecutorchErrorCode.InvalidConfig,
@@ -184,10 +202,26 @@ export class LLMController {
       }
       this.nativeModule.setTopp(generationConfig.topp);
     }
-
-    // reset inner state when loading new configuration
-    this.messageHistoryCallback(this.chatConfig.initialMessageHistory);
-    this.isGeneratingCallback(false);
+    if (generationConfig.minP !== undefined) {
+      if (generationConfig.minP < 0 || generationConfig.minP > 1) {
+        throw new RnExecutorchError(
+          RnExecutorchErrorCode.InvalidConfig,
+          'Min P has to be in range [0, 1]'
+        );
+      }
+      this.nativeModule.setMinP(generationConfig.minP);
+    }
+    if (generationConfig.repetitionPenalty !== undefined) {
+      if (generationConfig.repetitionPenalty < 0) {
+        throw new RnExecutorchError(
+          RnExecutorchErrorCode.InvalidConfig,
+          'Repetition penalty must be non-negative'
+        );
+      }
+      this.nativeModule.setRepetitionPenalty(
+        generationConfig.repetitionPenalty
+      );
+    }
   }
 
   private getImageToken(): string {

--- a/packages/react-native-executorch/src/hooks/natural_language_processing/useLLM.ts
+++ b/packages/react-native-executorch/src/hooks/natural_language_processing/useLLM.ts
@@ -62,6 +62,7 @@ export function useLLM({
           tokenizerSource: model.tokenizerSource,
           tokenizerConfigSource: model.tokenizerConfigSource!,
           capabilities: model.capabilities,
+          defaultGenerationConfig: model.generationConfig,
           onDownloadProgressCallback: setDownloadProgress,
         });
       } catch (e) {

--- a/packages/react-native-executorch/src/types/llm.ts
+++ b/packages/react-native-executorch/src/types/llm.ts
@@ -248,6 +248,10 @@ export interface LLMConfig {
    * `temperature` - Scales output logits by the inverse of temperature. Controls the randomness / creativity of text generation.
    *
    * `topp` - Only samples from the smallest set of tokens whose cumulative probability exceeds topp.
+   *
+   * `minP` - Minimum probability threshold: tokens with prob < minP * max_prob are excluded. 0 disables filtering.
+   *
+   * `repetitionPenalty` - Multiplicative penalty applied to logits of recently generated tokens. Values > 1 discourage repetition. 1 disables the penalty.
    */
   generationConfig?: GenerationConfig;
 }
@@ -326,12 +330,16 @@ export interface ToolsConfig {
  * @category Types
  * @property {number} [temperature] - Scales output logits by the inverse of temperature. Controls the randomness / creativity of text generation.
  * @property {number} [topp] - Only samples from the smallest set of tokens whose cumulative probability exceeds topp.
+ * @property {number} [minP] - Minimum probability threshold: tokens with prob < minP * max_prob are excluded. 0 disables filtering.
+ * @property {number} [repetitionPenalty] - Multiplicative penalty applied to logits of recently generated tokens. Values > 1 discourage repetition. 1 disables the penalty.
  * @property {number} [outputTokenBatchSize] - Soft upper limit on the number of tokens in each token batch (in certain cases there can be more tokens in given batch, i.e. when the batch would end with special emoji join character).
  * @property {number} [batchTimeInterval] - Upper limit on the time interval between consecutive token batches.
  */
 export interface GenerationConfig {
   temperature?: number;
   topp?: number;
+  minP?: number;
+  repetitionPenalty?: number;
   outputTokenBatchSize?: number;
   batchTimeInterval?: number;
 }

--- a/packages/react-native-executorch/src/types/llm.ts
+++ b/packages/react-native-executorch/src/types/llm.ts
@@ -87,6 +87,13 @@ export interface LLMProps {
      * Example: `['vision']` enables `sendMessage(text, { imagePath })`.
      */
     capabilities?: readonly LLMCapability[];
+    /**
+     * Recommended default generation settings, typically copied from the
+     * upstream `generation_config.json` or the model card. Applied automatically
+     * after the native module loads and before any user `configure()` call,
+     * so callers only need to override the values they want to change.
+     */
+    generationConfig?: GenerationConfig;
   };
   /**
    * Boolean that can prevent automatic model loading (and downloading the data if you load it for the first time) after running the hook.

--- a/packages/react-native-executorch/src/types/llm.ts
+++ b/packages/react-native-executorch/src/types/llm.ts
@@ -336,7 +336,8 @@ export interface ToolsConfig {
  * Object configuring generation settings.
  * @category Types
  * @property {number} [temperature] - Scales output logits by the inverse of temperature. Controls the randomness / creativity of text generation.
- * @property {number} [topp] - Only samples from the smallest set of tokens whose cumulative probability exceeds topp.
+ * @property {number} [topP] - Only samples from the smallest set of tokens whose cumulative probability exceeds topP.
+ * @property {number} [topp] - **Deprecated.** Use `topP` instead.
  * @property {number} [minP] - Minimum probability threshold: tokens with prob < minP * max_prob are excluded. 0 disables filtering.
  * @property {number} [repetitionPenalty] - Multiplicative penalty applied to logits of recently generated tokens. Values > 1 discourage repetition. 1 disables the penalty.
  * @property {number} [outputTokenBatchSize] - Soft upper limit on the number of tokens in each token batch (in certain cases there can be more tokens in given batch, i.e. when the batch would end with special emoji join character).
@@ -344,6 +345,8 @@ export interface ToolsConfig {
  */
 export interface GenerationConfig {
   temperature?: number;
+  topP?: number;
+  /** @deprecated Use `topP` instead. */
   topp?: number;
   minP?: number;
   repetitionPenalty?: number;


### PR DESCRIPTION
## Description

Adds `min_p` and `repetition_penalty` sampling parameters to `GenerationConfig`, plumbs them through the full stack (`Sampler` → `TextDecoderRunner` → `TextTokenGenerator` → `BaseLLMRunner` / `TextRunner` / `MultimodalRunner` → JSI bindings → `LLMController`), introduces a per-model default `generationConfig` that gets applied automatically on load (populated for Qwen3 and LFM2-VL from their upstream recommendations), and replaces the distorting `cv::resize` in `VisionEncoder` with the existing `resizePadded` helper so multimodal inputs keep their aspect ratio. Also fixes three silent pre-existing bugs surfaced along the way: an xorshift PRNG seeded with `0` that made sampling deterministic, a `Sampler::apply_min_p` renormalization gap, and inline `{}` no-op overrides in `MultimodalRunner` that would desync in future refactors.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

**Sampling parameter plumbing**
1. Open `apps/llm`, load any supported model (e.g. `LFM2_VL_450M_QUANTIZED`).
2. Without any manual `configure()` call, send a prompt. The model card defaults are applied automatically — for LFM2-VL you should now see coherent, non-repetitive descriptions (previously the model often produced generic or looping replies at the library's default `temperature=0.8, topp=0.9`).
3. Optionally override via `useLLM(...)`'s `configure({ generationConfig: { temperature: 0.7, minP: 0.1, repetitionPenalty: 1.05 } })` and confirm the generation style changes.

**Letterbox preprocessing**
1. With a multimodal model loaded in `apps/llm` → `multimodal_llm` screen, attach a photo with a non-square aspect ratio (e.g. 3000×2250 from your camera roll).
2. Ask the model to describe it. Before this PR the image was stretched into the PTE's square input shape — the model would sometimes misidentify subjects in wide/tall photos. After, the image is letterboxed so proportions are preserved.

### Screenshots

<!-- none -->

### Related issues

<!-- none -->

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

**Per-model recommended defaults**

Model presets gain an optional `generationConfig` field; `LLMController.load` applies it before flipping `isReady`, so users see sensible sampling out of the box. User `configure()` calls still override per-field. Populated for:

- **Qwen3** family (`temperature=0.6, topp=0.95`, from `generation_config.json`)
- **LFM2-VL** family (`temperature=0.1, minP=0.15, repetitionPenalty=1.05`, from the LiquidAI model card)

Other presets (Llama, SmolLM2, Hammer, Phi-4, Qwen2.5, LFM2 text) keep the library defaults — these model cards don't publish sampling recommendations, so adding arbitrary values would be guessing.