### PR TITLE
refactor: merge std::runtime_error catch blocks in host functions

### DIFF
--- a/packages/react-native-executorch/common/rnexecutorch/RnExecutorchInstaller.h
+++ b/packages/react-native-executorch/common/rnexecutorch/RnExecutorchInstaller.h
@@ -101,11 +101,6 @@ private:
                           rt, "message", jsi::String::createFromUtf8(rt, msg));
                       promise->reject(jsi::Value(rt, std::move(errorData)));
                     });
-                  } catch (const std::runtime_error &e) {
-                    jsCallInvoker->invokeAsync(
-                        [promise, msg = std::string(e.what())]() {
-                          promise->reject(msg);
-                        });
                   } catch (const std::exception &e) {
                     jsCallInvoker->invokeAsync(
                         [promise, msg = std::string(e.what())]() {

--- a/packages/react-native-executorch/common/rnexecutorch/host_objects/ModelHostObject.h
+++ b/packages/react-native-executorch/common/rnexecutorch/host_objects/ModelHostObject.h
@@ -266,14 +266,6 @@ public:
       errorData.setProperty(runtime, "message",
                             jsi::String::createFromUtf8(runtime, e.what()));
       throw jsi::JSError(runtime, jsi::Value(runtime, std::move(errorData)));
-    } catch (const std::runtime_error &e) {
-      // This catch should be merged with the next one
-      // (std::runtime_error inherits from std::exception) HOWEVER react
-      // native has broken RTTI which breaks proper exception type
-      // checking. Remove when the following change is present in our
-      // version:
-      // https://github.com/facebook/react-native/commit/3132cc88dd46f95898a756456bebeeb6c248f20e
-      throw jsi::JSError(runtime, e.what());
     } catch (const std::exception &e) {
       throw jsi::JSError(runtime, e.what());
     } catch (...) {
@@ -344,14 +336,6 @@ public:
       errorData.setProperty(runtime, "message",
                             jsi::String::createFromUtf8(runtime, e.what()));
       throw jsi::JSError(runtime, jsi::Value(runtime, std::move(errorData)));
-    } catch (const std::runtime_error &e) {
-      // This catch should be merged with the next one
-      // (std::runtime_error inherits from std::exception) HOWEVER react
-      // native has broken RTTI which breaks proper exception type
-      // checking. Remove when the following change is present in our
-      // version:
-      // https://github.com/facebook/react-native/commit/3132cc88dd46f95898a756456bebeeb6c248f20e
-      throw jsi::JSError(runtime, e.what());
     } catch (const std::exception &e) {
       throw jsi::JSError(runtime, e.what());
     } catch (...) {
@@ -426,22 +410,6 @@ public:
                   promise->reject(jsi::Value(runtime, std::move(errorData)));
                 });
                 return;
-              } catch (const std::runtime_error &e) {
-                // This catch should be merged with the next two
-                // (std::runtime_error and jsi::JSError inherits from
-                // std::exception) HOWEVER react native has broken RTTI
-                // which breaks proper exception type checking. Remove when
-                // the following change is present in our version:
-                // https://github.com/facebook/react-native/commit/3132cc88dd46f95898a756456bebeeb6c248f20e
-                callInvoker->invokeAsync([e = std::move(e), promise]() {
-                  promise->reject(std::string(e.what()));
-                });
-                return;
-              } catch (const jsi::JSError &e) {
-                callInvoker->invokeAsync([e = std::move(e), promise]() {
-                  promise->reject(std::string(e.what()));
-                });
-                return;
               } catch (const std::exception &e) {
                 callInvoker->invokeAsync([e = std::move(e), promise]() {
                   promise->reject(std::string(e.what()));
@@ -473,14 +441,6 @@ public:
       errorData.setProperty(runtime, "message",
                             jsi::String::createFromUtf8(runtime, e.what()));
       throw jsi::JSError(runtime, jsi::Value(runtime, std::move(errorData)));
-    } catch (const std::runtime_error &e) {
-      // This catch should be merged with the next one
-      // (std::runtime_error inherits from std::exception) HOWEVER react
-      // native has broken RTTI which breaks proper exception type
-      // checking. Remove when the following change is present in our
-      // version:
-      // https://github.com/facebook/react-native/commit/3132cc88dd46f95898a756456bebeeb6c248f20e
-      throw jsi::JSError(runtime, e.what());
     } catch (const std::exception &e) {
       throw jsi::JSError(runtime, e.what());
     } catch (...) {


### PR DESCRIPTION
## Summary

- Removes the redundant `std::runtime_error` (and `jsi::JSError`) catch blocks across `ModelHostObject.h` and `RnExecutorchInstaller.h`. They were workarounds for broken RTTI in older RN versions; the fix from facebook/react-native@3132cc8 is present in RN 0.81+, which is the project's minimum supported version.
- All five sites now catch `std::exception` polymorphically: `synchronousHostFunction`, `visionHostFunction`, `promiseHostFunction`, `unload`, and the model loader in `RnExecutorchInstaller`.

Closes #964

## Test plan

- [ ] C++ unit/integration tests in `common/rnexecutorch/tests` pass on Android (`run_tests.sh`)
- [ ] Smoke-test an example app: trigger a model load failure and a forward-pass failure, confirm error message + code propagate to JS unchanged