### PR TITLE
fix(podspec): exclude entire tests/ tree from pod sources

### DIFF
--- a/packages/react-native-executorch/react-native-executorch.podspec
+++ b/packages/react-native-executorch/react-native-executorch.podspec
@@ -70,7 +70,7 @@ Pod::Spec.new do |s|
   # react-native-skia. The headers are preserved by preserve_paths and
   # then made available by HEADER_SEARCH_PATHS.
   s.exclude_files = [
-    "common/rnexecutorch/tests/**/*.{cpp}",
+    "common/rnexecutorch/tests/**/*",
     "common/rnexecutorch/jsi/*.{h,hpp}"
   ]
   s.header_mappings_dir = "common/rnexecutorch"


### PR DESCRIPTION
## Description

The podspec source glob `common/**/*.{cpp,c,h,hpp}` pulls everything under `common/`, including artifacts CMake writes to `common/rnexecutorch/tests/build/` when the C++ unit tests are run locally. The existing exclude only filtered `*.cpp` under `tests/`, so the C-compiler-detection probe file `CMakeFiles/<version>/CompilerIdC/CMakeCCompilerId.c` (and any other `.c/.h/.hpp` artifact) leaked into `Pods.xcodeproj`. When the local CMake cache later regenerated under a different version, the baked-in path no longer existed and iOS builds failed with "Build input file cannot be found".

Replace the extension-specific filter with `tests/**/*` so the whole tree is excluded from pod sources, regardless of what's added or generated under it.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

1. From `packages/react-native-executorch/common/rnexecutorch/tests/`, run `./run_tests.sh` (or otherwise populate `tests/build/`).
2. In any example app (e.g. `apps/computer-vision`), run `pod install` and build for iOS.
3. Without this change the build fails with a missing `tests/build/CMakeFiles/<version>/CompilerIdC/CMakeCCompilerId.c`; with it, the build succeeds.

### Screenshots

### Related issues

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes