### PR TITLE
fix: read text-to-image scheduler config via ResourceFetcher adapter

### DIFF
--- a/packages/react-native-executorch/src/modules/computer_vision/TextToImageModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/TextToImageModule.ts
@@ -136,8 +136,8 @@ export class TextToImageModule extends BaseModule {
       );
     }
 
-    const response = await fetch('file://' + schedulerPath);
-    const schedulerConfig = await response.json();
+    const schedulerJson = await ResourceFetcher.fs.readAsString(schedulerPath);
+    const schedulerConfig = JSON.parse(schedulerJson);
 
     return global.loadTextToImage(
       tokenizerPath,


### PR DESCRIPTION
## Description

`TextToImageModule.load()` was reading the downloaded `scheduler_config.json` via `fetch('file://' + path)`. RN's global `fetch` does not support `file://` URLs on Android, so loading any text-to-image model failed with `TypeError: Network request failed` immediately after the 5 model files finished downloading. iOS happened to tolerate it. Switch to `ResourceFetcher.fs.readAsString`, which is the adapter API intended for reading config files (already used by `LLMController`).

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

1. In `apps/computer-vision`, open the Text to Image screen on a physical Android device.
2. Pick either `BK_SDM_TINY_VPRED_256` or `BK_SDM_TINY_VPRED_512`.
3. Without this change, loading reaches ~100% then errors with `Load failed: TypeError: Network request failed` (from `TextToImageModule.ts:62`).
4. With this change, loading completes and `generate()` works.

### Screenshots

### Related issues

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes