### PR TITLE
fix: BareResourceFetcher import path in documentation

### DIFF
--- a/docs/docs/01-fundamentals/02-loading-models.md
+++ b/docs/docs/01-fundamentals/02-loading-models.md
@@ -37,7 +37,7 @@ and
 
 ```typescript
 import { initExecutorch } from 'react-native-executorch';
-import { BareResourceFetcher } from '@react-native-executorch/bare-adapter';
+import { BareResourceFetcher } from 'react-native-executorch-bare-resource-fetcher';
 
 initExecutorch({
   resourceFetcher: BareResourceFetcher,

--- a/docs/versioned_docs/version-0.8.x/01-fundamentals/02-loading-models.md
+++ b/docs/versioned_docs/version-0.8.x/01-fundamentals/02-loading-models.md
@@ -37,7 +37,7 @@ and
 
 ```typescript
 import { initExecutorch } from 'react-native-executorch';
-import { BareResourceFetcher } from '@react-native-executorch/bare-adapter';
+import { BareResourceFetcher } from 'react-native-executorch-bare-resource-fetcher';
 
 initExecutorch({
   resourceFetcher: BareResourceFetcher,


### PR DESCRIPTION
- Fix incorrect import path from '@react-native-executorch/bare-adapter' to 'react-native-executorch-bare-resource-fetcher'
- Update both current and versioned documentation files
- Ensures users can properly import BareResourceFetcher

## Description

<!-- Provide a concise and descriptive summary of the changes implemented in this PR. -->

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

###  Tested on
 - [ ] iOS
 - [ ] Android
 
### Testing instructions
- Build documentation locally via yarn start and check if everything is corrected.

### Screenshots
### Related issues

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes
Checked versioned documentation files; the issue does not exist there.
<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
