### PR TITLE
refactor: streamline error handling

### DIFF
--- a/docs/docs/05-utilities/04-error-handling.md
+++ b/docs/docs/05-utilities/04-error-handling.md
@@ -83,15 +83,15 @@ These errors occur when trying to perform operations on a model in an invalid st
 
 These errors occur when invalid configuration or input is provided.
 
-| Error Code             | Description                          | When It Occurs                                                                          | How to Handle                                            |
-| ---------------------- | ------------------------------------ | --------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| `InvalidConfig`        | Configuration parameters are invalid | Setting parameters outside valid ranges (e.g., `topp` outside [0, 1])                   | Check parameter constraints and provide valid values     |
-| `InvalidUserInput`     | Input provided to API is invalid     | Passing empty arrays, null values, or malformed data to methods                         | Validate input before calling methods                    |
-| `InvalidModelSource`   | Model source type is invalid         | Providing wrong type for model source (e.g., object when string expected)               | Ensure model source matches expected type                |
-| `LanguageNotSupported` | Language not supported by model      | Passing unsupported language to multilingual OCR or Speech-to-Text models               | Use a supported language or different model              |
-| `PlatformNotSupported` | Current platform is not supported    | Using features (e.g., camera frame processing) on an unsupported platform or OS version | Ensure you're running on a supported platform/OS version |
-| `WrongDimensions`      | Input tensor dimensions don't match  | Providing input with incorrect shape for the model                                      | Check model's expected input dimensions                  |
-| `UnexpectedNumInputs`  | Wrong number of inputs provided      | Passing more or fewer inputs than model expects                                         | Match the number of inputs to model metadata             |
+| Error Code             | Description                          | When It Occurs                                                                          | How to Handle                                                 |
+| ---------------------- | ------------------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `InvalidConfig`        | Configuration parameters are invalid | Setting parameters outside valid ranges (e.g., `topp` outside [0, 1])                   | Check parameter constraints and provide valid values          |
+| `InvalidUserInput`     | Input provided to API is invalid     | Passing empty arrays, null values, or malformed data to methods                         | Validate input before calling methods                         |
+| `InvalidModelSource`   | Model source type is invalid         | Providing wrong type for model source (e.g., object when string expected)               | Ensure model source matches expected type                     |
+| `LanguageNotSupported` | Language not supported by model      | Passing unsupported language to multilingual OCR or Speech-to-Text models               | Use a supported language or different model                   |
+| `PlatformNotSupported` | Current platform is not supported    | Using features (e.g., camera frame processing) on an unsupported platform or OS version | Ensure you're running on a supported platform/OS version      |
+| `WrongDimensions`      | Input tensor dimensions don't match  | Providing input with incorrect shape for the model                                      | Check model's expected input dimensions                       |
+| `UnexpectedNumInputs`  | Wrong number of inputs provided      | Passing more or fewer inputs than model expects                                         | Verify the expected model I/O contract in docs or source code |
 
 ### File Operations Errors
 
@@ -133,12 +133,12 @@ These errors are specific to streaming transcription operations.
 
 These errors come from the ExecuTorch runtime during model execution.
 
-| Error Code           | Description                      | When It Occurs                                 | How to Handle                                  |
-| -------------------- | -------------------------------- | ---------------------------------------------- | ---------------------------------------------- |
-| `InvalidModelOutput` | Model output size unexpected     | Model produces output of wrong size            | Verify model is compatible with the library    |
-| `ThreadPoolError`    | Threadpool operation failed      | Internal threading issue                       | Restart the model or app                       |
-| `TokenizerError`     | Tokenizer or tokenization failed | Tokenizer initialization or processing error   | Check tokenizer files and model compatibility  |
-| `UnknownError`       | Unexpected error occurred        | 3rd-party library error or unhandled exception | Check logs for details, report if reproducible |
+| Error Code           | Description                      | When It Occurs                                 | How to Handle                                               |
+| -------------------- | -------------------------------- | ---------------------------------------------- | ----------------------------------------------------------- |
+| `InvalidModelOutput` | Model output size unexpected     | Model produces output of wrong size            | Verify model's expected I/O contract in docs or source code |
+| `ThreadPoolError`    | Threadpool operation failed      | Internal threading issue                       | Restart the model or app                                    |
+| `TokenizerError`     | Tokenizer or tokenization failed | Tokenizer initialization or processing error   | Check tokenizer files and model compatibility               |
+| `UnknownError`       | Unexpected error occurred        | 3rd-party library error or unhandled exception | Check logs for details, report if reproducible              |
 
 ### ExecuTorch Runtime Errors
 

--- a/docs/docs/05-utilities/04-error-handling.md
+++ b/docs/docs/05-utilities/04-error-handling.md
@@ -68,7 +68,9 @@ llm.delete();
 
 ## Reference
 
-All errors in React Native ExecuTorch inherit from `RnExecutorchError` and include a `code` property from the `RnExecutorchErrorCode` enum. Below is a comprehensive list of all possible errors, organized by category.
+All errors in React Native ExecuTorch inherit from `RnExecutorchError` and include a `code` property. The code is typed as `RnExecutorchErrorCode | number`: in practice you'll almost always see a member of the enum, but the codes are generated from a shared config into both the C++ and TS sources, and if those generated files drift the raw numeric value flows through unchanged. When switching on `err.code`, always include a `default` branch.
+
+Below is a comprehensive list of all possible errors, organized by category.
 
 ### Module State Errors
 

--- a/packages/react-native-executorch/common/rnexecutorch/Error.h
+++ b/packages/react-native-executorch/common/rnexecutorch/Error.h
@@ -1,36 +1,13 @@
 #pragma once
 
 #include <executorch/runtime/core/error.h>
+#include <source_location>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <variant>
 
 #include <rnexecutorch/ErrorCodes.h>
-
-namespace rnexecutorch::detail {
-constexpr const char *basename(const char *path) noexcept {
-  const char *base = path;
-  while (*path) {
-    if (*path++ == '/')
-      base = path;
-  }
-  return base;
-}
-} // namespace rnexecutorch::detail
-
-// clang-format off
-#define CHECK_OK_OR_THROW_FORWARD_ERROR(result) \
-  if (!(result).ok()) \
-    throw RnExecutorchError( \
-        (result).error(), std::string("[") + ::rnexecutorch::detail::basename(__FILE__) + \
-        "] Forward pass failed (in: " + __func__ + "). Ensure the model input is correct.")
-
-#define THROW_NOT_LOADED_ERROR() \
-  throw RnExecutorchError( \
-      RnExecutorchErrorCode::ModuleNotLoaded, \
-      std::string("[") + ::rnexecutorch::detail::basename(__FILE__) + \
-      "] Model not loaded (in: " + __func__ + ")")
-// clang-format on
 
 namespace rnexecutorch {
 
@@ -59,4 +36,40 @@ public:
   }
 };
 
+namespace detail {
+
+// npos + 1 wraps to 0, so the no-slash case returns the whole path.
+constexpr std::string_view basename(std::string_view path) noexcept {
+  return path.substr(path.find_last_of('/') + 1);
+}
+
+inline std::string locationPrefix(const std::source_location &loc) {
+  return "[" + std::string(basename(loc.file_name())) + "] ";
+}
+
+[[noreturn]] inline void
+throwNotLoaded(std::source_location loc = std::source_location::current()) {
+  throw RnExecutorchError(RnExecutorchErrorCode::ModuleNotLoaded,
+                          locationPrefix(loc) + "Model not loaded (in: " +
+                              loc.function_name() + ")");
+}
+
+template <typename Result>
+inline void checkOkOrThrowForwardError(
+    const Result &result,
+    std::source_location loc = std::source_location::current()) {
+  if (!result.ok()) {
+    throw RnExecutorchError(
+        result.error(), locationPrefix(loc) +
+                            "Forward pass failed (in: " + loc.function_name() +
+                            "). Ensure the model input is correct.");
+  }
+}
+
+} // namespace detail
 } // namespace rnexecutorch
+
+#define CHECK_OK_OR_THROW_FORWARD_ERROR(result)                                \
+  ::rnexecutorch::detail::checkOkOrThrowForwardError(result)
+
+#define THROW_NOT_LOADED_ERROR() ::rnexecutorch::detail::throwNotLoaded()

--- a/packages/react-native-executorch/common/rnexecutorch/Error.h
+++ b/packages/react-native-executorch/common/rnexecutorch/Error.h
@@ -7,6 +7,31 @@
 
 #include <rnexecutorch/ErrorCodes.h>
 
+namespace rnexecutorch::detail {
+constexpr const char *basename(const char *path) noexcept {
+  const char *base = path;
+  while (*path) {
+    if (*path++ == '/')
+      base = path;
+  }
+  return base;
+}
+} // namespace rnexecutorch::detail
+
+// clang-format off
+#define CHECK_OK_OR_THROW_FORWARD_ERROR(result) \
+  if (!(result).ok()) \
+    throw RnExecutorchError( \
+        (result).error(), std::string("[") + ::rnexecutorch::detail::basename(__FILE__) + \
+        "] Forward pass failed (in: " + __func__ + "). Ensure the model input is correct.")
+
+#define THROW_NOT_LOADED_ERROR() \
+  throw RnExecutorchError( \
+      RnExecutorchErrorCode::ModuleNotLoaded, \
+      std::string("[") + ::rnexecutorch::detail::basename(__FILE__) + \
+      "] Model not loaded (in: " + __func__ + ")")
+// clang-format on
+
 namespace rnexecutorch {
 
 using ErrorVariant =

--- a/packages/react-native-executorch/common/rnexecutorch/ErrorCodes.h
+++ b/packages/react-native-executorch/common/rnexecutorch/ErrorCodes.h
@@ -48,7 +48,9 @@ enum class RnExecutorchErrorCode : int32_t {
    */
   FileReadFailed = 114,
   /**
-   * Thrown when the size of model output is unexpected.
+   * Thrown when the size of model output is unexpected. If you're using your
+   * custom model with any of the pre-defined modules, please verify docs or
+   * source code for the expected model I/O contract.
    */
   InvalidModelOutput = 115,
   /**
@@ -77,7 +79,9 @@ enum class RnExecutorchErrorCode : int32_t {
   InvalidModelSource = 120,
   /**
    * Thrown when the number of passed inputs to the model is different than the
-   * model metadata specifies.
+   * model metadata specifies. If you're using your custom model with any of the
+   * pre-defined modules, please verify docs or source code for the expected
+   * model I/O contract.
    */
   UnexpectedNumInputs = 121,
   /**

--- a/packages/react-native-executorch/common/rnexecutorch/TokenizerModule.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/TokenizerModule.cpp
@@ -18,24 +18,18 @@ TokenizerModule::TokenizerModule(
   auto status = tokenizer->load(source);
 
   if (status != tokenizers::Error::Ok) {
-    throw RnExecutorchError(RnExecutorchErrorCode::TokenizerError,
-                            "Unexpected issue occured while loading tokenizer");
+    throw RnExecutorchError(
+        RnExecutorchErrorCode::TokenizerError,
+        "Unexpected issue occurred while loading tokenizer");
   };
   std::filesystem::path modelPath{source};
   memorySizeLowerBound = std::filesystem::file_size(modelPath);
 }
 
-void TokenizerModule::ensureTokenizerLoaded(
-    const std::string &methodName) const {
-  if (!tokenizer) {
-    throw RnExecutorchError(
-        RnExecutorchErrorCode::ModuleNotLoaded,
-        methodName + " function was called on an uninitialized tokenizer!");
-  }
-}
-
 std::vector<uint64_t> TokenizerModule::encode(std::string s) const {
-  ensureTokenizerLoaded("encode");
+  if (!tokenizer) {
+    THROW_NOT_LOADED_ERROR();
+  }
 
   // If the used tokenizer.json has defined post_processor field,
   // setting any of bos or eos arguments to value other than provided constant
@@ -44,9 +38,9 @@ std::vector<uint64_t> TokenizerModule::encode(std::string s) const {
   auto encodeResult =
       tokenizer->encode(s, numOfAddedBoSTokens, numOfAddedEoSTokens);
   if (!encodeResult.ok()) {
-    throw rnexecutorch::RnExecutorchError(
-        rnexecutorch::RnExecutorchErrorCode::TokenizerError,
-        "Unexpected issue occured while encoding: " +
+    throw RnExecutorchError(
+        RnExecutorchErrorCode::TokenizerError,
+        "Unexpected issue occurred while encoding: " +
             std::to_string(static_cast<int32_t>(encodeResult.error())));
   }
   return encodeResult.get();
@@ -54,13 +48,15 @@ std::vector<uint64_t> TokenizerModule::encode(std::string s) const {
 
 std::string TokenizerModule::decode(std::vector<uint64_t> vec,
                                     bool skipSpecialTokens) const {
-  ensureTokenizerLoaded("decode");
+  if (!tokenizer) {
+    THROW_NOT_LOADED_ERROR();
+  }
 
   auto decodeResult = tokenizer->decode(vec, skipSpecialTokens);
   if (!decodeResult.ok()) {
     throw RnExecutorchError(
         RnExecutorchErrorCode::TokenizerError,
-        "Unexpected issue occured while decoding: " +
+        "Unexpected issue occurred while decoding: " +
             std::to_string(static_cast<int32_t>(decodeResult.error())));
   }
 
@@ -68,30 +64,36 @@ std::string TokenizerModule::decode(std::vector<uint64_t> vec,
 }
 
 size_t TokenizerModule::getVocabSize() const {
-  ensureTokenizerLoaded("getVocabSize");
+  if (!tokenizer) {
+    THROW_NOT_LOADED_ERROR();
+  }
   return static_cast<size_t>(tokenizer->vocab_size());
 }
 
 std::string TokenizerModule::idToToken(uint64_t tokenId) const {
-  ensureTokenizerLoaded("idToToken");
+  if (!tokenizer) {
+    THROW_NOT_LOADED_ERROR();
+  }
   auto result = tokenizer->id_to_piece(tokenId);
   if (!result.ok()) {
-    throw rnexecutorch::RnExecutorchError(
-        rnexecutorch::RnExecutorchErrorCode::TokenizerError,
-        "Unexpected issue occured while trying to convert id to token: " +
+    throw RnExecutorchError(
+        RnExecutorchErrorCode::TokenizerError,
+        "Unexpected issue occurred while converting id to token: " +
             std::to_string(static_cast<int32_t>(result.error())));
   }
   return result.get();
 }
 
 uint64_t TokenizerModule::tokenToId(std::string token) const {
-  ensureTokenizerLoaded("tokenToId");
+  if (!tokenizer) {
+    THROW_NOT_LOADED_ERROR();
+  }
 
   auto result = tokenizer->piece_to_id(token);
   if (!result.ok()) {
-    throw rnexecutorch::RnExecutorchError(
-        rnexecutorch::RnExecutorchErrorCode::TokenizerError,
-        "Unexpected issue occured while trying to convert token to id: " +
+    throw RnExecutorchError(
+        RnExecutorchErrorCode::TokenizerError,
+        "Unexpected issue occurred while converting token to id: " +
             std::to_string(static_cast<int32_t>(result.error())));
   }
   return result.get();

--- a/packages/react-native-executorch/common/rnexecutorch/TokenizerModule.h
+++ b/packages/react-native-executorch/common/rnexecutorch/TokenizerModule.h
@@ -24,7 +24,6 @@ public:
   std::size_t getMemoryLowerBound() const noexcept;
 
 private:
-  void ensureTokenizerLoaded(const std::string &methodName) const;
   std::unique_ptr<tokenizers::HFTokenizer> tokenizer;
   std::size_t memorySizeLowerBound{0};
 };

--- a/packages/react-native-executorch/common/rnexecutorch/models/BaseModel.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/BaseModel.cpp
@@ -31,8 +31,7 @@ BaseModel::BaseModel(const std::string &modelSource,
 std::vector<int32_t> BaseModel::getInputShape(std::string method_name,
                                               int32_t index) const {
   if (!module_) {
-    throw RnExecutorchError(RnExecutorchErrorCode::ModuleNotLoaded,
-                            "Model not loaded: Cannot get input shape");
+    THROW_NOT_LOADED_ERROR();
   }
 
   auto method_meta = module_->method_meta(method_name);
@@ -58,8 +57,7 @@ std::vector<int32_t> BaseModel::getInputShape(std::string method_name,
 std::vector<std::vector<int32_t>>
 BaseModel::getAllInputShapes(std::string methodName) const {
   if (!module_) {
-    throw RnExecutorchError(RnExecutorchErrorCode::ModuleNotLoaded,
-                            "Model not loaded: Cannot get all input shapes");
+    THROW_NOT_LOADED_ERROR();
   }
 
   auto method_meta = module_->method_meta(methodName);
@@ -91,8 +89,7 @@ BaseModel::getAllInputShapes(std::string methodName) const {
 std::vector<JSTensorViewOut>
 BaseModel::forwardJS(std::vector<JSTensorViewIn> tensorViewVec) const {
   if (!module_) {
-    throw RnExecutorchError(RnExecutorchErrorCode::ModuleNotLoaded,
-                            "Model not loaded: Cannot perform forward pass");
+    THROW_NOT_LOADED_ERROR();
   }
   std::vector<executorch::runtime::EValue> evalues;
   evalues.reserve(tensorViewVec.size());
@@ -114,11 +111,7 @@ BaseModel::forwardJS(std::vector<JSTensorViewIn> tensorViewVec) const {
   }
 
   auto result = module_->forward(evalues);
-  if (!result.ok()) {
-    throw RnExecutorchError(result.error(),
-                            "The model's forward function did not succeed. "
-                            "Ensure the model input is correct.");
-  }
+  CHECK_OK_OR_THROW_FORWARD_ERROR(result);
 
   auto &outputs = result.get();
   std::vector<JSTensorViewOut> output;
@@ -141,8 +134,7 @@ BaseModel::forwardJS(std::vector<JSTensorViewIn> tensorViewVec) const {
 Result<executorch::runtime::MethodMeta>
 BaseModel::getMethodMeta(const std::string &methodName) const {
   if (!module_) {
-    throw RnExecutorchError(RnExecutorchErrorCode::ModuleNotLoaded,
-                            "Model not loaded: Cannot get method meta");
+    THROW_NOT_LOADED_ERROR();
   }
   return module_->method_meta(methodName);
 }
@@ -150,8 +142,7 @@ BaseModel::getMethodMeta(const std::string &methodName) const {
 Result<std::vector<EValue>>
 BaseModel::forward(const EValue &input_evalue) const {
   if (!module_) {
-    throw RnExecutorchError(RnExecutorchErrorCode::ModuleNotLoaded,
-                            "Model not loaded: Cannot perform forward pass");
+    THROW_NOT_LOADED_ERROR();
   }
   return module_->forward(input_evalue);
 }
@@ -159,8 +150,7 @@ BaseModel::forward(const EValue &input_evalue) const {
 Result<std::vector<EValue>>
 BaseModel::forward(const std::vector<EValue> &input_evalues) const {
   if (!module_) {
-    throw RnExecutorchError(RnExecutorchErrorCode::ModuleNotLoaded,
-                            "Model not loaded: Cannot perform forward pass");
+    THROW_NOT_LOADED_ERROR();
   }
   return module_->forward(input_evalues);
 }
@@ -169,8 +159,7 @@ Result<std::vector<EValue>>
 BaseModel::execute(const std::string &methodName,
                    const std::vector<EValue> &input_value) const {
   if (!module_) {
-    throw RnExecutorchError(RnExecutorchErrorCode::ModuleNotLoaded,
-                            "Model not loaded, cannot run execute");
+    THROW_NOT_LOADED_ERROR();
   }
   return module_->execute(methodName, input_value);
 }

--- a/packages/react-native-executorch/common/rnexecutorch/models/classification/Classification.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/classification/Classification.cpp
@@ -60,11 +60,7 @@ Classification::runInference(cv::Mat image) {
                                                   preprocessed);
 
   auto forwardResult = BaseModel::forward(inputTensor);
-  if (!forwardResult.ok()) {
-    throw RnExecutorchError(forwardResult.error(),
-                            "The model's forward function did not succeed. "
-                            "Ensure the model input is correct.");
-  }
+  CHECK_OK_OR_THROW_FORWARD_ERROR(forwardResult);
   return postprocess(forwardResult->at(0).toTensor());
 }
 

--- a/packages/react-native-executorch/common/rnexecutorch/models/embeddings/image/ImageEmbeddings.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/embeddings/image/ImageEmbeddings.cpp
@@ -38,12 +38,7 @@ ImageEmbeddings::runInference(cv::Mat image) {
 
   auto forwardResult = BaseModel::forward(inputTensor);
 
-  if (!forwardResult.ok()) {
-    throw RnExecutorchError(
-        forwardResult.error(),
-        "The model's forward function did not succeed. Ensure the model input "
-        "is correct.");
-  }
+  CHECK_OK_OR_THROW_FORWARD_ERROR(forwardResult);
 
   auto forwardResultTensor = forwardResult->at(0).toTensor();
   return std::make_shared<OwningArrayBuffer>(

--- a/packages/react-native-executorch/common/rnexecutorch/models/embeddings/text/TextEmbeddings.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/embeddings/text/TextEmbeddings.cpp
@@ -56,12 +56,7 @@ TextEmbeddings::generate(const std::string input) {
       attnMaskShape, preprocessed.attentionMask.data(), ScalarType::Long);
 
   auto forwardResult = BaseModel::forward({tokenIds, attnMask});
-  if (!forwardResult.ok()) {
-    throw RnExecutorchError(
-        forwardResult.error(),
-        "The model's forward function did not succeed. Ensure the model input "
-        "is correct.");
-  }
+  CHECK_OK_OR_THROW_FORWARD_ERROR(forwardResult);
 
   return BaseEmbeddings::postprocess(forwardResult);
 }

--- a/packages/react-native-executorch/common/rnexecutorch/models/instance_segmentation/BaseInstanceSegmentation.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/instance_segmentation/BaseInstanceSegmentation.cpp
@@ -79,13 +79,7 @@ std::vector<types::Instance> BaseInstanceSegmentation::runInference(
 
   auto forwardResult =
       BaseModel::execute(methodName, {buildInputTensor(image)});
-  if (!forwardResult.ok()) {
-    throw RnExecutorchError(
-        forwardResult.error(),
-        "The model's forward function did not succeed. "
-        "Ensure the model input is correct and method name '" +
-            methodName + "' is valid.");
-  }
+  CHECK_OK_OR_THROW_FORWARD_ERROR(forwardResult);
 
   validateOutputTensors(forwardResult.get());
 

--- a/packages/react-native-executorch/common/rnexecutorch/models/ocr/Detector.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/ocr/Detector.cpp
@@ -51,11 +51,7 @@ std::vector<types::DetectorBBox> Detector::generate(const cv::Mat &inputImage,
       constants::kNormalizationVariance);
   auto forwardResult = BaseModel::execute(methodName, {inputTensor});
 
-  if (!forwardResult.ok()) {
-    throw RnExecutorchError(forwardResult.error(),
-                            "The model's forward function did not succeed. "
-                            "Ensure the model input is correct.");
-  }
+  CHECK_OK_OR_THROW_FORWARD_ERROR(forwardResult);
 
   return postprocess(forwardResult->at(0).toTensor(), modelInputSize);
 }

--- a/packages/react-native-executorch/common/rnexecutorch/models/ocr/Recognizer.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/ocr/Recognizer.cpp
@@ -39,11 +39,7 @@ Recognizer::generate(const cv::Mat &grayImage, int32_t inputWidth) {
   TensorPtr inputTensor =
       image_processing::getTensorFromMatrixGray(tensorDims, grayImage);
   auto forwardResult = BaseModel::execute(method_name, {inputTensor});
-  if (!forwardResult.ok()) {
-    throw RnExecutorchError(forwardResult.error(),
-                            "The model's forward function did not succeed. "
-                            "Ensure the model input is correct.");
-  }
+  CHECK_OK_OR_THROW_FORWARD_ERROR(forwardResult);
 
   return postprocess(forwardResult->at(0).toTensor());
 }

--- a/packages/react-native-executorch/common/rnexecutorch/models/privacy_filter/PrivacyFilter.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/privacy_filter/PrivacyFilter.cpp
@@ -99,11 +99,7 @@ void PrivacyFilter::runWindow(std::vector<int64_t> &paddedInputIds,
 
   auto forwardResult =
       BaseModel::forward({*inputIdsTensor, *attentionMaskTensor});
-  if (!forwardResult.ok()) {
-    throw RnExecutorchError(forwardResult.error(),
-                            "The model's forward function did not succeed. "
-                            "Ensure the model input is correct.");
-  }
+  CHECK_OK_OR_THROW_FORWARD_ERROR(forwardResult);
   auto &out = forwardResult.get();
   if (out.empty()) {
     throw RnExecutorchError(RnExecutorchErrorCode::UnknownError,

--- a/packages/react-native-executorch/common/rnexecutorch/models/semantic_segmentation/BaseSemanticSegmentation.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/semantic_segmentation/BaseSemanticSegmentation.cpp
@@ -63,11 +63,7 @@ BaseSemanticSegmentation::runInference(
                                                   preprocessed);
 
   auto forwardResult = BaseModel::forward(inputTensor);
-  if (!forwardResult.ok()) {
-    throw RnExecutorchError(forwardResult.error(),
-                            "The model's forward function did not succeed. "
-                            "Ensure the model input is correct.");
-  }
+  CHECK_OK_OR_THROW_FORWARD_ERROR(forwardResult);
 
   return computeResult(forwardResult->at(0).toTensor(), originalSize,
                        allClasses_, classesOfInterest, resize);

--- a/packages/react-native-executorch/common/rnexecutorch/models/style_transfer/StyleTransfer.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/style_transfer/StyleTransfer.cpp
@@ -42,11 +42,7 @@ cv::Mat StyleTransfer::runInference(cv::Mat image, cv::Size outputSize) {
       image_processing::getTensorFromMatrix(modelInputShape_, preprocessed);
 
   auto forwardResult = BaseModel::forward(inputTensor);
-  if (!forwardResult.ok()) {
-    throw RnExecutorchError(forwardResult.error(),
-                            "The model's forward function did not succeed. "
-                            "Ensure the model input is correct.");
-  }
+  CHECK_OK_OR_THROW_FORWARD_ERROR(forwardResult);
 
   cv::Mat mat = image_processing::getMatrixFromTensor(
       modelInputSize(), forwardResult->at(0).toTensor());

--- a/packages/react-native-executorch/common/rnexecutorch/models/text_to_image/UNet.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/text_to_image/UNet.cpp
@@ -27,11 +27,7 @@ std::vector<float> UNet::generate(std::vector<float> &latents, int32_t timestep,
 
   auto forwardResult =
       BaseModel::forward({latentsTensor, timestepTensor, embeddingsTensor});
-  if (!forwardResult.ok()) {
-    throw RnExecutorchError(forwardResult.error(),
-                            "The model's forward function did not succeed. "
-                            "Ensure the model input is correct.");
-  }
+  CHECK_OK_OR_THROW_FORWARD_ERROR(forwardResult);
 
   auto forwardResultTensor = forwardResult->at(0).toTensor();
   const auto *dataPtr = forwardResultTensor.const_data_ptr<float>();

--- a/packages/react-native-executorch/common/rnexecutorch/models/text_to_speech/kokoro/DurationPredictor.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/text_to_speech/kokoro/DurationPredictor.cpp
@@ -89,11 +89,7 @@ DurationPredictor::generate(std::span<const Token> tokens,
   auto results = execute(selectedMethod, {tokensTensor, textMaskTensor,
                                           voiceRefTensor, speedTensor});
 
-  if (!results.ok()) {
-    throw RnExecutorchError(results.error(),
-                            "The model's forward function did not succeed. "
-                            "Ensure the model input is correct.");
-  }
+  CHECK_OK_OR_THROW_FORWARD_ERROR(results);
 
   // Unpack the result
   auto predDurTensor = results->at(0).toTensor();
@@ -175,7 +171,7 @@ void DurationPredictor::scaleDurations(Tensor &durations, size_t nTokens,
         shrinking ? std::ceil(scaled) - scaled : scaled - std::floor(scaled);
 
     durationsPtr[i] = static_cast<int64_t>(shrinking ? std::ceil(scaled)
-                                                      : std::floor(scaled));
+                                                     : std::floor(scaled));
     scaledSum += durationsPtr[i];
 
     // Keeps the entries sorted by the remainders

--- a/packages/react-native-executorch/common/rnexecutorch/models/vertical_ocr/VerticalDetector.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/vertical_ocr/VerticalDetector.cpp
@@ -35,11 +35,7 @@ VerticalDetector::generate(const cv::Mat &inputImage, int32_t inputWidth) {
       constants::kNormalizationVariance);
   auto forwardResult = BaseModel::execute(methodName, {inputTensor});
 
-  if (!forwardResult.ok()) {
-    throw RnExecutorchError(forwardResult.error(),
-                            "The model's forward function did not succeed. "
-                            "Ensure the model input is correct.");
-  }
+  CHECK_OK_OR_THROW_FORWARD_ERROR(forwardResult);
   return postprocess(forwardResult->at(0).toTensor(),
                      calculateModelImageSize(inputWidth),
                      detectSingleCharacters);

--- a/packages/react-native-executorch/common/rnexecutorch/models/voice_activity_detection/VoiceActivityDetection.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/voice_activity_detection/VoiceActivityDetection.cpp
@@ -84,11 +84,7 @@ VoiceActivityDetection::generate(std::span<float> waveform) const {
         chunk.data(), {kModelInputMax, kPaddedWindowSize},
         executorch::aten::ScalarType::Float);
     auto forwardResult = BaseModel::forward(inputTensor);
-    if (!forwardResult.ok()) {
-      throw RnExecutorchError(forwardResult.error(),
-                              "The model's forward function did not succeed. "
-                              "Ensure the model input is correct.");
-    }
+    CHECK_OK_OR_THROW_FORWARD_ERROR(forwardResult);
     auto tensor = forwardResult->at(0).toTensor();
     startIdx = utils::getNonSpeechClassProbabilites(
         tensor, tensor.size(2), tensor.size(1), scores, startIdx);
@@ -100,11 +96,7 @@ VoiceActivityDetection::generate(std::span<float> waveform) const {
       lastChunk.data(), {lastChunkSize, kPaddedWindowSize},
       executorch::aten::ScalarType::Float);
   auto forwardResult = BaseModel::forward(inputTensor);
-  if (!forwardResult.ok()) {
-    throw RnExecutorchError(forwardResult.error(),
-                            "The model's forward function did not succeed. "
-                            "Ensure the model input is correct.");
-  }
+  CHECK_OK_OR_THROW_FORWARD_ERROR(forwardResult);
   auto tensor = forwardResult->at(0).toTensor();
   startIdx = utils::getNonSpeechClassProbabilites(tensor, tensor.size(2),
                                                   remainder, scores, startIdx);

--- a/packages/react-native-executorch/src/controllers/BaseOCRController.ts
+++ b/packages/react-native-executorch/src/controllers/BaseOCRController.ts
@@ -1,7 +1,11 @@
 import { Logger } from '../common/Logger';
 import { symbols } from '../constants/ocr/symbols';
 import { RnExecutorchErrorCode } from '../errors/ErrorCodes';
-import { RnExecutorchError, parseUnknownError } from '../errors/errorUtils';
+import {
+  RnExecutorchError,
+  parseUnknownError,
+  DOWNLOAD_INTERRUPTED_MESSAGE,
+} from '../errors/errorUtils';
 import { isPixelData } from '../modules/computer_vision/VisionModule';
 import { Frame, PixelData, ResourceSource } from '../types/common';
 import { OCRLanguage, OCRDetection } from '../types/ocr';
@@ -61,7 +65,7 @@ export abstract class BaseOCRController {
       if (paths === null || paths.length < 2) {
         throw new RnExecutorchError(
           RnExecutorchErrorCode.DownloadInterrupted,
-          'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.'
+          DOWNLOAD_INTERRUPTED_MESSAGE
         );
       }
       this.nativeModule = await this.loadNativeModule(

--- a/packages/react-native-executorch/src/controllers/BaseOCRController.ts
+++ b/packages/react-native-executorch/src/controllers/BaseOCRController.ts
@@ -1,11 +1,7 @@
 import { Logger } from '../common/Logger';
 import { symbols } from '../constants/ocr/symbols';
 import { RnExecutorchErrorCode } from '../errors/ErrorCodes';
-import {
-  RnExecutorchError,
-  parseUnknownError,
-  DOWNLOAD_INTERRUPTED_MESSAGE,
-} from '../errors/errorUtils';
+import { RnExecutorchError, parseUnknownError } from '../errors/errorUtils';
 import { isPixelData } from '../modules/computer_vision/VisionModule';
 import { Frame, PixelData, ResourceSource } from '../types/common';
 import { OCRLanguage, OCRDetection } from '../types/ocr';
@@ -63,10 +59,7 @@ export abstract class BaseOCRController {
         recognizerSource
       );
       if (paths === null || paths.length < 2) {
-        throw new RnExecutorchError(
-          RnExecutorchErrorCode.DownloadInterrupted,
-          DOWNLOAD_INTERRUPTED_MESSAGE
-        );
+        throw new RnExecutorchError(RnExecutorchErrorCode.DownloadInterrupted);
       }
       this.nativeModule = await this.loadNativeModule(
         paths[0]!,
@@ -128,16 +121,10 @@ export abstract class BaseOCRController {
     input: string | PixelData
   ): Promise<OCRDetection[]> => {
     if (!this.isReady) {
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.ModuleNotLoaded,
-        'The model is currently not loaded. Please load the model before calling forward().'
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModuleNotLoaded);
     }
     if (this.isGenerating) {
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.ModelGenerating,
-        'The model is currently generating. Please wait until previous model run is complete.'
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModelGenerating);
     }
 
     try {
@@ -164,10 +151,7 @@ export abstract class BaseOCRController {
 
   public delete() {
     if (this.isGenerating) {
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.ModelGenerating,
-        'The model is currently generating. Please wait until previous model run is complete.'
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModelGenerating);
     }
     if (this.nativeModule) {
       this.nativeModule.unload();

--- a/packages/react-native-executorch/src/controllers/LLMController.ts
+++ b/packages/react-native-executorch/src/controllers/LLMController.ts
@@ -13,7 +13,11 @@ import {
 } from '../types/llm';
 import { parseToolCall } from '../utils/llm';
 import { Logger } from '../common/Logger';
-import { RnExecutorchError, parseUnknownError } from '../errors/errorUtils';
+import {
+  RnExecutorchError,
+  parseUnknownError,
+  DOWNLOAD_INTERRUPTED_MESSAGE,
+} from '../errors/errorUtils';
 import { RnExecutorchErrorCode } from '../errors/ErrorCodes';
 
 export class LLMController {
@@ -115,7 +119,7 @@ export class LLMController {
       if (!tokenizerPath || !tokenizerConfigPath || !modelPath) {
         throw new RnExecutorchError(
           RnExecutorchErrorCode.DownloadInterrupted,
-          'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.'
+          DOWNLOAD_INTERRUPTED_MESSAGE
         );
       }
 
@@ -260,7 +264,7 @@ export class LLMController {
     if (this._isGenerating) {
       throw new RnExecutorchError(
         RnExecutorchErrorCode.ModelGenerating,
-        'You cannot delete the model now. You need ot interrupt it first.'
+        'You cannot delete the model now. You need to interrupt it first.'
       );
     }
 

--- a/packages/react-native-executorch/src/controllers/LLMController.ts
+++ b/packages/react-native-executorch/src/controllers/LLMController.ts
@@ -13,11 +13,7 @@ import {
 } from '../types/llm';
 import { parseToolCall } from '../utils/llm';
 import { Logger } from '../common/Logger';
-import {
-  RnExecutorchError,
-  parseUnknownError,
-  DOWNLOAD_INTERRUPTED_MESSAGE,
-} from '../errors/errorUtils';
+import { RnExecutorchError, parseUnknownError } from '../errors/errorUtils';
 import { RnExecutorchErrorCode } from '../errors/ErrorCodes';
 
 export class LLMController {
@@ -117,10 +113,7 @@ export class LLMController {
       const modelPath = modelResult?.[0];
 
       if (!tokenizerPath || !tokenizerConfigPath || !modelPath) {
-        throw new RnExecutorchError(
-          RnExecutorchErrorCode.DownloadInterrupted,
-          DOWNLOAD_INTERRUPTED_MESSAGE
-        );
+        throw new RnExecutorchError(RnExecutorchErrorCode.DownloadInterrupted);
       }
 
       this.tokenizerConfig = JSON.parse(
@@ -278,16 +271,10 @@ export class LLMController {
 
   public async forward(input: string, imagePaths?: string[]): Promise<string> {
     if (!this._isReady) {
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.ModuleNotLoaded,
-        'The model is currently not loaded. Please load the model before calling forward().'
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModuleNotLoaded);
     }
     if (this._isGenerating) {
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.ModelGenerating,
-        'The model is currently generating. Please wait until previous model run is complete.'
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModelGenerating);
     }
     try {
       this.isGeneratingCallback(true);

--- a/packages/react-native-executorch/src/errors/ErrorCodes.ts
+++ b/packages/react-native-executorch/src/errors/ErrorCodes.ts
@@ -35,7 +35,7 @@ export enum RnExecutorchErrorCode {
    */
   FileReadFailed = 114,
   /**
-   * Thrown when the size of model output is unexpected.
+   * Thrown when the size of model output is unexpected. If you're using your custom model with any of the pre-defined modules, please verify docs or source code for the expected model I/O contract.
    */
   InvalidModelOutput = 115,
   /**
@@ -59,7 +59,7 @@ export enum RnExecutorchErrorCode {
    */
   InvalidModelSource = 120,
   /**
-   * Thrown when the number of passed inputs to the model is different than the model metadata specifies.
+   * Thrown when the number of passed inputs to the model is different than the model metadata specifies. If you're using your custom model with any of the pre-defined modules, please verify docs or source code for the expected model I/O contract.
    */
   UnexpectedNumInputs = 121,
   /**

--- a/packages/react-native-executorch/src/errors/errorUtils.ts
+++ b/packages/react-native-executorch/src/errors/errorUtils.ts
@@ -1,6 +1,20 @@
 import { RnExecutorchErrorCode } from './ErrorCodes';
 
 /**
+ * Default user-facing message for error codes that are thrown verbatim from
+ * multiple call sites. When a code is listed here, the `message` argument to
+ * {@link RnExecutorchError} can be omitted.
+ */
+const DefaultErrorMessages: Partial<Record<RnExecutorchErrorCode, string>> = {
+  [RnExecutorchErrorCode.DownloadInterrupted]:
+    'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.',
+  [RnExecutorchErrorCode.ModelGenerating]:
+    'The model is currently generating. Please wait until previous model run is complete.',
+  [RnExecutorchErrorCode.ModuleNotLoaded]:
+    'The model is currently not loaded. Please load the model before calling forward().',
+};
+
+/**
  * Custom error class for React Native ExecuTorch errors.
  */
 export class RnExecutorchError extends Error {
@@ -14,21 +28,14 @@ export class RnExecutorchError extends Error {
    */
   public cause?: unknown;
 
-  constructor(code: number, message: string, cause?: unknown) {
-    super(message);
-    /**
-     * The error code representing the type of error.
-     */
+  constructor(code: RnExecutorchErrorCode, message?: string, cause?: unknown) {
+    const resolved =
+      message ??
+      DefaultErrorMessages[code] ??
+      `RnExecutorch error (code ${code})`;
+    super(resolved);
     this.code = code;
-
-    /**
-     * The message describing the error.
-     */
-    this.message = message;
-
-    /**
-     * The original cause of the error, if any.
-     */
+    this.message = resolved;
     this.cause = cause;
   }
 }
@@ -64,6 +71,3 @@ export function parseUnknownError(e: unknown): RnExecutorchError {
 
   return new RnExecutorchError(RnExecutorchErrorCode.Internal, String(e));
 }
-
-export const DOWNLOAD_INTERRUPTED_MESSAGE =
-  'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.';

--- a/packages/react-native-executorch/src/errors/errorUtils.ts
+++ b/packages/react-native-executorch/src/errors/errorUtils.ts
@@ -64,3 +64,6 @@ export function parseUnknownError(e: unknown): RnExecutorchError {
 
   return new RnExecutorchError(RnExecutorchErrorCode.Internal, String(e));
 }
+
+export const DOWNLOAD_INTERRUPTED_MESSAGE =
+  'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.';

--- a/packages/react-native-executorch/src/errors/errorUtils.ts
+++ b/packages/react-native-executorch/src/errors/errorUtils.ts
@@ -5,7 +5,7 @@ import { RnExecutorchErrorCode } from './ErrorCodes';
  * multiple call sites. When a code is listed here, the `message` argument to
  * {@link RnExecutorchError} can be omitted.
  */
-const DefaultErrorMessages: Partial<Record<RnExecutorchErrorCode, string>> = {
+const DefaultErrorMessages: { [code: number]: string } = {
   [RnExecutorchErrorCode.DownloadInterrupted]:
     'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.',
   [RnExecutorchErrorCode.ModelGenerating]:
@@ -20,19 +20,29 @@ const DefaultErrorMessages: Partial<Record<RnExecutorchErrorCode, string>> = {
 export class RnExecutorchError extends Error {
   /**
    * The error code representing the type of error.
+   *
+   * Typed as `RnExecutorchErrorCode | number` because codes are defined in
+   * `scripts/errors.config.ts` and generated into both the C++ and the TS
+   * sources. If those generated files drift, a code emitted on one side may
+   * not exist in the enum on the other and flows through as a raw number.
+   * Consumers switching on `code` should always include a `default` branch.
    */
-  public code: RnExecutorchErrorCode;
+  public code: RnExecutorchErrorCode | number;
 
   /**
    * The original cause of the error, if any.
    */
   public cause?: unknown;
 
-  constructor(code: RnExecutorchErrorCode, message?: string, cause?: unknown) {
+  constructor(
+    code: RnExecutorchErrorCode | number,
+    message?: string,
+    cause?: unknown
+  ) {
     const resolved =
       message ??
       DefaultErrorMessages[code] ??
-      `RnExecutorch error (code ${code})`;
+      `RnExecutorch error: ${RnExecutorchErrorCode[code] ?? `code ${code}`}`;
     super(resolved);
     this.code = code;
     this.message = resolved;

--- a/packages/react-native-executorch/src/hooks/computer_vision/useTextToImage.ts
+++ b/packages/react-native-executorch/src/hooks/computer_vision/useTextToImage.ts
@@ -84,15 +84,9 @@ export const useTextToImage = ({
     seed?: number
   ): Promise<string> => {
     if (!isReady || !moduleInstance)
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.ModuleNotLoaded,
-        'The model is currently not loaded. Please load the model before calling forward().'
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModuleNotLoaded);
     if (isGenerating)
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.ModelGenerating,
-        'The model is currently generating. Please wait until previous model run is complete.'
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModelGenerating);
     try {
       setIsGenerating(true);
       return await moduleInstance.forward(input, imageSize, numSteps, seed);

--- a/packages/react-native-executorch/src/hooks/natural_language_processing/useSpeechToText.ts
+++ b/packages/react-native-executorch/src/hooks/natural_language_processing/useSpeechToText.ts
@@ -87,10 +87,7 @@ export const useSpeechToText = ({
         );
       }
       if (isGenerating) {
-        throw new RnExecutorchError(
-          RnExecutorchErrorCode.ModelGenerating,
-          'The model is currently generating. Please wait until previous model run is complete.'
-        );
+        throw new RnExecutorchError(RnExecutorchErrorCode.ModelGenerating);
       }
 
       setIsGenerating(true);
@@ -119,10 +116,7 @@ export const useSpeechToText = ({
         );
       }
       if (isGenerating) {
-        throw new RnExecutorchError(
-          RnExecutorchErrorCode.ModelGenerating,
-          'The model is currently generating. Please wait until previous model run is complete.'
-        );
+        throw new RnExecutorchError(RnExecutorchErrorCode.ModelGenerating);
       }
 
       setIsGenerating(true);

--- a/packages/react-native-executorch/src/hooks/natural_language_processing/useTextToSpeech.ts
+++ b/packages/react-native-executorch/src/hooks/natural_language_processing/useTextToSpeech.ts
@@ -80,10 +80,7 @@ export const useTextToSpeech = ({
           `The model is currently not loaded. Please load the model before calling ${methodName}().`
         );
       if (isGenerating)
-        throw new RnExecutorchError(
-          RnExecutorchErrorCode.ModelGenerating,
-          'The model is currently generating. Please wait until previous model run is complete.'
-        );
+        throw new RnExecutorchError(RnExecutorchErrorCode.ModelGenerating);
       return moduleInstance;
     },
     [isReady, isGenerating, moduleInstance]

--- a/packages/react-native-executorch/src/hooks/natural_language_processing/useTokenizer.ts
+++ b/packages/react-native-executorch/src/hooks/natural_language_processing/useTokenizer.ts
@@ -46,10 +46,7 @@ export const useTokenizer = ({
           'The model is currently not loaded. Please load the model before calling this function.'
         );
       if (isGenerating)
-        throw new RnExecutorchError(
-          RnExecutorchErrorCode.ModelGenerating,
-          'The model is currently generating. Please wait until previous model run is complete.'
-        );
+        throw new RnExecutorchError(RnExecutorchErrorCode.ModelGenerating);
       try {
         setIsGenerating(true);
         return fn.apply(tokenizerInstance, args);

--- a/packages/react-native-executorch/src/hooks/useModule.ts
+++ b/packages/react-native-executorch/src/hooks/useModule.ts
@@ -86,15 +86,9 @@ export const useModule = <
 
   const forward = async (...input: ForwardArgs): Promise<ForwardReturn> => {
     if (!isReady)
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.ModuleNotLoaded,
-        'The model is currently not loaded. Please load the model before calling forward().'
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModuleNotLoaded);
     if (isGenerating)
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.ModelGenerating,
-        'The model is currently generating. Please wait until previous model run is complete.'
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModelGenerating);
     try {
       setIsGenerating(true);
       return await moduleInstance.forward(...input);

--- a/packages/react-native-executorch/src/hooks/useModuleFactory.ts
+++ b/packages/react-native-executorch/src/hooks/useModuleFactory.ts
@@ -76,16 +76,10 @@ export function useModuleFactory<M extends Deletable, Config>({
 
   const runForward = async <R>(fn: (instance: M) => Promise<R>): Promise<R> => {
     if (!isReady || !instance) {
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.ModuleNotLoaded,
-        'The model is currently not loaded. Please load the model before calling forward().'
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModuleNotLoaded);
     }
     if (isGenerating) {
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.ModelGenerating,
-        'The model is currently generating. Please wait until previous model run is complete.'
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModelGenerating);
     }
     try {
       setIsGenerating(true);

--- a/packages/react-native-executorch/src/modules/computer_vision/ClassificationModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/ClassificationModule.ts
@@ -10,6 +10,7 @@ import {
   ResolveLabels as ResolveLabelsFor,
   VisionLabeledModule,
 } from './VisionLabeledModule';
+import { buildLabelArray } from '../../utils/labelUtils';
 
 const ModelConfigs = {
   'efficientnet-v2-s': {
@@ -71,13 +72,7 @@ export class ClassificationModule<
     ] as ClassificationConfig<LabelEnum>;
     const normMean = preprocessorConfig?.normMean ?? [];
     const normStd = preprocessorConfig?.normStd ?? [];
-    const allLabelNames: string[] = [];
-    for (const [name, value] of Object.entries(labelMap)) {
-      if (typeof value === 'number') allLabelNames[value] = name;
-    }
-    for (let i = 0; i < allLabelNames.length; i++) {
-      if (allLabelNames[i] == null) allLabelNames[i] = '';
-    }
+    const allLabelNames = buildLabelArray(labelMap);
     const modelPath = await fetchModelPath(modelSource, onDownloadProgress);
     const nativeModule = await global.loadClassification(
       modelPath,
@@ -117,13 +112,7 @@ export class ClassificationModule<
   ): Promise<ClassificationModule<L>> {
     const normMean = config.preprocessorConfig?.normMean ?? [];
     const normStd = config.preprocessorConfig?.normStd ?? [];
-    const allLabelNames: string[] = [];
-    for (const [name, value] of Object.entries(config.labelMap)) {
-      if (typeof value === 'number') allLabelNames[value] = name;
-    }
-    for (let i = 0; i < allLabelNames.length; i++) {
-      if (allLabelNames[i] == null) allLabelNames[i] = '';
-    }
+    const allLabelNames = buildLabelArray(config.labelMap);
     const modelPath = await fetchModelPath(modelSource, onDownloadProgress);
     const nativeModule = await global.loadClassification(
       modelPath,

--- a/packages/react-native-executorch/src/modules/computer_vision/ImageEmbeddingsModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/ImageEmbeddingsModule.ts
@@ -2,11 +2,7 @@ import { ResourceFetcher } from '../../utils/ResourceFetcher';
 import { ImageEmbeddingsModelName } from '../../types/imageEmbeddings';
 import { ResourceSource, PixelData } from '../../types/common';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
-import {
-  parseUnknownError,
-  RnExecutorchError,
-  DOWNLOAD_INTERRUPTED_MESSAGE,
-} from '../../errors/errorUtils';
+import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
 import { Logger } from '../../common/Logger';
 import { VisionModule } from './VisionModule';
 
@@ -39,10 +35,7 @@ export class ImageEmbeddingsModule extends VisionModule<Float32Array> {
       );
 
       if (!paths?.[0]) {
-        throw new RnExecutorchError(
-          RnExecutorchErrorCode.DownloadInterrupted,
-          DOWNLOAD_INTERRUPTED_MESSAGE
-        );
+        throw new RnExecutorchError(RnExecutorchErrorCode.DownloadInterrupted);
       }
 
       return new ImageEmbeddingsModule(

--- a/packages/react-native-executorch/src/modules/computer_vision/ImageEmbeddingsModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/ImageEmbeddingsModule.ts
@@ -2,7 +2,11 @@ import { ResourceFetcher } from '../../utils/ResourceFetcher';
 import { ImageEmbeddingsModelName } from '../../types/imageEmbeddings';
 import { ResourceSource, PixelData } from '../../types/common';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
-import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
+import {
+  parseUnknownError,
+  RnExecutorchError,
+  DOWNLOAD_INTERRUPTED_MESSAGE,
+} from '../../errors/errorUtils';
 import { Logger } from '../../common/Logger';
 import { VisionModule } from './VisionModule';
 
@@ -37,7 +41,7 @@ export class ImageEmbeddingsModule extends VisionModule<Float32Array> {
       if (!paths?.[0]) {
         throw new RnExecutorchError(
           RnExecutorchErrorCode.DownloadInterrupted,
-          'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.'
+          DOWNLOAD_INTERRUPTED_MESSAGE
         );
       }
 

--- a/packages/react-native-executorch/src/modules/computer_vision/ObjectDetectionModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/ObjectDetectionModule.ts
@@ -244,10 +244,7 @@ export class ObjectDetectionModule<
     options?: ObjectDetectionOptions<ResolveLabels<T>>
   ): Promise<Detection<ResolveLabels<T>>[]> {
     if (this.nativeModule == null) {
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.ModuleNotLoaded,
-        'The model is currently not loaded. Please load the model before calling forward().'
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModuleNotLoaded);
     }
 
     // Extract parameters with defaults from config

--- a/packages/react-native-executorch/src/modules/computer_vision/ObjectDetectionModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/ObjectDetectionModule.ts
@@ -13,6 +13,7 @@ import {
 } from '../../types/objectDetection';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
 import { RnExecutorchError } from '../../errors/errorUtils';
+import { buildLabelArray } from '../../utils/labelUtils';
 import {
   CocoLabel,
   CocoLabelYolo,
@@ -114,13 +115,7 @@ export class ObjectDetectionModule<
     const { labelMap, preprocessorConfig } = modelConfig;
     const normMean = preprocessorConfig?.normMean ?? [];
     const normStd = preprocessorConfig?.normStd ?? [];
-    const allLabelNames: string[] = [];
-    for (const [name, value] of Object.entries(labelMap)) {
-      if (typeof value === 'number') allLabelNames[value] = name;
-    }
-    for (let i = 0; i < allLabelNames.length; i++) {
-      if (allLabelNames[i] == null) allLabelNames[i] = '';
-    }
+    const allLabelNames = buildLabelArray(labelMap);
     const modelPath = await fetchModelPath(modelSource, onDownloadProgress);
     const nativeModule = await global.loadObjectDetection(
       modelPath,
@@ -344,13 +339,7 @@ export class ObjectDetectionModule<
   ): Promise<ObjectDetectionModule<L>> {
     const normMean = config.preprocessorConfig?.normMean ?? [];
     const normStd = config.preprocessorConfig?.normStd ?? [];
-    const allLabelNames: string[] = [];
-    for (const [name, value] of Object.entries(config.labelMap)) {
-      if (typeof value === 'number') allLabelNames[value] = name;
-    }
-    for (let i = 0; i < allLabelNames.length; i++) {
-      if (allLabelNames[i] == null) allLabelNames[i] = '';
-    }
+    const allLabelNames = buildLabelArray(config.labelMap);
     const modelPath = await fetchModelPath(modelSource, onDownloadProgress);
     const nativeModule = await global.loadObjectDetection(
       modelPath,

--- a/packages/react-native-executorch/src/modules/computer_vision/StyleTransferModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/StyleTransferModule.ts
@@ -1,11 +1,7 @@
 import { ResourceFetcher } from '../../utils/ResourceFetcher';
 import { StyleTransferModelName } from '../../types/styleTransfer';
 import { ResourceSource, PixelData } from '../../types/common';
-import {
-  parseUnknownError,
-  RnExecutorchError,
-  DOWNLOAD_INTERRUPTED_MESSAGE,
-} from '../../errors/errorUtils';
+import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
 import { Logger } from '../../common/Logger';
 import { VisionModule } from './VisionModule';
@@ -39,10 +35,7 @@ export class StyleTransferModule extends VisionModule<PixelData | string> {
       );
 
       if (!paths?.[0]) {
-        throw new RnExecutorchError(
-          RnExecutorchErrorCode.DownloadInterrupted,
-          DOWNLOAD_INTERRUPTED_MESSAGE
-        );
+        throw new RnExecutorchError(RnExecutorchErrorCode.DownloadInterrupted);
       }
 
       return new StyleTransferModule(await global.loadStyleTransfer(paths[0]));

--- a/packages/react-native-executorch/src/modules/computer_vision/StyleTransferModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/StyleTransferModule.ts
@@ -1,7 +1,11 @@
 import { ResourceFetcher } from '../../utils/ResourceFetcher';
 import { StyleTransferModelName } from '../../types/styleTransfer';
 import { ResourceSource, PixelData } from '../../types/common';
-import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
+import {
+  parseUnknownError,
+  RnExecutorchError,
+  DOWNLOAD_INTERRUPTED_MESSAGE,
+} from '../../errors/errorUtils';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
 import { Logger } from '../../common/Logger';
 import { VisionModule } from './VisionModule';
@@ -37,7 +41,7 @@ export class StyleTransferModule extends VisionModule<PixelData | string> {
       if (!paths?.[0]) {
         throw new RnExecutorchError(
           RnExecutorchErrorCode.DownloadInterrupted,
-          'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.'
+          DOWNLOAD_INTERRUPTED_MESSAGE
         );
       }
 

--- a/packages/react-native-executorch/src/modules/computer_vision/TextToImageModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/TextToImageModule.ts
@@ -5,11 +5,7 @@ import { BaseModule } from '../BaseModule';
 
 import { PNG } from 'pngjs/browser';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
-import {
-  parseUnknownError,
-  RnExecutorchError,
-  DOWNLOAD_INTERRUPTED_MESSAGE,
-} from '../../errors/errorUtils';
+import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
 import { Logger } from '../../common/Logger';
 
 /**
@@ -119,10 +115,7 @@ export class TextToImageModule extends BaseModule {
       model.decoderSource
     );
     if (!results || results.length !== 5) {
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.DownloadInterrupted,
-        DOWNLOAD_INTERRUPTED_MESSAGE
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.DownloadInterrupted);
     }
     const [tokenizerPath, schedulerPath, encoderPath, unetPath, decoderPath] =
       results;
@@ -134,10 +127,7 @@ export class TextToImageModule extends BaseModule {
       !unetPath ||
       !decoderPath
     ) {
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.DownloadInterrupted,
-        DOWNLOAD_INTERRUPTED_MESSAGE
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.DownloadInterrupted);
     }
 
     const schedulerJson = await ResourceFetcher.fs.readAsString(schedulerPath);

--- a/packages/react-native-executorch/src/modules/computer_vision/TextToImageModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/TextToImageModule.ts
@@ -5,7 +5,11 @@ import { BaseModule } from '../BaseModule';
 
 import { PNG } from 'pngjs/browser';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
-import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
+import {
+  parseUnknownError,
+  RnExecutorchError,
+  DOWNLOAD_INTERRUPTED_MESSAGE,
+} from '../../errors/errorUtils';
 import { Logger } from '../../common/Logger';
 
 /**
@@ -117,7 +121,7 @@ export class TextToImageModule extends BaseModule {
     if (!results || results.length !== 5) {
       throw new RnExecutorchError(
         RnExecutorchErrorCode.DownloadInterrupted,
-        'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.'
+        DOWNLOAD_INTERRUPTED_MESSAGE
       );
     }
     const [tokenizerPath, schedulerPath, encoderPath, unetPath, decoderPath] =
@@ -132,7 +136,7 @@ export class TextToImageModule extends BaseModule {
     ) {
       throw new RnExecutorchError(
         RnExecutorchErrorCode.DownloadInterrupted,
-        'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.'
+        DOWNLOAD_INTERRUPTED_MESSAGE
       );
     }
 

--- a/packages/react-native-executorch/src/modules/computer_vision/VisionModule.ts
+++ b/packages/react-native-executorch/src/modules/computer_vision/VisionModule.ts
@@ -131,10 +131,7 @@ export abstract class VisionModule<TOutput> extends BaseModule {
    */
   async forward(input: string | PixelData, ...args: any[]): Promise<TOutput> {
     if (this.nativeModule == null)
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.ModuleNotLoaded,
-        'The model is currently not loaded. Please load the model before calling forward().'
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModuleNotLoaded);
     // Type detection and routing
     if (typeof input === 'string') {
       return await this.nativeModule.generateFromString(input, ...args);

--- a/packages/react-native-executorch/src/modules/general/ExecutorchModule.ts
+++ b/packages/react-native-executorch/src/modules/general/ExecutorchModule.ts
@@ -3,7 +3,11 @@ import { BaseModule } from '../BaseModule';
 import { ResourceSource } from '../../types/common';
 import { ResourceFetcher } from '../../utils/ResourceFetcher';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
-import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
+import {
+  parseUnknownError,
+  RnExecutorchError,
+  DOWNLOAD_INTERRUPTED_MESSAGE,
+} from '../../errors/errorUtils';
 import { Logger } from '../../common/Logger';
 
 /**
@@ -29,7 +33,7 @@ export class ExecutorchModule extends BaseModule {
       if (!paths?.[0]) {
         throw new RnExecutorchError(
           RnExecutorchErrorCode.DownloadInterrupted,
-          'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.'
+          DOWNLOAD_INTERRUPTED_MESSAGE
         );
       }
       this.nativeModule = await global.loadExecutorchModule(paths[0]);

--- a/packages/react-native-executorch/src/modules/general/ExecutorchModule.ts
+++ b/packages/react-native-executorch/src/modules/general/ExecutorchModule.ts
@@ -3,11 +3,7 @@ import { BaseModule } from '../BaseModule';
 import { ResourceSource } from '../../types/common';
 import { ResourceFetcher } from '../../utils/ResourceFetcher';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
-import {
-  parseUnknownError,
-  RnExecutorchError,
-  DOWNLOAD_INTERRUPTED_MESSAGE,
-} from '../../errors/errorUtils';
+import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
 import { Logger } from '../../common/Logger';
 
 /**
@@ -31,10 +27,7 @@ export class ExecutorchModule extends BaseModule {
         modelSource
       );
       if (!paths?.[0]) {
-        throw new RnExecutorchError(
-          RnExecutorchErrorCode.DownloadInterrupted,
-          DOWNLOAD_INTERRUPTED_MESSAGE
-        );
+        throw new RnExecutorchError(RnExecutorchErrorCode.DownloadInterrupted);
       }
       this.nativeModule = await global.loadExecutorchModule(paths[0]);
     } catch (error) {

--- a/packages/react-native-executorch/src/modules/natural_language_processing/PrivacyFilterModule.ts
+++ b/packages/react-native-executorch/src/modules/natural_language_processing/PrivacyFilterModule.ts
@@ -7,7 +7,11 @@ import {
 import { ResourceFetcher } from '../../utils/ResourceFetcher';
 import { BaseModule } from '../BaseModule';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
-import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
+import {
+  parseUnknownError,
+  RnExecutorchError,
+  DOWNLOAD_INTERRUPTED_MESSAGE,
+} from '../../errors/errorUtils';
 import { Logger } from '../../common/Logger';
 
 /**
@@ -64,7 +68,7 @@ export class PrivacyFilterModule extends BaseModule {
       if (!modelPath || !tokenizerPath) {
         throw new RnExecutorchError(
           RnExecutorchErrorCode.DownloadInterrupted,
-          'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.'
+          DOWNLOAD_INTERRUPTED_MESSAGE
         );
       }
       const labels = Array.from(namedSources.labelNames);

--- a/packages/react-native-executorch/src/modules/natural_language_processing/PrivacyFilterModule.ts
+++ b/packages/react-native-executorch/src/modules/natural_language_processing/PrivacyFilterModule.ts
@@ -7,11 +7,7 @@ import {
 import { ResourceFetcher } from '../../utils/ResourceFetcher';
 import { BaseModule } from '../BaseModule';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
-import {
-  parseUnknownError,
-  RnExecutorchError,
-  DOWNLOAD_INTERRUPTED_MESSAGE,
-} from '../../errors/errorUtils';
+import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
 import { Logger } from '../../common/Logger';
 
 /**
@@ -66,10 +62,7 @@ export class PrivacyFilterModule extends BaseModule {
       const modelPath = modelResult?.[0];
       const tokenizerPath = tokenizerResult?.[0];
       if (!modelPath || !tokenizerPath) {
-        throw new RnExecutorchError(
-          RnExecutorchErrorCode.DownloadInterrupted,
-          DOWNLOAD_INTERRUPTED_MESSAGE
-        );
+        throw new RnExecutorchError(RnExecutorchErrorCode.DownloadInterrupted);
       }
       const labels = Array.from(namedSources.labelNames);
       const biases = packViterbiBiases(namedSources.viterbiBiases);

--- a/packages/react-native-executorch/src/modules/natural_language_processing/SpeechToTextModule.ts
+++ b/packages/react-native-executorch/src/modules/natural_language_processing/SpeechToTextModule.ts
@@ -7,11 +7,7 @@ import {
 import { ResourceFetcher } from '../../utils/ResourceFetcher';
 import { ResourceSource } from '../../types/common';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
-import {
-  RnExecutorchError,
-  parseUnknownError,
-  DOWNLOAD_INTERRUPTED_MESSAGE,
-} from '../../errors/errorUtils';
+import { RnExecutorchError, parseUnknownError } from '../../errors/errorUtils';
 import { Logger } from '../../common/Logger';
 
 /**
@@ -104,10 +100,7 @@ export class SpeechToTextModule {
       modelPromise,
     ]);
     if (!modelSources?.[0] || !tokenizerSources?.[0]) {
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.DownloadInterrupted,
-        DOWNLOAD_INTERRUPTED_MESSAGE
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.DownloadInterrupted);
     }
     // Currently only Whisper architecture is supported
     return await global.loadSpeechToText(

--- a/packages/react-native-executorch/src/modules/natural_language_processing/SpeechToTextModule.ts
+++ b/packages/react-native-executorch/src/modules/natural_language_processing/SpeechToTextModule.ts
@@ -7,7 +7,11 @@ import {
 import { ResourceFetcher } from '../../utils/ResourceFetcher';
 import { ResourceSource } from '../../types/common';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
-import { RnExecutorchError, parseUnknownError } from '../../errors/errorUtils';
+import {
+  RnExecutorchError,
+  parseUnknownError,
+  DOWNLOAD_INTERRUPTED_MESSAGE,
+} from '../../errors/errorUtils';
 import { Logger } from '../../common/Logger';
 
 /**
@@ -102,7 +106,7 @@ export class SpeechToTextModule {
     if (!modelSources?.[0] || !tokenizerSources?.[0]) {
       throw new RnExecutorchError(
         RnExecutorchErrorCode.DownloadInterrupted,
-        'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.'
+        DOWNLOAD_INTERRUPTED_MESSAGE
       );
     }
     // Currently only Whisper architecture is supported
@@ -263,13 +267,13 @@ export class SpeechToTextModule {
   private validateOptions(options: DecodingOptions) {
     if (!this.modelConfig.isMultilingual && options.language) {
       throw new RnExecutorchError(
-        RnExecutorchErrorCode.InvalidConfig,
+        RnExecutorchErrorCode.MultilingualConfiguration,
         'Model is not multilingual, cannot set language'
       );
     }
     if (this.modelConfig.isMultilingual && !options.language) {
       throw new RnExecutorchError(
-        RnExecutorchErrorCode.InvalidConfig,
+        RnExecutorchErrorCode.MultilingualConfiguration,
         'Model is multilingual, provide a language'
       );
     }

--- a/packages/react-native-executorch/src/modules/natural_language_processing/TextEmbeddingsModule.ts
+++ b/packages/react-native-executorch/src/modules/natural_language_processing/TextEmbeddingsModule.ts
@@ -3,11 +3,7 @@ import { TextEmbeddingsModelName } from '../../types/textEmbeddings';
 import { ResourceFetcher } from '../../utils/ResourceFetcher';
 import { BaseModule } from '../BaseModule';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
-import {
-  parseUnknownError,
-  RnExecutorchError,
-  DOWNLOAD_INTERRUPTED_MESSAGE,
-} from '../../errors/errorUtils';
+import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
 import { Logger } from '../../common/Logger';
 
 /**
@@ -42,10 +38,7 @@ export class TextEmbeddingsModule extends BaseModule {
       const modelPath = modelResult?.[0];
       const tokenizerPath = tokenizerResult?.[0];
       if (!modelPath || !tokenizerPath) {
-        throw new RnExecutorchError(
-          RnExecutorchErrorCode.DownloadInterrupted,
-          DOWNLOAD_INTERRUPTED_MESSAGE
-        );
+        throw new RnExecutorchError(RnExecutorchErrorCode.DownloadInterrupted);
       }
       return new TextEmbeddingsModule(
         await global.loadTextEmbeddings(modelPath, tokenizerPath)
@@ -88,10 +81,7 @@ export class TextEmbeddingsModule extends BaseModule {
    */
   async forward(input: string): Promise<Float32Array> {
     if (this.nativeModule == null)
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.ModuleNotLoaded,
-        'The model is currently not loaded. Please load the model before calling forward().'
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModuleNotLoaded);
     return new Float32Array(await this.nativeModule.generate(input));
   }
 }

--- a/packages/react-native-executorch/src/modules/natural_language_processing/TextEmbeddingsModule.ts
+++ b/packages/react-native-executorch/src/modules/natural_language_processing/TextEmbeddingsModule.ts
@@ -3,7 +3,11 @@ import { TextEmbeddingsModelName } from '../../types/textEmbeddings';
 import { ResourceFetcher } from '../../utils/ResourceFetcher';
 import { BaseModule } from '../BaseModule';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
-import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
+import {
+  parseUnknownError,
+  RnExecutorchError,
+  DOWNLOAD_INTERRUPTED_MESSAGE,
+} from '../../errors/errorUtils';
 import { Logger } from '../../common/Logger';
 
 /**
@@ -40,7 +44,7 @@ export class TextEmbeddingsModule extends BaseModule {
       if (!modelPath || !tokenizerPath) {
         throw new RnExecutorchError(
           RnExecutorchErrorCode.DownloadInterrupted,
-          'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.'
+          DOWNLOAD_INTERRUPTED_MESSAGE
         );
       }
       return new TextEmbeddingsModule(

--- a/packages/react-native-executorch/src/modules/natural_language_processing/TextToSpeechModule.ts
+++ b/packages/react-native-executorch/src/modules/natural_language_processing/TextToSpeechModule.ts
@@ -152,7 +152,7 @@ export class TextToSpeechModule {
     const queue: Float32Array[] = [];
 
     let waiter: (() => void) | null = null;
-    let error: unknown;
+    let error: RnExecutorchError | undefined;
     let nativeStreamFinished = false;
 
     this.isStreaming = true;
@@ -175,7 +175,7 @@ export class TextToSpeechModule {
         nativeStreamFinished = true;
         wake();
       } catch (e) {
-        error = e;
+        error = parseUnknownError(e);
         nativeStreamFinished = true;
         wake();
       }
@@ -208,7 +208,7 @@ export class TextToSpeechModule {
     const queue: Float32Array[] = [];
 
     let waiter: (() => void) | null = null;
-    let error: unknown;
+    let error: RnExecutorchError | undefined;
     let nativeStreamFinished = false;
 
     const wake = () => {
@@ -229,7 +229,7 @@ export class TextToSpeechModule {
         nativeStreamFinished = true;
         wake();
       } catch (e) {
-        error = e;
+        error = parseUnknownError(e);
         nativeStreamFinished = true;
         wake();
       }

--- a/packages/react-native-executorch/src/modules/natural_language_processing/TokenizerModule.ts
+++ b/packages/react-native-executorch/src/modules/natural_language_processing/TokenizerModule.ts
@@ -1,10 +1,6 @@
 import { ResourceSource } from '../../types/common';
 import { ResourceFetcher } from '../../utils/ResourceFetcher';
-import {
-  parseUnknownError,
-  RnExecutorchError,
-  DOWNLOAD_INTERRUPTED_MESSAGE,
-} from '../../errors/errorUtils';
+import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
 import { Logger } from '../../common/Logger';
 
@@ -35,10 +31,7 @@ export class TokenizerModule {
       );
       const path = paths?.[0];
       if (!path) {
-        throw new RnExecutorchError(
-          RnExecutorchErrorCode.DownloadInterrupted,
-          DOWNLOAD_INTERRUPTED_MESSAGE
-        );
+        throw new RnExecutorchError(RnExecutorchErrorCode.DownloadInterrupted);
       }
       this.nativeModule = await global.loadTokenizerModule(path);
     } catch (error) {

--- a/packages/react-native-executorch/src/modules/natural_language_processing/TokenizerModule.ts
+++ b/packages/react-native-executorch/src/modules/natural_language_processing/TokenizerModule.ts
@@ -1,6 +1,10 @@
 import { ResourceSource } from '../../types/common';
 import { ResourceFetcher } from '../../utils/ResourceFetcher';
-import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
+import {
+  parseUnknownError,
+  RnExecutorchError,
+  DOWNLOAD_INTERRUPTED_MESSAGE,
+} from '../../errors/errorUtils';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
 import { Logger } from '../../common/Logger';
 
@@ -33,7 +37,7 @@ export class TokenizerModule {
       if (!path) {
         throw new RnExecutorchError(
           RnExecutorchErrorCode.DownloadInterrupted,
-          'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.'
+          DOWNLOAD_INTERRUPTED_MESSAGE
         );
       }
       this.nativeModule = await global.loadTokenizerModule(path);

--- a/packages/react-native-executorch/src/modules/natural_language_processing/VADModule.ts
+++ b/packages/react-native-executorch/src/modules/natural_language_processing/VADModule.ts
@@ -3,7 +3,11 @@ import { ResourceSource } from '../../types/common';
 import { Segment, VADModelName } from '../../types/vad';
 import { BaseModule } from '../BaseModule';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
-import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
+import {
+  parseUnknownError,
+  RnExecutorchError,
+  DOWNLOAD_INTERRUPTED_MESSAGE,
+} from '../../errors/errorUtils';
 import { Logger } from '../../common/Logger';
 
 /**
@@ -34,7 +38,7 @@ export class VADModule extends BaseModule {
       if (!paths?.[0]) {
         throw new RnExecutorchError(
           RnExecutorchErrorCode.DownloadInterrupted,
-          'The download has been interrupted. As a result, not every file was downloaded. Please retry the download.'
+          DOWNLOAD_INTERRUPTED_MESSAGE
         );
       }
       return new VADModule(await global.loadVAD(paths[0]));

--- a/packages/react-native-executorch/src/modules/natural_language_processing/VADModule.ts
+++ b/packages/react-native-executorch/src/modules/natural_language_processing/VADModule.ts
@@ -3,11 +3,7 @@ import { ResourceSource } from '../../types/common';
 import { Segment, VADModelName } from '../../types/vad';
 import { BaseModule } from '../BaseModule';
 import { RnExecutorchErrorCode } from '../../errors/ErrorCodes';
-import {
-  parseUnknownError,
-  RnExecutorchError,
-  DOWNLOAD_INTERRUPTED_MESSAGE,
-} from '../../errors/errorUtils';
+import { parseUnknownError, RnExecutorchError } from '../../errors/errorUtils';
 import { Logger } from '../../common/Logger';
 
 /**
@@ -36,10 +32,7 @@ export class VADModule extends BaseModule {
         namedSources.modelSource
       );
       if (!paths?.[0]) {
-        throw new RnExecutorchError(
-          RnExecutorchErrorCode.DownloadInterrupted,
-          DOWNLOAD_INTERRUPTED_MESSAGE
-        );
+        throw new RnExecutorchError(RnExecutorchErrorCode.DownloadInterrupted);
       }
       return new VADModule(await global.loadVAD(paths[0]));
     } catch (error) {
@@ -74,10 +67,7 @@ export class VADModule extends BaseModule {
    */
   async forward(waveform: Float32Array): Promise<Segment[]> {
     if (this.nativeModule == null)
-      throw new RnExecutorchError(
-        RnExecutorchErrorCode.ModuleNotLoaded,
-        'The model is currently not loaded. Please load the model before calling forward().'
-      );
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModuleNotLoaded);
     return await this.nativeModule.generate(waveform);
   }
 }

--- a/packages/react-native-executorch/src/utils/labelUtils.ts
+++ b/packages/react-native-executorch/src/utils/labelUtils.ts
@@ -1,0 +1,12 @@
+export function buildLabelArray(
+  labelMap: Record<string, number | string>
+): string[] {
+  const labels: string[] = [];
+  for (const [name, value] of Object.entries(labelMap)) {
+    if (typeof value === 'number') labels[value] = name;
+  }
+  for (let i = 0; i < labels.length; i++) {
+    if (labels[i] == null) labels[i] = '';
+  }
+  return labels;
+}

--- a/scripts/errors.config.ts
+++ b/scripts/errors.config.ts
@@ -38,8 +38,7 @@ export const errorDefinitions = {
    */
   FileReadFailed: 0x72,
   /*
-   * Thrown when the size of model output is unexpected.
-   */
+   * Thrown when the size of model output is unexpected. If you're using your custom model with any of the pre-defined modeules, please verify docs or source code for the expected model I/O contract.
   InvalidModelOutput: 0x73,
   /*
    * Thrown when the dimensions of input tensors don't match the model's expected dimensions.
@@ -62,7 +61,7 @@ export const errorDefinitions = {
    */
   InvalidModelSource: 0x78,
   /*
-   * Thrown when the number of passed inputs to the model is different than the model metadata specifies.
+   * Thrown when the number of passed inputs to the model is different than the model metadata specifies. If you're using your custom model with any of the pre-defined modeules, please verify docs or source code for the expected model I/O contract.
    */
   UnexpectedNumInputs: 0x79,
   /*

--- a/scripts/errors.config.ts
+++ b/scripts/errors.config.ts
@@ -38,7 +38,8 @@ export const errorDefinitions = {
    */
   FileReadFailed: 0x72,
   /*
-   * Thrown when the size of model output is unexpected. If you're using your custom model with any of the pre-defined modeules, please verify docs or source code for the expected model I/O contract.
+   * Thrown when the size of model output is unexpected. If you're using your custom model with any of the pre-defined modules, please verify docs or source code for the expected model I/O contract.
+   */
   InvalidModelOutput: 0x73,
   /*
    * Thrown when the dimensions of input tensors don't match the model's expected dimensions.
@@ -61,7 +62,7 @@ export const errorDefinitions = {
    */
   InvalidModelSource: 0x78,
   /*
-   * Thrown when the number of passed inputs to the model is different than the model metadata specifies. If you're using your custom model with any of the pre-defined modeules, please verify docs or source code for the expected model I/O contract.
+   * Thrown when the number of passed inputs to the model is different than the model metadata specifies. If you're using your custom model with any of the pre-defined modules, please verify docs or source code for the expected model I/O contract.
    */
   UnexpectedNumInputs: 0x79,
   /*


### PR DESCRIPTION
## Description

I decided that defining a specific error for not meeting the contract is probably an overkill, as the input layer can be ine, output layer can be wrong and we already have the code that can distinguish between those. I added comments and I refactored the both native and JS error handling a bit
It also fixes a few typos & bugs

### Introduces a breaking change?

- [ ] Yes
- [ ] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

- Trigger a download interruption (kill network mid-fetch, or pass a bad URL) for any model — confirm thrown error has code DownloadInterrupted and the expected "The download has been interrupted..." message
  - Call forward() on a module before load() resolves — confirm code ModuleNotLoaded and "...before calling forward()." message
  - Kick off a second forward() while the first is still running — confirm code ModelGenerating and "...wait until previous model run is complete." message
  - Hit one of the overridden sites to make sure custom messages still flow through: e.g. LLMController.generate() with empty messages array (should say "Messages array is empty!", code InvalidUserInput), or
  BaseOCRController.internalLoad with an unsupported language ("...not supported. Please try using other language.", code LanguageNotSupported)
  - Spot-check a couple modules across categories — LLM, OCR, SpeechToText, VAD, TextToImage, Classification — make sure load + forward still work end-to-end on device (the constructor signature change shouldn't
  affect runtime)
  - Verify error.code is still set correctly on caught errors in JS (try/catch then check e.code and e.message)

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
