### PR TITLE
docs: clarify resource fetcher install steps and peer deps

### DIFF
--- a/docs/docs/01-fundamentals/01-getting-started.md
+++ b/docs/docs/01-fundamentals/01-getting-started.md
@@ -45,10 +45,12 @@ Installation is pretty straightforward, use your package manager of choice to in
 
     ```bash
     npm install react-native-executorch
-    # For Expo projects
+    # For Expo projects, you need to install expo resource fetcher
     npm install react-native-executorch-expo-resource-fetcher
-    # For bare React Native projects
+    npm install expo-file-system expo-asset
+    # For bare React Native projects, you need to install bare resource fetcher
     npm install react-native-executorch-bare-resource-fetcher
+    npm install @dr.pogodin/react-native-fs @kesha-antonov/react-native-background-downloader
     ```
 
   </TabItem>
@@ -56,10 +58,12 @@ Installation is pretty straightforward, use your package manager of choice to in
 
     ```bash
     pnpm install react-native-executorch
-    # For Expo projects
+    # For Expo projects, you need to install expo resource fetcher
     pnpm install react-native-executorch-expo-resource-fetcher
-    # For bare React Native projects
+    pnpm install expo-file-system expo-asset
+    # For bare React Native projects, you need to install bare resource fetcher
     pnpm install react-native-executorch-bare-resource-fetcher
+    pnpm install @dr.pogodin/react-native-fs @kesha-antonov/react-native-background-downloader
     ```
 
   </TabItem>
@@ -67,10 +71,12 @@ Installation is pretty straightforward, use your package manager of choice to in
 
     ```bash
     yarn add react-native-executorch
-    # For Expo projects
+    # For Expo projects, you need to install expo resource fetcher
     yarn add react-native-executorch-expo-resource-fetcher
-    # For bare React Native projects
+    yarn add expo-file-system expo-asset
+    # For bare React Native projects, you need to install bare resource fetcher
     yarn add react-native-executorch-bare-resource-fetcher
+    yarn add @dr.pogodin/react-native-fs @kesha-antonov/react-native-background-downloader
     ```
 
   </TabItem>
@@ -82,7 +88,7 @@ Before using any other API, you must call `initExecutorch` with a resource fetch
 ```js
 import { initExecutorch } from 'react-native-executorch';
 import { ExpoResourceFetcher } from 'react-native-executorch-expo-resource-fetcher';
-// or BareResourceFetcher for Expo projects
+// or BareResourceFetcher for bare react-native projects
 
 initExecutorch({ resourceFetcher: ExpoResourceFetcher });
 ```

--- a/docs/versioned_docs/version-0.8.x/01-fundamentals/01-getting-started.md
+++ b/docs/versioned_docs/version-0.8.x/01-fundamentals/01-getting-started.md
@@ -45,10 +45,12 @@ Installation is pretty straightforward, use your package manager of choice to in
 
     ```bash
     npm install react-native-executorch
-    # For Expo projects
+    # For Expo projects, you need to install expo resource fetcher
     npm install react-native-executorch-expo-resource-fetcher
-    # For bare React Native projects
+    npm install expo-file-system expo-asset
+    # For bare React Native projects, you need to install bare resource fetcher
     npm install react-native-executorch-bare-resource-fetcher
+    npm install @dr.pogodin/react-native-fs @kesha-antonov/react-native-background-downloader
     ```
 
   </TabItem>
@@ -56,10 +58,12 @@ Installation is pretty straightforward, use your package manager of choice to in
 
     ```bash
     pnpm install react-native-executorch
-    # For Expo projects
+    # For Expo projects, you need to install expo resource fetcher
     pnpm install react-native-executorch-expo-resource-fetcher
-    # For bare React Native projects
+    pnpm install expo-file-system expo-asset
+    # For bare React Native projects, you need to install bare resource fetcher
     pnpm install react-native-executorch-bare-resource-fetcher
+    pnpm install @dr.pogodin/react-native-fs @kesha-antonov/react-native-background-downloader
     ```
 
   </TabItem>
@@ -67,10 +71,12 @@ Installation is pretty straightforward, use your package manager of choice to in
 
     ```bash
     yarn add react-native-executorch
-    # For Expo projects
+    # For Expo projects, you need to install expo resource fetcher
     yarn add react-native-executorch-expo-resource-fetcher
-    # For bare React Native projects
+    yarn add expo-file-system expo-asset
+    # For bare React Native projects, you need to install bare resource fetcher
     yarn add react-native-executorch-bare-resource-fetcher
+    yarn add @dr.pogodin/react-native-fs @kesha-antonov/react-native-background-downloader
     ```
 
   </TabItem>
@@ -82,7 +88,7 @@ Before using any other API, you must call `initExecutorch` with a resource fetch
 ```js
 import { initExecutorch } from 'react-native-executorch';
 import { ExpoResourceFetcher } from 'react-native-executorch-expo-resource-fetcher';
-// or BareResourceFetcher for Expo projects
+// or BareResourceFetcher for bare react-native projects
 
 initExecutorch({ resourceFetcher: ExpoResourceFetcher });
 ```


### PR DESCRIPTION
## Description

Rewords the per-fetcher comments in the Getting Started installation block to make it explicit which fetcher to install for Expo vs bare React Native, and lists the required peer packages (`expo-file-system`/`expo-asset` for Expo; `@dr.pogodin/react-native-fs`/`@kesha-antonov/react-native-background-downloader` for bare RN) so the docs align with the README. Also fixes the stale `// or BareResourceFetcher for Expo projects` comment. Applied to both the current docs and the `version-0.8.x` versioned docs. Supersedes #1145.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

N/A — documentation-only change.

### Screenshots

### Related issues

Supersedes #1145.

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes