### PR TITLE
fix(llm): surface tool-call errors via sendMessage

### DIFF
--- a/packages/react-native-executorch/src/controllers/LLMController.ts
+++ b/packages/react-native-executorch/src/controllers/LLMController.ts
@@ -416,18 +416,20 @@ export class LLMController {
     }
 
     if (this.toolsConfig) {
-      const toolCalls = parseToolCall(response);
-      for (const toolCall of toolCalls) {
-        this.toolsConfig
-          .executeToolCallback(toolCall)
-          .then((toolResponse: string | null) => {
-            if (toolResponse) {
-              this.messageHistoryCallback([
-                ...this._messageHistory,
-                { content: toolResponse, role: 'assistant' },
-              ]);
-            }
-          });
+      try {
+        const toolCalls = parseToolCall(response);
+        for (const toolCall of toolCalls) {
+          const toolResponse =
+            await this.toolsConfig.executeToolCallback(toolCall);
+          if (toolResponse) {
+            this.messageHistoryCallback([
+              ...this._messageHistory,
+              { content: toolResponse, role: 'assistant' },
+            ]);
+          }
+        }
+      } catch (e) {
+        throw parseUnknownError(e);
       }
     }
 

--- a/packages/react-native-executorch/src/controllers/LLMController.ts
+++ b/packages/react-native-executorch/src/controllers/LLMController.ts
@@ -421,7 +421,7 @@ export class LLMController {
         for (const toolCall of toolCalls) {
           const toolResponse =
             await this.toolsConfig.executeToolCallback(toolCall);
-          if (toolResponse) {
+          if (toolResponse != null) {
             this.messageHistoryCallback([
               ...this._messageHistory,
               { content: toolResponse, role: 'assistant' },

--- a/packages/react-native-executorch/src/utils/llm.ts
+++ b/packages/react-native-executorch/src/utils/llm.ts
@@ -4,45 +4,56 @@ import { Schema, Validator } from 'jsonschema';
 import { jsonrepair } from 'jsonrepair';
 import { DEFAULT_STRUCTURED_OUTPUT_PROMPT } from '../constants/llmDefaults';
 import * as zCore from 'zod/v4/core';
-import { Logger } from '../common/Logger';
+import { RnExecutorchError } from '../errors/errorUtils';
+import { RnExecutorchErrorCode } from '../errors/ErrorCodes';
 
 /**
  * Parses tool calls from a given message string.
  * @category Utilities - LLM
  * @param message - The message string containing tool calls in JSON format.
- * @returns An array of `ToolCall` objects extracted from the message.
+ * @returns An array of `ToolCall` objects extracted from the message. Returns
+ *   an empty array if the model did not emit a `[...]` block (i.e. chose not
+ *   to call any tool).
+ * @throws {RnExecutorchError} `InvalidModelOutput` when a `[...]` block is
+ *   present but cannot be parsed as JSON — distinct from the model
+ *   legitimately deciding not to invoke a tool.
  */
 export const parseToolCall: (message: string) => ToolCall[] = (
   message: string
 ) => {
-  try {
-    const unparsedToolCalls = message.match('\\[(.|\\s)*\\]');
-    if (!unparsedToolCalls) {
-      throw Error('Regex did not match array.');
-    }
-    const parsedMessage: LLMTool[] = JSON.parse(unparsedToolCalls[0]);
-    const results = [];
-
-    for (const tool of parsedMessage) {
-      if (
-        'name' in tool &&
-        typeof tool.name === 'string' &&
-        'arguments' in tool &&
-        tool.arguments !== null &&
-        typeof tool.arguments === 'object'
-      ) {
-        results.push({
-          toolName: tool.name,
-          arguments: tool.arguments,
-        });
-      }
-    }
-
-    return results;
-  } catch (e) {
-    Logger.error(e);
+  const unparsedToolCalls = message.match('\\[(.|\\s)*\\]');
+  if (!unparsedToolCalls) {
     return [];
   }
+
+  let parsedMessage: LLMTool[];
+  try {
+    parsedMessage = JSON.parse(unparsedToolCalls[0]);
+  } catch (e) {
+    throw new RnExecutorchError(
+      RnExecutorchErrorCode.InvalidModelOutput,
+      `Failed to parse tool call JSON from model output: ${unparsedToolCalls[0]}`,
+      e
+    );
+  }
+
+  const results: ToolCall[] = [];
+  for (const tool of parsedMessage) {
+    if (
+      'name' in tool &&
+      typeof tool.name === 'string' &&
+      'arguments' in tool &&
+      tool.arguments !== null &&
+      typeof tool.arguments === 'object'
+    ) {
+      results.push({
+        toolName: tool.name,
+        arguments: tool.arguments,
+      });
+    }
+  }
+
+  return results;
 };
 
 const filterObjectKeys = (obj: object, keysToRemove: string[]) => {


### PR DESCRIPTION
## Description

`useLLM` with `toolsConfig` silently dropped errors from the tool-execution path: `parseToolCall` swallowed every parse failure with `Logger.error`, and `LLMController.sendMessage` fired `executeToolCallback` without `await` or `.catch`. Neither `llm.error` nor the caller's `await llm.sendMessage(...)` `try/catch` ever saw them.

This PR makes those errors propagate:

- `parseToolCall` now distinguishes "no tool call in output" (returns `[]` — the model legitimately chose not to call a tool) from "malformed tool-call JSON" (throws `RnExecutorchError(InvalidModelOutput)`).
- `LLMController.sendMessage` `await`s `executeToolCallback` inside `try/catch` and rethrows via `parseUnknownError`, so failures reach the caller's `try/catch` (and the hook's `error` state if wired).

### Introduces a breaking change?

- [x] Yes
- [ ] No

Callers of `parseToolCall` that previously received `[]` for malformed tool-call JSON now get a thrown `RnExecutorchError(InvalidModelOutput)`. Same applies to `sendMessage` when `toolsConfig` is set and the tool path throws — the error now surfaces instead of being silently swallowed.

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

1. Open the `llm` demo app → **Tool calling** screen.
2. Switch the picker to a non-tool-trained model (e.g. Llama 3.2 1B QLoRA / SpinQuant).
3. Send a tool-shaped prompt (`What events do I have today?`).
4. If the tool-execution path throws (e.g. "max recursion depth reached" on tool-naive models, malformed tool-call JSON), the on-screen `ErrorBanner` now displays the error instead of staying empty.
5. Sanity check on a tool-trained model (Hammer 2.1 1.5B): tool calls still execute normally and no error banner appears.

### Related issues

Fixes #1157

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
