### PR TITLE
fix(computer-vision): align vision_camera segmentation overlay with preview

### DIFF
--- a/apps/computer-vision/app/vision_camera/index.tsx
+++ b/apps/computer-vision/app/vision_camera/index.tsx
@@ -234,7 +234,14 @@ export default function VisionCameraScreen() {
         device={device}
         outputs={frameOutput ? [frameOutput] : []}
         isActive={isFocused}
-        orientationSource="device"
+        // Segmentation draws a 2D mask that the native side rotates into the
+        // activity's coord system (portrait, since the activity is locked).
+        // Pin the preview to that same coord system so mask + preview can't
+        // drift apart when the phone is tilted. Other tasks render coords
+        // (bboxes/points) and tolerate the device-rotated preview fine.
+        orientationSource={
+          activeTask === 'segmentation' ? 'interface' : 'device'
+        }
         onError={(e) => {
           console.warn('[Camera] onError', e);
           setError(e.message);

--- a/apps/computer-vision/components/vision_camera/tasks/SegmentationTask.tsx
+++ b/apps/computer-vision/components/vision_camera/tasks/SegmentationTask.tsx
@@ -153,14 +153,16 @@ export default function SegmentationTask({
           const result = segRof(frame, isFrontCamera, [], false);
           if (result?.ARGMAX) {
             const argmax: Int32Array = result.ARGMAX;
-            // Native rotates the mask into screen-space (see
-            // `inverseRotateMat`). Derive screen-space dims from
-            // `frame.orientation`: portrait orientations ("left"/"right")
-            // swap sensor-native width/height, landscape ones keep them.
-            const orient = frame.orientation;
-            const isScreenPortrait = orient === 'left' || orient === 'right';
-            const screenW = isScreenPortrait ? frame.height : frame.width;
-            const screenH = isScreenPortrait ? frame.width : frame.height;
+            // Both the preview and the mask live in a portrait coord system:
+            // the activity is portrait-locked (so CameraX's PreviewView always
+            // renders the preview in portrait orientation regardless of how
+            // the device is physically tilted), and the native side runs
+            // `inverseRotateMat` which always converts the mask into the same
+            // portrait coord system. Treat sensor-native dims as portrait by
+            // swapping height/width — same convention as the sibling OCR and
+            // ObjectDetection tasks.
+            const screenW = frame.height;
+            const screenH = frame.width;
             // Mask buffer dims: the C++ side returns the mask at model output
             // resolution (the `resizeToInput=false` arg below). All built-in
             // segmentation models output a square spatial map (e.g. 520×520),

--- a/apps/computer-vision/components/vision_camera/tasks/SegmentationTask.tsx
+++ b/apps/computer-vision/components/vision_camera/tasks/SegmentationTask.tsx
@@ -78,6 +78,7 @@ export default function SegmentationTask({
   }[activeModel];
 
   const [maskImage, setMaskImage] = useState<SkImage | null>(null);
+  const [imageSize, setImageSize] = useState({ width: 1, height: 1 });
   const lastFrameTimeRef = useRef(Date.now());
 
   useEffect(() => {
@@ -117,11 +118,12 @@ export default function SegmentationTask({
   const segRof = active.runOnFrame;
 
   const updateMask = useCallback(
-    (img: SkImage) => {
+    (p: { img: SkImage; screenW: number; screenH: number }) => {
       setMaskImage((prev) => {
         prev?.dispose();
-        return img;
+        return p.img;
       });
+      setImageSize({ width: p.screenW, height: p.screenH });
       const now = Date.now();
       const diff = now - lastFrameTimeRef.current;
       if (diff > 0) onFpsChange(Math.round(1000 / diff), diff);
@@ -151,18 +153,22 @@ export default function SegmentationTask({
           const result = segRof(frame, isFrontCamera, [], false);
           if (result?.ARGMAX) {
             const argmax: Int32Array = result.ARGMAX;
-            // Sensor frames are landscape-native, so width/height are swapped
-            // relative to portrait screen orientation.
-            const screenW = frame.height;
-            const screenH = frame.width;
-            const maskW =
-              argmax.length === screenW * screenH
-                ? screenW
-                : Math.round(Math.sqrt(argmax.length));
-            const maskH =
-              argmax.length === screenW * screenH
-                ? screenH
-                : Math.round(Math.sqrt(argmax.length));
+            // Native rotates the mask into screen-space (see
+            // `inverseRotateMat`). Derive screen-space dims from
+            // `frame.orientation`: portrait orientations ("left"/"right")
+            // swap sensor-native width/height, landscape ones keep them.
+            const orient = frame.orientation;
+            const isScreenPortrait = orient === 'left' || orient === 'right';
+            const screenW = isScreenPortrait ? frame.height : frame.width;
+            const screenH = isScreenPortrait ? frame.width : frame.height;
+            // Mask buffer dims: the C++ side returns the mask at model output
+            // resolution (the `resizeToInput=false` arg below). All built-in
+            // segmentation models output a square spatial map (e.g. 520×520),
+            // so sqrt(length) recovers the side. Non-square model outputs
+            // would need dims exposed from native.
+            const maskSide = Math.round(Math.sqrt(argmax.length));
+            const maskW = maskSide;
+            const maskH = maskSide;
             const pixels = new Uint8Array(maskW * maskH * 4);
             for (let i = 0; i < argmax.length; i++) {
               const color = colors[argmax[i]!] ?? [0, 0, 0, 0];
@@ -182,7 +188,7 @@ export default function SegmentationTask({
               skData,
               maskW * 4
             );
-            if (img) scheduleOnRN(updateMask, img);
+            if (img) scheduleOnRN(updateMask, { img, screenW, screenH });
           }
         } catch {
           // Frame may be disposed before processing completes — transient, safe to ignore.
@@ -200,16 +206,29 @@ export default function SegmentationTask({
 
   if (!maskImage) return null;
 
+  // Match the camera preview's cover-scale + center layout so the mask
+  // aligns pixel-for-pixel with what the user sees. `fit="fill"` lets the
+  // (square) mask stretch into the preview rect — which is computed in
+  // screen-space dims rather than the sensor-native ones.
+  const scale = Math.max(
+    canvasSize.width / imageSize.width,
+    canvasSize.height / imageSize.height
+  );
+  const dstW = imageSize.width * scale;
+  const dstH = imageSize.height * scale;
+  const offsetX = (canvasSize.width - dstW) / 2;
+  const offsetY = (canvasSize.height - dstH) / 2;
+
   return (
     <View style={StyleSheet.absoluteFill} pointerEvents="none">
       <Canvas style={StyleSheet.absoluteFill}>
         <SkiaImage
           image={maskImage}
-          fit="cover"
-          x={0}
-          y={0}
-          width={canvasSize.width}
-          height={canvasSize.height}
+          fit="fill"
+          x={offsetX}
+          y={offsetY}
+          width={dstW}
+          height={dstH}
         />
       </Canvas>
     </View>


### PR DESCRIPTION
## Description

In the `computer-vision` demo's vision_camera screen the semantic-segmentation overlay landed rotated and offset relative to the camera preview (FCN ResNet50 / any DeepLab variant). Two layers fixed:

- `SegmentationTask.tsx`: the `argmax.length === screenW * screenH` branch was unreachable (`runOnFrame` runs with `resizeToInput=false`, so the mask is always at *model output* resolution) and the `<SkiaImage fit="cover">` then stretched it across the whole portrait canvas. Drop the dead branch, infer the (square) mask side from `sqrt(length)`, and draw the SkiaImage into the camera preview's cover-fit rect with `fit="fill"` — same pattern as `OCRTask`/`ObjectDetectionTask`. Mask + preview now line up pixel-for-pixel in portrait.
- `vision_camera/index.tsx`: pin `orientationSource` to `'interface'` while the segmentation task is active. The activity is portrait-locked and the native side rotates the mask into that coord system via `inverseRotateMat`, but `'device'` made the preview rotate with the phone, leaving the mask drifted by 90° in landscape. Other tasks keep `'device'` since their bbox/point coords tolerate the device-rotated preview fine.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

1. Open the `computer-vision` demo → vision_camera screen.
2. Select **Segment → FCN ResNet50** (or any DeepLab variant).
3. Aim the camera at a clear asymmetric subject (e.g. a TV).
4. The colored overlay should line up with the actual subject in the preview, not rotated/displaced.
5. Tilt the phone to landscape — the mask should keep tracking the same object as in portrait.
6. Switch to another task (Classify / Detect / OCR / …) and back to Segment — preview should keep rotating with the device for those, and re-pin to the activity orientation for Segment.

### Screenshots

<!-- Add before/after if available -->

### Related issues

Fixes #1158.

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

iOS not retested with this patch — the C++ rotation already handles iOS correctly and the JS change is platform-agnostic, but a quick sanity check on a portrait iPhone before merge wouldn't hurt.