### PR TITLE
docs: add 0.9.x to compatibility table

### DIFF
--- a/docs/docs/07-other/01-compatibility.mdx
+++ b/docs/docs/07-other/01-compatibility.mdx
@@ -17,7 +17,7 @@ React Native ExecuTorch supports only the [New Architecture](https://reactnative
     <thead>
       <tr>
         <th rowSpan={2}>React Native ExecuTorch</th>
-        <th colSpan={7}>React Native version</th>
+        <th colSpan={8}>React Native version</th>
       </tr>
       <tr>
         <th>0.78</th>
@@ -27,6 +27,7 @@ React Native ExecuTorch supports only the [New Architecture](https://reactnative
         <th>0.82</th>
         <th>0.83</th>
         <th>0.84</th>
+        <th>0.85</th>
       </tr>
     </thead>
     <tbody>
@@ -39,12 +40,14 @@ React Native ExecuTorch supports only the [New Architecture](https://reactnative
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
+        <td><div className={styles.supported}>yes</div></td>
       </tr>
       <tr>
         <td><div className={styles.version}>0.9.x</div></td>
         <td><div className={styles.notSupported}>no</div></td>
         <td><div className={styles.notSupported}>no</div></td>
         <td><div className={styles.notSupported}>no</div></td>
+        <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
@@ -61,7 +64,7 @@ React Native ExecuTorch supports only the [New Architecture](https://reactnative
     <thead>
       <tr>
         <th rowSpan={2}>Bare Resource Fetcher</th>
-        <th colSpan={7}>React Native version</th>
+        <th colSpan={8}>React Native version</th>
       </tr>
       <tr>
         <th>0.78</th>
@@ -71,6 +74,7 @@ React Native ExecuTorch supports only the [New Architecture](https://reactnative
         <th>0.82</th>
         <th>0.83</th>
         <th>0.84</th>
+        <th>0.85</th>
       </tr>
     </thead>
     <tbody>
@@ -83,12 +87,14 @@ React Native ExecuTorch supports only the [New Architecture](https://reactnative
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
+        <td><div className={styles.supported}>yes</div></td>
       </tr>
       <tr>
         <td><div className={styles.version}>0.9.x</div></td>
         <td><div className={styles.notSupported}>no</div></td>
         <td><div className={styles.notSupported}>no</div></td>
         <td><div className={styles.notSupported}>no</div></td>
+        <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>

--- a/docs/docs/07-other/01-compatibility.mdx
+++ b/docs/docs/07-other/01-compatibility.mdx
@@ -40,6 +40,16 @@ React Native ExecuTorch supports only the [New Architecture](https://reactnative
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
       </tr>
+      <tr>
+        <td><div className={styles.version}>0.9.x</div></td>
+        <td><div className={styles.notSupported}>no</div></td>
+        <td><div className={styles.notSupported}>no</div></td>
+        <td><div className={styles.notSupported}>no</div></td>
+        <td><div className={styles.supported}>yes</div></td>
+        <td><div className={styles.supported}>yes</div></td>
+        <td><div className={styles.supported}>yes</div></td>
+        <td><div className={styles.supported}>yes</div></td>
+      </tr>
     </tbody>
   </table>
 </div>
@@ -74,6 +84,16 @@ React Native ExecuTorch supports only the [New Architecture](https://reactnative
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
       </tr>
+      <tr>
+        <td><div className={styles.version}>0.9.x</div></td>
+        <td><div className={styles.notSupported}>no</div></td>
+        <td><div className={styles.notSupported}>no</div></td>
+        <td><div className={styles.notSupported}>no</div></td>
+        <td><div className={styles.supported}>yes</div></td>
+        <td><div className={styles.supported}>yes</div></td>
+        <td><div className={styles.supported}>yes</div></td>
+        <td><div className={styles.supported}>yes</div></td>
+      </tr>
     </tbody>
   </table>
 </div>
@@ -97,6 +117,13 @@ React Native ExecuTorch supports only the [New Architecture](https://reactnative
     <tbody>
       <tr>
         <td><div className={styles.version}>0.8.x</div></td>
+        <td><div className={styles.notSupported}>no</div></td>
+        <td><div className={styles.notSupported}>no</div></td>
+        <td><div className={styles.supported}>yes</div></td>
+        <td><div className={styles.supported}>yes</div></td>
+      </tr>
+      <tr>
+        <td><div className={styles.version}>0.9.x</div></td>
         <td><div className={styles.notSupported}>no</div></td>
         <td><div className={styles.notSupported}>no</div></td>
         <td><div className={styles.supported}>yes</div></td>


### PR DESCRIPTION
## Description

Adds a `0.9.x` row to each compatibility table (identical support matrix to `0.8.x`). Also extends the two React Native tables with a `0.85` column, with `0.8.x` and `0.9.x` marked supported. Expo SDK table untouched.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

Docs render: open the Compatibility page and verify the `0.9.x` row renders alongside `0.8.x` and the `0.85` column appears in both RN tables.

Android (0.9, current main):
1. In `apps/bare-rn/package.json` bump `react` to `19.2.3`, `react-native` to `0.85.3`, `@react-native-community/cli*` to `20.1.0`, `@react-native/*` to `0.85.3`, `@types/react` to `^19.2.0`, `react-test-renderer` to `19.2.3`.
2. In `apps/bare-rn/android/gradle/wrapper/gradle-wrapper.properties` bump gradle distribution to `9.3.1` (no other Android config changes needed — `compileSdk 36`, `NDK 27.1.12297006`, `Kotlin 2.1.20` already match the RN 0.85 template).
3. `yarn install` at the workspace root.
4. `cd apps/bare-rn && yarn android`.
5. Wait for the LFM2.5-1.2B-Instruct model to download in-app, then send a prompt — confirm it streams a reply.

Android (0.8):
1. Fresh init: `npx @react-native-community/cli@20.1.0 init Rne08Rn85Test --version 0.85.3`.
2. `npm install react-native-executorch@0.8.4 react-native-executorch-bare-resource-fetcher@0.8.0 react-native-safe-area-context @dr.pogodin/react-native-fs @kesha-antonov/react-native-background-downloader` (bare-fetcher 0.8.0 is the only stable 0.8 publish).
3. Copy the bare-rn `App.tsx` over and replace the LLM import — in 0.8 there's no `models.llm.*` factory; use the flat constant `LFM2_5_1_2B_INSTRUCT` from `react-native-executorch`.
4. `npx react-native run-android`.
5. Same in-app verification: model loads, prompt streams a reply.

iOS: repeat the equivalent flow for both versions to confirm before merging.

### Screenshots

### Related issues

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

Android validation was performed on a physical device (Samsung S24 Ultra, `SM-S948B`). 0.9 used the workspace package against RN 0.85.3; 0.8 used the published `react-native-executorch@0.8.4` + `react-native-executorch-bare-resource-fetcher@0.8.0`. Both builds succeeded and the LFM2.5-1.2B-Instruct forward pass produced output. iOS still needs the same verification.