### PR TITLE
fix: fix markdown list rendering collapse in LLM example app

### DIFF
--- a/apps/llm/components/MarkdownComponent.tsx
+++ b/apps/llm/components/MarkdownComponent.tsx
@@ -16,7 +16,6 @@ export default function MarkdownComponent({ text }: MarkdownComponentProps) {
           fontFamily: 'regular',
           lineHeight: 19.6,
           fontSize: fontSize,
-          alignSelf: 'flex-start',
         },
         paragraph: {
           marginTop: 0,

--- a/apps/llm/components/MessageItem.tsx
+++ b/apps/llm/components/MessageItem.tsx
@@ -24,7 +24,9 @@ const MessageItem = memo(({ message, deleteMessage }: MessageItemProps) => {
         <View style={styles.aiMessageIconContainer}>
           <LlamaIcon width={24} height={24} />
         </View>
-        <MarkdownComponent text={message.content} />
+        <View style={styles.aiMessageContent}>
+          <MarkdownComponent text={message.content} />
+        </View>
         <CloseButton deleteMessage={deleteMessage} role={message.role} />
       </View>
     );
@@ -76,6 +78,9 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-start',
     marginVertical: 8,
     alignItems: 'center',
+  },
+  aiMessageContent: {
+    flex: 1,
   },
   userMessageWrapper: {
     flexDirection: 'row-reverse',


### PR DESCRIPTION
## Description

Fixes the problem in LLM example app that collapsed the rendered markdown list.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

Run the LLM example app with the 'Give me 3 fun ...' example prompt and Qwen3.5 or SmolLM2 model and confirm that the final markdown list is rendered correctly.

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->
Fixes #1178 

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
