### PR TITLE
fix(build): pack phonemis submodule sources in npm tarball

### DIFF
--- a/packages/react-native-executorch/scripts/create-package.sh
+++ b/packages/react-native-executorch/scripts/create-package.sh
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+# Phonemis is a git submodule whose sources the podspec compiles directly
+# (see third-party/common/phonemis/src in react-native-executorch.podspec).
+# Init it explicitly so the files are present in the packed tarball.
+# Run from repo root so the submodule path resolves regardless of cwd.
+git -C "$(git rev-parse --show-toplevel)" submodule update --init --recursive \
+  packages/react-native-executorch/third-party/common/phonemis
+
+# Trim phonemis to what consumers need at build time. Done here (not via
+# package.json "files") because the submodule's own .gitignore has
+# `!scripts/build*` which npm-packlist honors and re-includes those files
+# despite our exclusion rules. Restore on exit so the working tree stays clean.
+PHONEMIS_DIR="third-party/common/phonemis"
+restore_phonemis() {
+  git -C "$PHONEMIS_DIR" checkout -- data test scripts requirements.txt 2>/dev/null || true
+}
+trap restore_phonemis EXIT
+rm -rf "$PHONEMIS_DIR/data" "$PHONEMIS_DIR/test" "$PHONEMIS_DIR/scripts"
+rm -f "$PHONEMIS_DIR/requirements.txt"
+
 yarn install --immutable
 
 if [ $# -ge 1 ] && [ "$1" = "generate_nightly_version" ]; then


### PR DESCRIPTION
## Description

Init the phonemis git submodule in `create-package.sh` so its sources are present in the published npm tarball. Previously the submodule was empty at pack time, so the podspec's `third-party/common/phonemis/src/**/*.{cpp,hpp,h}` source-files glob found nothing and TTS-using apps could not build from the npm package.

`data/`, `scripts/`, `test/`, and `requirements.txt` are trimmed in the script (working-tree trim, restored on exit via `trap`) rather than via the `package.json` `files` field, because the submodule's own `.gitignore` re-includes `scripts/build*` via `!scripts/build*` and `npm-packlist` honors that rule against `files` exclusions.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

1. From `packages/react-native-executorch`, run `./scripts/create-package.sh`.
2. `tar tzf react-native-executorch-*.tgz | grep phonemis/src | wc -l` → 87 source files.
3. `tar tzf react-native-executorch-*.tgz | grep -E "phonemis/(data|test|requirements)"` → empty.
4. Install the tarball into a fresh RN/Expo app, run `pod install` + iOS/Android build; phonemis should compile cleanly into `libreact-native-executorch.{a,so}`.

### Screenshots

### Related issues

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes