### PR TITLE
chore: Bump version to v0.10.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,21 +1,34 @@
 # General Overview
 
+## Version tag conventions
+
+Model URLs in `packages/react-native-executorch/src/constants/modelUrls.ts` are built from two constants in `versions.ts`:
+
+- `VERSION_TAG` — the **in-development** version (`resolve/v${LIB_VERSION}`). On `main` it points at the upcoming release; HuggingFace files under this tag may not be published until release day.
+- `PREVIOUS_VERSION_TAG` — the **latest published stable** release. Use for back-compat references that should follow the last shipped version.
+
+Anything that must stay pinned to a specific older HuggingFace tag (e.g. deprecated aliases whose files were removed in a later release) should hardcode `resolve/v{MAJOR}.{MINOR}.0` directly in `modelUrls.ts` rather than reusing `PREVIOUS_VERSION_TAG`.
+
 ## Minor version release
 
 The release process of new minor version consists of the following steps:
 
-1. Update version tags in `packages/react-native-executorch/src/constants/modelUrls.ts` to point to the proper `MINOR` version and update tags on [🤗 huggingface](https://huggingface.co/software-mansion).
-2. Make sure unreleased models with tags `NEXT_VERSION_TAG` are updated to `VERSION_TAG`.
-3. Update version in `packages/react-native-executorch/src/constants/versions.ts`.
-4. Commit with a message 'Release v{MAJOR}.{MINOR}.0'.
-5. Create a new release branch `release/{MAJOR}.{MINOR}` and push it to the remote.
+1. On `main`, confirm every model URL in `packages/react-native-executorch/src/constants/modelUrls.ts` that should ship in this release is already pointing at `VERSION_TAG` (the in-development tag) and that the matching files exist on [🤗 huggingface](https://huggingface.co/software-mansion) under the `v{MAJOR}.{MINOR}.0` tag.
+2. Make sure `LIB_VERSION` in `packages/react-native-executorch/src/constants/versions.ts` is `{MAJOR}.{MINOR}.0` so `VERSION_TAG` resolves to `resolve/v{MAJOR}.{MINOR}.0`.
+3. Ensure the `version` field of `package.json` is `{MAJOR}.{MINOR}.0` for the core package (`react-native-executorch`) and both adapter packages (`bare-resource-fetcher`, `expo-resource-fetcher`).
+4. If any of the above required changes, commit them on `main` with the message 'Release v{MAJOR}.{MINOR}.0'.
+5. Create a new release branch `release/{MAJOR}.{MINOR}` from `main` and push it to the remote.
 6. Stability tests are performed on the release branch and all fixes to the new-found issues are pushed into the main branch and cherry-picked into the release branch. This allows for further development on the main branch without interfering with the release process.
 7. Once all tests are passed, tag the release branch with proper version tag `v{MAJOR}.{MINOR}.0` and run the following publish workflows:
    - [npm publish (core)](https://github.com/software-mansion/react-native-executorch/actions/workflows/npm-publish.yml)
    - [npm publish bare-resource-fetcher](https://github.com/software-mansion/react-native-executorch/actions/workflows/npm-publish-bare-resource-fetcher.yml)
    - [npm publish expo-resource-fetcher](https://github.com/software-mansion/react-native-executorch/actions/workflows/npm-publish-expo-resource-fetcher.yml)
 8. Create the release notes on GitHub.
-9. Bump version in `package.json` on the `main` branch to `v{MAJOR}.{NEXT_MINOR}.0` for the core package and both adapter packages (`bare-resource-fetcher`, `expo-resource-fetcher`). Commit with a message 'Bump version to v{MAJOR}.{NEXT_MINOR}.0'.
+9. Bump `main` to the next development cycle in a single PR:
+   - Bump `version` in `package.json` to `{MAJOR}.{NEXT_MINOR}.0` for the core package and both adapter packages.
+   - Bump `LIB_VERSION` in `versions.ts` to `{MAJOR}.{NEXT_MINOR}.0` (this auto-bumps `VERSION_TAG`).
+   - Bump `PREVIOUS_VERSION_TAG` in `versions.ts` to `resolve/v{MAJOR}.{MINOR}.0` (the version that was just published).
+   - Commit with the message 'Bump version to v{MAJOR}.{NEXT_MINOR}.0'.
 10. Create versioned docs by running from repo root `(cd docs && yarn docs:version {MAJOR}.{MINOR}.x)` (the 'x' part is intentional and is not to be substituted). Also, make sure that all the links in `api-reference` are not broken.
 11. Create a PR with the updated docs.
 12. Update README.md with release video, if available.

--- a/packages/bare-resource-fetcher/package.json
+++ b/packages/bare-resource-fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-executorch-bare-resource-fetcher",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Bare React Native resource fetcher for react-native-executorch",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/expo-resource-fetcher/package.json
+++ b/packages/expo-resource-fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-executorch-expo-resource-fetcher",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Expo resource fetcher for react-native-executorch",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-executorch",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "An easy way to run AI models in React Native with ExecuTorch",
   "source": "./src/index.ts",
   "main": "./lib/module/index.js",

--- a/packages/react-native-executorch/src/constants/modelUrls.ts
+++ b/packages/react-native-executorch/src/constants/modelUrls.ts
@@ -3,16 +3,19 @@ import {
   PRIVACY_FILTER_NEMOTRON_LABELS,
   PRIVACY_FILTER_OPENAI_LABELS,
 } from './privacyFilterLabels';
-import { URL_PREFIX, VERSION_TAG, PREVIOUS_VERSION_TAG } from './versions';
+import { URL_PREFIX, VERSION_TAG } from './versions';
 
 // LLMs
 
 // LLAMA 3.2
 const LLAMA3_2_3B_MODEL = `${URL_PREFIX}-llama-3.2/${VERSION_TAG}/3b/xnnpack/llama_3_2_3b_xnnpack_bf16.pte`;
-const LLAMA3_2_3B_QLORA_MODEL = `${URL_PREFIX}-llama-3.2/${PREVIOUS_VERSION_TAG}/llama-3.2-3B/QLoRA/llama3_2-3B_qat_lora.pte`;
+// Pinned to v0.8.0 — the last HF tag where the QLoRA files live; SpinQuant
+// supersedes them in later releases.
+const LLAMA3_2_3B_QLORA_MODEL = `${URL_PREFIX}-llama-3.2/resolve/v0.8.0/llama-3.2-3B/QLoRA/llama3_2-3B_qat_lora.pte`;
 const LLAMA3_2_3B_SPINQUANT_MODEL = `${URL_PREFIX}-llama-3.2/${VERSION_TAG}/3b/xnnpack/llama_3_2_3b_xnnpack_spinquant.pte`;
 const LLAMA3_2_1B_MODEL = `${URL_PREFIX}-llama-3.2/${VERSION_TAG}/1b/xnnpack/llama_3_2_1b_xnnpack_bf16.pte`;
-const LLAMA3_2_1B_QLORA_MODEL = `${URL_PREFIX}-llama-3.2/${PREVIOUS_VERSION_TAG}/llama-3.2-1B/QLoRA/llama3_2_qat_lora.pte`;
+// Pinned to v0.8.0 — see note above on LLAMA3_2_3B_QLORA_MODEL.
+const LLAMA3_2_1B_QLORA_MODEL = `${URL_PREFIX}-llama-3.2/resolve/v0.8.0/llama-3.2-1B/QLoRA/llama3_2_qat_lora.pte`;
 const LLAMA3_2_1B_SPINQUANT_MODEL = `${URL_PREFIX}-llama-3.2/${VERSION_TAG}/1b/xnnpack/llama_3_2_1b_xnnpack_spinquant.pte`;
 const LLAMA3_2_TOKENIZER = `${URL_PREFIX}-llama-3.2/${VERSION_TAG}/tokenizer.json`;
 const LLAMA3_2_TOKENIZER_CONFIG = `${URL_PREFIX}-llama-3.2/${VERSION_TAG}/tokenizer_config.json`;

--- a/packages/react-native-executorch/src/constants/versions.ts
+++ b/packages/react-native-executorch/src/constants/versions.ts
@@ -1,8 +1,10 @@
-export const LIB_VERSION = '0.9.0';
+export const LIB_VERSION = '0.10.0';
 
 export const URL_PREFIX =
   'https://huggingface.co/software-mansion/react-native-executorch';
-// Used by @deprecated constants that still resolve v0.8.0 files (e.g. the
-// Llama QLoRA aliases superseded by SpinQuant).
-export const PREVIOUS_VERSION_TAG = 'resolve/v0.8.0';
+// Latest stable release. Use for back-compat references that should follow
+// the last published version rather than the in-development VERSION_TAG.
+export const PREVIOUS_VERSION_TAG = 'resolve/v0.9.0';
+// In-development version; resolves to whatever LIB_VERSION on main currently
+// targets. Models served under this tag may not be published yet.
 export const VERSION_TAG = `resolve/v${LIB_VERSION}`;


### PR DESCRIPTION
## Description

Step 9 of the minor release process: bumps `main` to the next development cycle now that `release/0.9` has been cut. Bumps the 3 package.json versions (core, bare-resource-fetcher, expo-resource-fetcher) to 0.10.0, bumps `LIB_VERSION` to 0.10.0 (so `VERSION_TAG` resolves to `resolve/v0.10.0`), and bumps `PREVIOUS_VERSION_TAG` to `resolve/v0.9.0`. The two deprecated Llama 3.2 QLoRA aliases now inline their `resolve/v0.8.0` pin (those files only exist at v0.8.0). `RELEASE.md` is updated to describe the `VERSION_TAG` (dev) / `PREVIOUS_VERSION_TAG` (latest stable) convention.

> [!IMPORTANT]
> Merge AFTER v0.9.0 has been tagged and published to npm. The daily nightly publish workflow runs against `main`, so merging earlier would cause nightlies to start tagging as `0.10.0-*` before `0.9.0` is on the `latest` dist-tag.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

N/A — pure version bump on `main`; v0.10.0 is in development, no release artifacts exist yet.

### Screenshots

### Related issues

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

The QLoRA pin previously rode on `PREVIOUS_VERSION_TAG = resolve/v0.8.0`; inlining it lets `PREVIOUS_VERSION_TAG` carry its intended "latest stable" meaning going forward.