### PR TITLE
fix(ocr): sort boxes within a row left-to-right

### DIFF
--- a/packages/react-native-executorch/common/rnexecutorch/models/ocr/utils/DetectorUtils.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/ocr/utils/DetectorUtils.cpp
@@ -534,6 +534,7 @@ removeSmallBoxesFromArray(const std::vector<types::DetectorBBox> &boxes,
 }
 
 static float minimumYFromBox(const types::BBox &bbox) { return bbox.p1.y; }
+static float minimumXFromBox(const types::BBox &bbox) { return bbox.p1.x; }
 
 std::vector<types::DetectorBBox>
 groupTextBoxes(std::vector<types::DetectorBBox> &boxes, float centerThreshold,
@@ -603,12 +604,32 @@ groupTextBoxes(std::vector<types::DetectorBBox> &boxes, float centerThreshold,
       removeSmallBoxesFromArray(mergedVec, minSideThreshold, maxSideThreshold);
 
   std::ranges::sort(mergedVec, [](const auto &obj1, const auto &obj2) {
-    const auto &coords1 = obj1.bbox;
-    const auto &coords2 = obj2.bbox;
-    const float minY1 = minimumYFromBox(coords1);
-    const float minY2 = minimumYFromBox(coords2);
-    return minY1 < minY2;
+    return minimumYFromBox(obj1.bbox) < minimumYFromBox(obj2.bbox);
   });
+
+  // Group boxes whose top-Y differs by less than half the mean text height into
+  // a row, then sort within each row left-to-right by top-X. Without this,
+  // ties on minY fall back to the earlier descending-size sort, which reads as
+  // "by probability" rather than reading order.
+  float yThresh = 0.0f;
+  if (!mergedVec.empty()) {
+    float totalHeight = 0.0f;
+    for (const auto &box : mergedVec) {
+      totalHeight += minSideLength(box.bbox);
+    }
+    yThresh = (totalHeight / static_cast<float>(mergedVec.size())) * 0.5f;
+  }
+  for (auto rowBegin = mergedVec.begin(); rowBegin != mergedVec.end();) {
+    const float rowY = minimumYFromBox(rowBegin->bbox);
+    auto rowEnd =
+        std::find_if(rowBegin, mergedVec.end(), [rowY, yThresh](const auto &b) {
+          return minimumYFromBox(b.bbox) - rowY > yThresh;
+        });
+    std::sort(rowBegin, rowEnd, [](const auto &a, const auto &b) {
+      return minimumXFromBox(a.bbox) < minimumXFromBox(b.bbox);
+    });
+    rowBegin = rowEnd;
+  }
 
   std::vector<types::DetectorBBox> orderedSortedBoxes;
   orderedSortedBoxes.reserve(mergedVec.size());


### PR DESCRIPTION
## Description

This is potentially a blocker for demo app recordings for promotion purposes.

`useOCR().forward(image)` returned boxes top-to-bottom but boxes on the same visual row fell back to the earlier descending-side-length ordering — reading as "by probability" rather than reading order.

After the final Y-sort in `groupTextBoxes`, group consecutive boxes whose top-Y differs by less than half the mean text height and sort each group left-to-right by top-X.

Single-comparator soft-Y-equality is intentionally avoided — `A~B`, `B~C` with `A` far from `C` violates strict weak ordering and is UB under `std::sort`.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

1. Run the `computer-vision` demo → OCR screen.
2. Pick a photo with multiple short tokens on the same line (e.g. `Price 12.99 USD`).
3. Inspect the results list — tokens within a row now come out left-to-right.

### Related issues

Closes #1159