### PR TITLE
fix: use PREVIOUS_VERSION_TAG for OCR and TTS URLs

### DIFF
--- a/packages/react-native-executorch/src/constants/ocr/models.ts
+++ b/packages/react-native-executorch/src/constants/ocr/models.ts
@@ -1,11 +1,11 @@
 import { alphabets, symbols } from './symbols';
 
-import { URL_PREFIX, VERSION_TAG } from '../versions';
+import { URL_PREFIX, PREVIOUS_VERSION_TAG } from '../versions';
 
-const DETECTOR_CRAFT_MODEL = `${URL_PREFIX}-detector-craft/${VERSION_TAG}/xnnpack/craft_xnnpack_int8.pte`;
+const DETECTOR_CRAFT_MODEL = `${URL_PREFIX}-detector-craft/${PREVIOUS_VERSION_TAG}/xnnpack/craft_xnnpack_int8.pte`;
 
 const createHFRecognizerDownloadUrl = (alphabet: keyof typeof alphabets) =>
-  `${URL_PREFIX}-recognizer-crnn.en/${VERSION_TAG}/${alphabet}/xnnpack/crnn_${alphabet}_xnnpack_fp32.pte`;
+  `${URL_PREFIX}-recognizer-crnn.en/${PREVIOUS_VERSION_TAG}/${alphabet}/xnnpack/crnn_${alphabet}_xnnpack_fp32.pte`;
 
 const RECOGNIZER_ENGLISH_CRNN = createHFRecognizerDownloadUrl('english');
 const RECOGNIZER_LATIN_CRNN = createHFRecognizerDownloadUrl('latin');

--- a/packages/react-native-executorch/src/constants/tts/models.ts
+++ b/packages/react-native-executorch/src/constants/tts/models.ts
@@ -1,7 +1,7 @@
-import { URL_PREFIX, VERSION_TAG } from '../versions';
+import { URL_PREFIX, PREVIOUS_VERSION_TAG } from '../versions';
 
 // Text to speech (tts) - Kokoro model(s)
-const KOKORO_MODEL_ROOT = `${URL_PREFIX}-kokoro/${VERSION_TAG}/xnnpack`;
+const KOKORO_MODEL_ROOT = `${URL_PREFIX}-kokoro/${PREVIOUS_VERSION_TAG}/xnnpack`;
 const KOKORO_STANDARD_MODEL_ROOT = `${KOKORO_MODEL_ROOT}/standard`;
 const KOKORO_POLISH_MODEL_ROOT = `${KOKORO_MODEL_ROOT}/polish`;
 const KOKORO_GERMAN_MODEL_ROOT = `${KOKORO_MODEL_ROOT}/german`;

--- a/packages/react-native-executorch/src/constants/tts/voices.ts
+++ b/packages/react-native-executorch/src/constants/tts/voices.ts
@@ -1,10 +1,10 @@
 import { TextToSpeechModelConfig } from '../../types/tts';
-import { VERSION_TAG, URL_PREFIX } from '../versions';
+import { PREVIOUS_VERSION_TAG, URL_PREFIX } from '../versions';
 import { KOKORO_STANDARD, KOKORO_POLISH, KOKORO_GERMAN } from './models';
 
 // Common prefixes - voices & phonemization data
-const KOKORO_VOICE_PREFIX = `${URL_PREFIX}-kokoro/${VERSION_TAG}/voices`;
-const KOKORO_PHONEMIZER_PREFIX = `${URL_PREFIX}-kokoro/${VERSION_TAG}/phonemizer`;
+const KOKORO_VOICE_PREFIX = `${URL_PREFIX}-kokoro/${PREVIOUS_VERSION_TAG}/voices`;
+const KOKORO_PHONEMIZER_PREFIX = `${URL_PREFIX}-kokoro/${PREVIOUS_VERSION_TAG}/phonemizer`;
 
 const KOKORO_PHONEMIZER_EN_US_PREFIX = `${KOKORO_PHONEMIZER_PREFIX}/en-us`;
 const KOKORO_PHONEMIZER_EN_US_TAGGER = `${KOKORO_PHONEMIZER_EN_US_PREFIX}/tags.json`;


### PR DESCRIPTION
## Description

Follow-up to #1188. The OCR detector/recognizer and Kokoro TTS voice/model URLs still pointed to `VERSION_TAG` (v0.10.0), which is not published on HF yet — every fetch 404'd in the computer-vision OCR demo and TTS examples. Swap them to `PREVIOUS_VERSION_TAG` (v0.9.0) to match the rest of the model URLs.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

1. Run the `computer-vision` demo → OCR screen on `main`. Detector/recognizer downloads 404.
2. With this PR applied, the same URLs resolve under v0.9.0 and OCR loads.
