### PR TITLE
chore: remove nightly schedule from resource fetcher publish workflows

### DIFF
--- a/.github/workflows/npm-publish-bare-resource-fetcher.yml
+++ b/.github/workflows/npm-publish-bare-resource-fetcher.yml
@@ -1,8 +1,6 @@
 name: NPM publish bare-resource-fetcher
 
 on:
-  schedule:
-    - cron: '01 00 * * *' # Every day at 00:01 UTC
   workflow_dispatch:
     inputs:
       latest-build:

--- a/.github/workflows/npm-publish-expo-resource-fetcher.yml
+++ b/.github/workflows/npm-publish-expo-resource-fetcher.yml
@@ -1,8 +1,6 @@
 name: NPM publish expo-resource-fetcher
 
 on:
-  schedule:
-    - cron: '01 00 * * *' # Every day at 00:01 UTC
   workflow_dispatch:
     inputs:
       latest-build:


### PR DESCRIPTION
## Description

The bare-resource-fetcher and expo-resource-fetcher packages rarely change, but the publish workflows ran on a nightly cron, flooding npm with effectively identical versions. Drop the `schedule` trigger from both workflows; keep `workflow_dispatch` (with the `latest-build` toggle) so we can still publish manually — including a nightly tag — when needed.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

CI-only change. Verify in the Actions tab that "NPM publish bare-resource-fetcher" and "NPM publish expo-resource-fetcher" no longer list a scheduled trigger but can still be dispatched manually.

### Screenshots

### Related issues

Closes #1167

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes