### PR TITLE
docs: document phonemis submodule init for demo apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,13 @@ We currently host a few example [apps](https://github.com/software-mansion/react
 - `text-embeddings` - Computing text representations for semantic search
 - `bare-rn` - LLM chat example for bare React Native (without Expo)
 
-If you would like to run a demo app, navigate to its project directory. Then install dependencies and run app with:
+If you would like to run a demo app, first initialize the required git submodules from the repository root:
+
+```bash
+git submodule update --init packages/react-native-executorch/third-party/common
+```
+
+Then navigate to its project directory, install dependencies and run app with:
 
 ```bash
 yarn && yarn <ios|android>

--- a/readmes/README_cn.md
+++ b/readmes/README_cn.md
@@ -142,7 +142,13 @@ const handleGenerate = async () => {
 - `text-embeddings` - 用于语义搜索的文本表示计算
 - `bare-rn` - 适用于原生 React Native（无 Expo）的 LLM 聊天示例
 
-如果您想运行示例应用程序，请导航到其项目目录。然后安装依赖项并运行应用：
+如果您想运行示例应用程序，请先在代码库根目录初始化所需的 git 子模块：
+
+```bash
+git submodule update --init packages/react-native-executorch/third-party/common
+```
+
+然后导航到其项目目录，安装依赖项并运行应用：
 
 ```bash
 yarn && yarn <ios|android>

--- a/readmes/README_es.md
+++ b/readmes/README_es.md
@@ -142,7 +142,13 @@ Actualmente alojamos algunos ejemplos de [aplicaciones](https://github.com/softw
 - `text-embeddings` - Cálculo de representaciones de texto para búsqueda semántica
 - `bare-rn` - Ejemplo de chat LLM para React Native puro (sin Expo)
 
-Si deseas ejecutar una aplicación de demostración, navega a su directorio de proyecto. Luego instala las dependencias y ejecuta la app con:
+Si deseas ejecutar una aplicación de demostración, primero inicializa los submódulos de git necesarios desde la raíz del repositorio:
+
+```bash
+git submodule update --init packages/react-native-executorch/third-party/common
+```
+
+Luego navega a su directorio de proyecto, instala las dependencias y ejecuta la app con:
 
 ```bash
 yarn && yarn <ios|android>

--- a/readmes/README_fr.md
+++ b/readmes/README_fr.md
@@ -142,7 +142,13 @@ Nous hébergeons actuellement quelques applications [exemples](https://github.co
 - `text-embeddings` - Calcul de représentations textuelles pour la recherche sémantique
 - `bare-rn` - Exemple de chat LLM pour React Native sans Expo
 
-Si vous souhaitez exécuter une application de démonstration, accédez à son répertoire de projet. Puis installez les dépendances et lancez l'application avec :
+Si vous souhaitez exécuter une application de démonstration, initialisez d'abord les sous-modules git nécessaires depuis la racine du dépôt :
+
+```bash
+git submodule update --init packages/react-native-executorch/third-party/common
+```
+
+Puis accédez à son répertoire de projet, installez les dépendances et lancez l'application avec :
 
 ```bash
 yarn && yarn <ios|android>

--- a/readmes/README_in.md
+++ b/readmes/README_in.md
@@ -142,7 +142,13 @@ const handleGenerate = async () => {
 - `text-embeddings` - अर्थ सेमांटिक खोज के लिए पाठ प्रस्तुतिकरण की गणना
 - `bare-rn` - bare React Native (Expo के बिना) के लिए LLM चैट उदाहरण
 
-यदि आप डेमो ऐप चलाना चाहते हैं, तो इसके प्रोजेक्ट डायरेक्टरी में नेविगेट करें। फिर निर्भरता इंस्टॉल करें और ऐप चलाएं:
+यदि आप डेमो ऐप चलाना चाहते हैं, तो पहले रिपॉजिटरी रूट से आवश्यक git submodules आरंभ करें:
+
+```bash
+git submodule update --init packages/react-native-executorch/third-party/common
+```
+
+फिर इसके प्रोजेक्ट डायरेक्टरी में नेविगेट करें, निर्भरता इंस्टॉल करें और ऐप चलाएं:
 
 ```bash
 yarn && yarn <ios|android>

--- a/readmes/README_pt.md
+++ b/readmes/README_pt.md
@@ -142,7 +142,13 @@ Atualmente, hospedamos alguns [apps](https://github.com/software-mansion/react-n
 - `text-embeddings` - Computação de representações de texto para busca semântica
 - `bare-rn` - Exemplo de chat LLM para React Native puro (sem Expo)
 
-Se deseja executar um aplicativo de demonstração, navegue até seu diretório de projeto. Em seguida, instale as dependências e execute o aplicativo com:
+Se deseja executar um aplicativo de demonstração, primeiro inicialize os submódulos do git necessários a partir da raiz do repositório:
+
+```bash
+git submodule update --init packages/react-native-executorch/third-party/common
+```
+
+Em seguida, navegue até seu diretório de projeto, instale as dependências e execute o aplicativo com:
 
 ```bash
 yarn && yarn <ios|android>


### PR DESCRIPTION
## Description

The TTS pipeline depends on the `phonemis` git submodule under `packages/react-native-executorch/third-party/common`, which isn't pulled by a plain `git clone`. The demo-app instructions in the root README and all translated READMEs (`readmes/README_{cn,es,fr,in,pt}.md`) skipped this step, so running any TTS-touching demo fails out of the box. This PR adds the scoped `git submodule update --init packages/react-native-executorch/third-party/common` step to each README. Scoped to `.../common` instead of `--recursive` so we don't pull `tokenizers-cpp` and `googletest`, which the demo apps don't need.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

1. Fresh-clone the repo without `--recurse-submodules`.
2. Follow the updated Demo Apps section.
3. Confirm the speech app builds and runs end-to-end.

### Screenshots

### Related issues

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes