### PR TITLE
fix(hooks): allow VAD streamInsert/streamStop during streaming

### DIFF
--- a/packages/react-native-executorch/src/hooks/natural_language_processing/useVAD.ts
+++ b/packages/react-native-executorch/src/hooks/natural_language_processing/useVAD.ts
@@ -9,14 +9,20 @@ import { useModuleFactory } from '../useModuleFactory';
  * @returns Ready to use VAD model.
  */
 export const useVAD = ({ model, preventLoad = false }: VADProps): VADType => {
-  const { error, isReady, isGenerating, downloadProgress, runForward } =
-    useModuleFactory({
-      factory: (config, onProgress) =>
-        VADModule.fromModelName(config, onProgress),
-      config: model,
-      deps: [model.modelName, model.modelSource],
-      preventLoad,
-    });
+  const {
+    error,
+    isReady,
+    isGenerating,
+    downloadProgress,
+    runForward,
+    runSideChannel,
+  } = useModuleFactory({
+    factory: (config, onProgress) =>
+      VADModule.fromModelName(config, onProgress),
+    config: model,
+    deps: [model.modelName, model.modelSource],
+    preventLoad,
+  });
 
   const forward = (waveform: Float32Array) =>
     runForward((inst) => inst.forward(waveform));
@@ -25,16 +31,9 @@ export const useVAD = ({ model, preventLoad = false }: VADProps): VADType => {
     runForward((inst) => inst.stream(input));
 
   const streamInsert = (waveform: Float32Array) =>
-    runForward((inst) => {
-      inst.streamInsert(waveform);
-      return Promise.resolve();
-    });
+    runSideChannel((inst) => inst.streamInsert(waveform));
 
-  const streamStop = () =>
-    runForward((inst) => {
-      inst.streamStop();
-      return Promise.resolve();
-    });
+  const streamStop = () => runSideChannel((inst) => inst.streamStop());
 
   return {
     error,

--- a/packages/react-native-executorch/src/hooks/useModuleFactory.ts
+++ b/packages/react-native-executorch/src/hooks/useModuleFactory.ts
@@ -14,7 +14,7 @@ type RunOnFrame<M> = M extends { runOnFrame: infer R } ? R : never;
  * not-loaded / already-generating guards so individual hooks only need to
  * define their typed `forward` wrapper.
  * @param props - Options object containing the factory function, config, deps array, and optional preventLoad flag.
- * @returns An object with error, isReady, isGenerating, downloadProgress, runForward, instance, and runOnFrame.
+ * @returns An object with error, isReady, isGenerating, downloadProgress, runForward, runSideChannel, instance, and runOnFrame.
  * @internal
  */
 export function useModuleFactory<M extends Deletable, Config>({
@@ -89,6 +89,16 @@ export function useModuleFactory<M extends Deletable, Config>({
     }
   };
 
+  // Non-gating call path for streaming modules: only checks `isReady`, never
+  // `isGenerating`. Lets side-channel methods (e.g. `streamInsert` buffer push,
+  // `streamStop` interrupt signal) run while `stream`/`forward` is in flight.
+  const runSideChannel = <R>(fn: (instance: M) => R): R => {
+    if (!isReady || !instance) {
+      throw new RnExecutorchError(RnExecutorchErrorCode.ModuleNotLoaded);
+    }
+    return fn(instance);
+  };
+
   const runOnFrame = useMemo(
     () =>
       instance && 'runOnFrame' in instance
@@ -103,6 +113,7 @@ export function useModuleFactory<M extends Deletable, Config>({
     isGenerating,
     downloadProgress,
     runForward,
+    runSideChannel,
     instance,
     runOnFrame,
   };


### PR DESCRIPTION
## Description

`useVAD` exposed `stream`, `streamInsert`, and `streamStop` all through `useModuleFactory.runForward`, which rejects calls while `isGenerating === true`. Once `stream()` was in flight, every `streamInsert(chunk)` rejected with *"model is currently generating"* — making the streaming API unusable in practice.

Add a `runSideChannel` primitive to `useModuleFactory` that only checks `isReady` (never `isGenerating` and never flips it). Streaming hooks now have two regimes:

- Gated (`runForward`): `forward`, `stream` — one at a time.
- Side-channel (`runSideChannel`): `streamInsert`, `streamStop` — allowed *during* a running stream.

`useVAD.streamInsert` / `streamStop` now use `runSideChannel`. `useTextToSpeech` and `useSpeechToText` aren't affected (they avoid `useModuleFactory` entirely for their side-channel methods); they're candidates for a follow-up migration onto the new primitive.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

End-to-end on the `apps/speech` Voice Activity Detection screen:

1. Build and install the speech app on an Android device (mic required; the screen disables Start on simulators).
2. Tap **Start VAD Stream** multiple times very quick, speak and pause. With this PR: `SPEAKING` / `SILENT` events appear in the log as expected. Without it (`git checkout HEAD~1 -- packages/react-native-executorch/src/hooks/{useModuleFactory.ts,natural_language_processing/useVAD.ts}` and reload Metro): `streamInsert` rejects on every 100 ms audio chunk and no SPEAKING transition fires and error occurs.

### Related issues

Fixes #1173