### PR TITLE
refactor(vad): store duration constants in ms instead of hops

### DIFF
--- a/packages/react-native-executorch/common/rnexecutorch/models/voice_activity_detection/Constants.h
+++ b/packages/react-native-executorch/common/rnexecutorch/models/voice_activity_detection/Constants.h
@@ -21,9 +21,9 @@ inline constexpr auto kPaddedWindowSize = std::bit_ceil(kWindowSize); // 512
 inline constexpr size_t kModelInputMin = 100;
 inline constexpr size_t kModelInputMax = 1000;
 inline constexpr auto kSpeechThreshold = 0.6f;
-inline constexpr size_t kMinSpeechDuration = 25;                 // 250 ms
-inline constexpr size_t kMinSilenceDuration = 10;                // 100 ms
-inline constexpr size_t kSpeechPad = 3;                          // 30 ms
+inline constexpr size_t kMinSpeechDurationMs = 250;
+inline constexpr size_t kMinSilenceDurationMs = 100;
+inline constexpr size_t kSpeechPadMs = 30;
 inline constexpr size_t kStreamBufferMaxSize = 10 * kSampleRate; // 10s
 inline constexpr size_t kStreamBufferMinReserve =
     1 * kSampleRate; // 1s of audio

--- a/packages/react-native-executorch/common/rnexecutorch/models/voice_activity_detection/VoiceActivityDetection.cpp
+++ b/packages/react-native-executorch/common/rnexecutorch/models/voice_activity_detection/VoiceActivityDetection.cpp
@@ -209,7 +209,7 @@ VoiceActivityDetection::postprocess(const std::vector<float> &scores,
       if (score >= threshold) {
         if (potentialStart == -1) {
           potentialStart = i;
-        } else if (i - potentialStart >= kMinSpeechDuration) {
+        } else if (i - potentialStart >= kMinSpeechDurationMs / kHopLengthMs) {
           triggered = true;
           startSegment = potentialStart;
           potentialStart = -1;
@@ -221,7 +221,7 @@ VoiceActivityDetection::postprocess(const std::vector<float> &scores,
       if (score < threshold) {
         if (potentialEnd == -1) {
           potentialEnd = i;
-        } else if (i - potentialEnd >= kMinSilenceDuration) {
+        } else if (i - potentialEnd >= kMinSilenceDurationMs / kHopLengthMs) {
           triggered = false;
           endSegment = potentialEnd;
           speechSegments.emplace_back(startSegment, endSegment);
@@ -237,11 +237,12 @@ VoiceActivityDetection::postprocess(const std::vector<float> &scores,
     speechSegments.emplace_back(startSegment, endSegment);
   }
 
+  constexpr size_t kSpeechPadHops = kSpeechPadMs / kHopLengthMs;
   for (auto &[start, end] : speechSegments) {
-    // std::max(start-kSpeedchPad, 0) might be underflow that is why we use ?
+    // std::max(start-kSpeechPadHops, 0) might be underflow that is why we use ?
     // operator.
-    start = (start > kSpeechPad ? start - kSpeechPad : 0) * kHopLength;
-    end = std::min(end + kSpeechPad, scores.size()) * kHopLength;
+    start = (start > kSpeechPadHops ? start - kSpeechPadHops : 0) * kHopLength;
+    end = std::min(end + kSpeechPadHops, scores.size()) * kHopLength;
   }
 
   // Merge tightly placed segments according to the max allowed gap parameter.


### PR DESCRIPTION
## Description

`kMinSpeechDuration`, `kMinSilenceDuration` and `kSpeechPad` were stored as hop counts with trailing comments hinting the ms equivalent. The unit implicitly depended on `kHopLengthMs`, and the comments would rot the moment someone changed it.

Rename to `*Ms` to match the `kWindowSizeMs` / `kHopLengthMs` convention and convert to hops at the use site via `/ kHopLengthMs`. Now `kHopLengthMs` changes propagate automatically and the source-of-truth unit is explicit in the name.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

Refactor only — values are unchanged (`250 / 10 = 25`, `100 / 10 = 10`, `30 / 10 = 3`). Existing VAD behavior should be identical.

### Screenshots

### Related issues

Closes #1172

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

Per discussion in the issue, picked option 2 (ms-based source of truth) over the rename-with-`Hops`-suffix option because it survives changes to `kHopLengthMs`.