### PR TITLE
feat(executorch-bindings): accept Float16Array dataPtr for fp16 tensors

### DIFF
--- a/docs/docs/03-hooks/03-executorch-bindings/useExecutorchModule.md
+++ b/docs/docs/03-hooks/03-executorch-bindings/useExecutorchModule.md
@@ -47,7 +47,7 @@ You need more details? Check the following resources:
 
 [`TensorPtr`](../../06-api-reference/interfaces/TensorPtr.md) is a JS representation of the underlying tensor, which is then passed to the model. You can read more about creating tensors [here](https://docs.pytorch.org/executorch/stable/extension-tensor.html). On JS side, the TensorPtr holds the following information:
 
-[`dataPtr`](../../06-api-reference/interfaces/TensorPtr.md#dataptr) - Represents a data buffer that will be used to create a tensor on the native side. This can be either an `ArrayBuffer` or a `TypedArray`. If your model takes in a datatype which is not covered by any of the `TypedArray` types, just pass an `ArrayBuffer` here.
+[`dataPtr`](../../06-api-reference/interfaces/TensorPtr.md#dataptr) - Represents a data buffer that will be used to create a tensor on the native side. This can be either an `ArrayBuffer` or a `TypedArray` (including `Float16Array` for half-precision tensors paired with `ScalarType.HALF`). For datatypes without a matching `TypedArray` — e.g. `bfloat16` — pack the raw bytes into an `ArrayBuffer` (or a `Uint16Array` view) and pass it directly.
 
 [`sizes`](../../06-api-reference/interfaces/TensorPtr.md#sizes) - Represents a shape of a given tensor, i.e. for a 640x640 RGB image with a batch size of 1, you would need to pass `[1, 3, 640, 640]` here.
 

--- a/packages/react-native-executorch/src/types/common.ts
+++ b/packages/react-native-executorch/src/types/common.ts
@@ -34,7 +34,7 @@ export enum ScalarType {
    */
   LONG = 4,
   /**
-   * Half-precision floating point type (16-bit).
+   * Half-precision (IEEE 754 binary16) floating point type. Pair with a `Float16Array` data buffer.
    */
   HALF = 5,
   /**
@@ -109,6 +109,7 @@ export enum ScalarType {
  */
 export type TensorBuffer =
   | ArrayBuffer
+  | Float16Array
   | Float32Array
   | Float64Array
   | Int8Array


### PR DESCRIPTION
## Description

Adds `Float16Array` to the `TensorBuffer` union so users running fp16-exported models can pass half-precision inputs ergonomically alongside the already-defined `ScalarType.HALF`. The native input path at `JsiConversions.h` already reads the underlying `ArrayBuffer` raw and forwards the integer `scalarType`, so no native changes are needed — TS 5.9 ships `Float16Array` in `lib.esnext.float16.d.ts` and the package targets `ESNext`.

`bfloat16` is intentionally left out: JS has no `BFloat16Array`, so callers who need it can still pack the raw bytes into an `ArrayBuffer` (or a `Uint16Array` view) — this is now noted in the docs.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

- `tsc --noEmit` on `packages/react-native-executorch` passes.
- Construct a `TensorPtr` with `dataPtr: new Float16Array(...)` and `scalarType: ScalarType.HALF`; type-checks and forwards to ExecuTorch as half-precision.

### Screenshots

### Related issues

Partially addresses #373 (fp16 only; bf16 has no JS TypedArray and is out of scope here).

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes