### PR TITLE
ci: verify generated error codes stay in sync with errors.config.ts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,14 @@ jobs:
       - name: Typecheck files
         run: yarn workspaces foreach --all --topological-dev run prepare && yarn typecheck
 
+      - name: Verify error codes are up to date
+        run: |
+          yarn codegen:errors
+          git diff --exit-code -- \
+            packages/react-native-executorch/src/errors/ErrorCodes.ts \
+            packages/react-native-executorch/common/rnexecutorch/ErrorCodes.h \
+            || { echo "::error::Error codes are stale. Run 'yarn codegen:errors' and commit the result."; exit 1; }
+
   build-library:
     runs-on: ubuntu-latest
     steps:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,6 +12,11 @@ pre-commit:
       run: npx prettier --write {staged_files} && git add {staged_files}
     format-objc:
       glob: '*.{h,hpp,m,mm,c,cpp}'
+      # ErrorCodes.h is generated verbatim by `yarn codegen:errors` and verified
+      # in CI with a raw diff; clang-format would rewrap its comments and break
+      # that check, so it is excluded here.
+      exclude:
+        - 'packages/react-native-executorch/common/rnexecutorch/ErrorCodes.h'
       run: clang-format -i {staged_files} && git add {staged_files}
     format-kotlin:
       glob: '*.{kt}'

--- a/packages/react-native-executorch/common/rnexecutorch/ErrorCodes.h
+++ b/packages/react-native-executorch/common/rnexecutorch/ErrorCodes.h
@@ -9,33 +9,27 @@ namespace rnexecutorch {
 
 enum class RnExecutorchErrorCode : int32_t {
   /**
-   * An umbrella-error that is thrown usually when something unexpected happens,
-   * for example a 3rd-party library error.
+   * An umbrella-error that is thrown usually when something unexpected happens, for example a 3rd-party library error.
    */
   UnknownError = 101,
   /**
-   * Thrown when a user tries to run a model that is not yet downloaded or
-   * loaded into memory.
+   * Thrown when a user tries to run a model that is not yet downloaded or loaded into memory.
    */
   ModuleNotLoaded = 102,
   /**
-   * An error ocurred when saving a file. This could be, for instance a result
-   * image from an image model.
+   * An error ocurred when saving a file. This could be, for instance a result image from an image model.
    */
   FileWriteFailed = 103,
   /**
-   * Thrown when a user tries to run a model that is currently processing. It is
-   * only allowed to run a single model prediction at a time.
+   * Thrown when a user tries to run a model that is currently processing. It is only allowed to run a single model prediction at a time.
    */
   ModelGenerating = 104,
   /**
-   * Thrown when a language is passed to a multi-language model that is not
-   * supported. For example OCR or Speech To Text.
+   * Thrown when a language is passed to a multi-language model that is not supported. For example OCR or Speech To Text.
    */
   LanguageNotSupported = 105,
   /**
-   * Thrown when config parameters passed to a model are invalid. For example,
-   * when LLM's topp is outside of range [0, 1].
+   * Thrown when config parameters passed to a model are invalid. For example, when LLM's topp is outside of range [0, 1].
    */
   InvalidConfig = 112,
   /**
@@ -43,34 +37,27 @@ enum class RnExecutorchErrorCode : int32_t {
    */
   ThreadPoolError = 113,
   /**
-   * Thrown when a file read operation failed. This could be invalid image url
-   * passed to image models, or unsupported format.
+   * Thrown when a file read operation failed. This could be invalid image url passed to image models, or unsupported format.
    */
   FileReadFailed = 114,
   /**
-   * Thrown when the size of model output is unexpected. If you're using your
-   * custom model with any of the pre-defined modules, please verify docs or
-   * source code for the expected model I/O contract.
+   * Thrown when the size of model output is unexpected. If you're using your custom model with any of the pre-defined modules, please verify docs or source code for the expected model I/O contract.
    */
   InvalidModelOutput = 115,
   /**
-   * Thrown when the dimensions of input tensors don't match the model's
-   * expected dimensions.
+   * Thrown when the dimensions of input tensors don't match the model's expected dimensions.
    */
   WrongDimensions = 116,
   /**
-   * Thrown when the input passed to our APIs is invalid, for example when
-   * passing an empty message array to LLM's generate().
+   * Thrown when the input passed to our APIs is invalid, for example when passing an empty message array to LLM's generate().
    */
   InvalidUserInput = 117,
   /**
-   * Thrown when the number of downloaded files is unexpected, due to download
-   * interruptions.
+   * Thrown when the number of downloaded files is unexpected, due to download interruptions.
    */
   DownloadInterrupted = 118,
   /**
-   * Thrown when a feature or platform is not supported in the current
-   * environment.
+   * Thrown when a feature or platform is not supported in the current environment.
    */
   PlatformNotSupported = 119,
   /**
@@ -78,10 +65,7 @@ enum class RnExecutorchErrorCode : int32_t {
    */
   InvalidModelSource = 120,
   /**
-   * Thrown when the number of passed inputs to the model is different than the
-   * model metadata specifies. If you're using your custom model with any of the
-   * pre-defined modules, please verify docs or source code for the expected
-   * model I/O contract.
+   * Thrown when the number of passed inputs to the model is different than the model metadata specifies. If you're using your custom model with any of the pre-defined modules, please verify docs or source code for the expected model I/O contract.
    */
   UnexpectedNumInputs = 121,
   /**
@@ -89,28 +73,23 @@ enum class RnExecutorchErrorCode : int32_t {
    */
   TokenizerError = 122,
   /**
-   * Thrown when there's a configuration mismatch between multilingual and
-   * language settings in Speech-to-Text models.
+   * Thrown when there's a configuration mismatch between multilingual and language settings in Speech-to-Text models.
    */
   MultilingualConfiguration = 160,
   /**
-   * Thrown when streaming transcription is attempted but audio data chunk is
-   * missing.
+   * Thrown when streaming transcription is attempted but audio data chunk is missing.
    */
   MissingDataChunk = 161,
   /**
-   * Thrown when trying to stop or insert data into a stream that hasn't been
-   * started.
+   * Thrown when trying to stop or insert data into a stream that hasn't been started.
    */
   StreamingNotStarted = 162,
   /**
-   * Thrown when trying to start a new streaming session while another is
-   * already in progress.
+   * Thrown when trying to start a new streaming session while another is already in progress.
    */
   StreamingInProgress = 163,
   /**
-   * Thrown when a resource fails to download. This could be due to invalid URL,
-   * or for example a network problem.
+   * Thrown when a resource fails to download. This could be due to invalid URL, or for example a network problem.
    */
   ResourceFetcherDownloadFailed = 180,
   /**
@@ -126,8 +105,7 @@ enum class RnExecutorchErrorCode : int32_t {
    */
   ResourceFetcherAlreadyOngoing = 183,
   /**
-   * Thrown when trying to pause, resume, or cancel a download that is not
-   * active.
+   * Thrown when trying to pause, resume, or cancel a download that is not active.
    */
   ResourceFetcherNotActive = 184,
   /**
@@ -139,9 +117,7 @@ enum class RnExecutorchErrorCode : int32_t {
    */
   ResourceFetcherAdapterNotInitialized = 186,
   /**
-   * Thrown when the platform does not support the resource fetching feature,
-   * which is required for downloading models and other resources in React
-   * Native ExecuTorch.
+   * Thrown when the platform does not support the resource fetching feature, which is required for downloading models and other resources in React Native ExecuTorch.
    */
   ResourceFetcherPlatformNotSupported = 187,
 };


### PR DESCRIPTION
## Description

`scripts/generate-errors.ts` (`yarn codegen:errors`) is the single source of truth for error codes, emitting `src/errors/ErrorCodes.ts` and `common/rnexecutorch/ErrorCodes.h`. Nothing in CI verified the committed generated files match `errors.config.ts`, so a contributor editing the config (or a generated file) without rerunning codegen could commit sources that silently disagree across the JSI boundary.

This adds a `lint`-job step that reruns codegen and diffs both generated files against what's committed, failing CI on drift. No native toolchain needed.

While wiring this up, the committed `ErrorCodes.h` is now stored verbatim as the generator emits it. The `clang-format` pre-commit hook previously rewrapped its comments, which would have made the raw diff fail in CI, so the generated header is excluded from that hook.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

1. Edit `scripts/errors.config.ts` (e.g. rename a code) without running codegen.
2. The new "Verify error codes are up to date" CI step fails with a stale-codes error.
3. Run `yarn codegen:errors`, commit the result — the step passes.

### Related issues

Closes #1209

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
