### PR TITLE
fix(ci): gate node_modules diagnostic on existing step id

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -90,9 +90,8 @@ jobs:
 
       - name: Show packed node_modules
         working-directory: ${{ env.EXECUTORCH_DIR }}
-        if: failure() && steps.node_modules.outcome == 'failure'
-        run: >-
-          ! grep -E "node_modules/.+" build.log
+        if: failure() && steps.check_node_modules.outcome == 'failure'
+        run: grep -E "node_modules/.+" build.log
 
       - name: Add package name to env
         working-directory: ${{ env.EXECUTORCH_DIR }}


### PR DESCRIPTION
## Description

The "Show packed node_modules" diagnostic in `.github/workflows/npm-publish.yml` was gated on `steps.node_modules.outcome == 'failure'`, but no step has `id: node_modules` — the check step's id is `check_node_modules`. The condition was therefore always undefined and the diagnostic never ran. On a `node_modules` leak the publish job failed (correctly, via `check_node_modules`) but the log showing *which* paths leaked was silently skipped.

This fixes the id reference and drops the exit-code inversion (`!`) so the step prints the matching paths and reports success.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

CI-only change. Verify the workflow still parses and that the `Show packed node_modules` step references `steps.check_node_modules.outcome`.

### Related issues

Closes #1210

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings