### PR TITLE
fix(docs): move banners inline with badges and update urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@
   </h1>
 </div>
 
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-executorch-1?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-executorch-1&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-executorch-2?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-executorch-2&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-react-native-executorch-3?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-react-native-executorch-3&n=1)
-
 <div align="center">
+  <a href="https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-executorch-1&n=1"><img src="https://swm-delivery.com/www/images/zone-gh-react-native-executorch-1?n=1" /></a>
+  <a href="https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-executorch-2&n=1"><img src="https://swm-delivery.com/www/images/zone-gh-react-native-executorch-2?n=1" /></a>
+  <a href="https://swm-delivery.com/www/delivery/ck-slug.php?zoneid=zone-gh-react-native-executorch-3&n=1"><img src="https://swm-delivery.com/www/images/zone-gh-react-native-executorch-3?n=1" /></a>
   <a href="https://github.com/software-mansion/react-native-executorch/graphs/contributors"><img src="https://img.shields.io/github/contributors/software-mansion/react-native-executorch?style=for-the-badge&color=00008B" alt="GitHub - Contributors"></a>
   <a href="https://github.com/software-mansion/react-native-executorch/stargazers"><img src="https://img.shields.io/github/stars/software-mansion/react-native-executorch?style=for-the-badge&color=00008B" alt="GitHub - Stars"></a>
   <a href="https://discord.gg/ZGqqY55qkP"><img src="https://img.shields.io/badge/Discord-Join%20Us-00008B?logo=discord&logoColor=white&style=for-the-badge" alt="Join our Discord community"></a>


### PR DESCRIPTION
## Description

Moves readme banners to the same block as the badges. Updates banners urls so clicks redirect correctly.

### Introduces a breaking change?

- [ ] Yes
- [X] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [X] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions


### Screenshots

### Related issues

Banners were introduced in #1054

### Checklist

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes
