### PR TITLE
fix(docs): disable Algolia Ask AI side panel to stop cookie widget overlap

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -198,7 +198,7 @@ const config = {
   customFields: {
     algolia: {
       suggestedQuestions: true,
-      enableSidePanel: true,
+      enableSidePanel: false,
     },
   },
 };


### PR DESCRIPTION
## Description

The floating Algolia "Ask AI" launcher (`.DocSearch-SidepanelButton.floating`) is pinned to the bottom-right corner, where it overlaps the GTM-injected cookie-consent widget. This sets `customFields.algolia.enableSidePanel: false`, which removes the redundant floating button. Ask AI is still reachable from inside the search modal, so no functionality is lost.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

1. `cd docs && yarn build && yarn serve` (or run the deployed site, since the cookie widget only loads via GTM there).
2. Confirm the bottom-right corner no longer shows the floating Ask AI button overlapping the cookie-consent widget.
3. Open search (⌘K) and confirm Ask AI is still available from within the modal.

### Screenshots

<img width="287" height="210" alt="image" src="https://github.com/user-attachments/assets/9494e632-b77e-4f35-ba83-0af3c2910e34" />


### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

The cookie-consent widget is injected at runtime via the GTM container and is org-level, so the fix is applied on the Algolia side.
