### PR TITLE
ci: add one-off webrtc bootstrap publish workflow

### DIFF
--- a/.github/workflows/npm-publish-webrtc-bootstrap.yml
+++ b/.github/workflows/npm-publish-webrtc-bootstrap.yml
@@ -1,0 +1,72 @@
+name: NPM publish webrtc bootstrap (one-off)
+
+# One-off workflow to perform the FIRST publish of react-native-executorch-webrtc.
+# The shared software-mansion/npm-package-publish action (used by
+# npm-publish-satellites.yml) publishes without `--access public`, which npm
+# rejects for a brand-new package when `--provenance` is requested. Once this
+# bootstrap has published 0.9.0 (creating the package as public), all future
+# webrtc releases go through npm-publish-satellites.yml and this file can be
+# deleted.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry run — pack only, do not publish'
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: 'npm-webrtc-bootstrap'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: github.repository == 'software-mansion/react-native-executorch'
+    runs-on: ubuntu-latest
+    environment: deployment
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      PACKAGE_DIR: packages/react-native-executorch-webrtc
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'yarn'
+          registry-url: https://registry.npmjs.org/
+
+      - name: Update NPM
+        run: npm install -g npm@latest
+
+      - name: Install monorepo dependencies
+        run: yarn install --immutable
+
+      - name: Build core package
+        working-directory: packages/react-native-executorch
+        run: yarn prepare
+
+      - name: Build package
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: yarn prepare
+
+      - name: Pack package
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: npm pack
+
+      - name: Publish package to npm
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: |
+          DRY_RUN_ARG=""
+          if [ "${{ inputs.dry-run }}" = "true" ]; then DRY_RUN_ARG="--dry-run"; fi
+          npm publish react-native-executorch-webrtc-*.tgz --tag latest --provenance --access public $DRY_RUN_ARG


### PR DESCRIPTION
## Description

One-off workflow to perform the **first** publish of `react-native-executorch-webrtc` to npm.

The shared `software-mansion/npm-package-publish` action (used by `npm-publish-satellites.yml`) publishes without `--access public`. npm rejects that for a brand-new package when `--provenance` is requested (`EUSAGE: Can't generate provenance for new or private package, you must set access to public`). This workflow does the initial publish with `npm publish --access public --provenance`, creating the package as public with a provenance attestation on 0.9.0.

Once 0.9.0 is on npm, all future webrtc releases go through `npm-publish-satellites.yml` (the package then already exists as public), and this file should be deleted.

`dry-run` defaults to `true`; set it to `false` for the actual publish.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

Dispatch this workflow with `dry-run: true` to confirm the pack + publish dry-run succeeds, then with `dry-run: false` to publish 0.9.0.

### Screenshots

### Related issues

Follow-up to #1258 and #1261.

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

This is intentionally temporary — a follow-up will remove it after the first publish. Mirrors the auth/build setup of the previous per-package satellite workflows (`environment: deployment`, OIDC `id-token`), so it authenticates the same way bare/expo did.
