### PR TITLE
[RNE Rewrite] docs(agents): update skills to match monorepo structure

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,6 +1,6 @@
-# Agent Skills Directory
+# Development Skills Directory
 
-This directory contains specialized agent skills (recipes) to guide AI coding agents (like Antigravity or Claude Code) in extending the codebase cleanly and consistently.
+This directory contains specialized skills (recipes) to guide contributors and AI coding assistants in extending the codebase cleanly and consistently.
 
 ## Available Skills
 

--- a/.agents/skills/add-native-extension/SKILL.md
+++ b/.agents/skills/add-native-extension/SKILL.md
@@ -17,19 +17,19 @@ Use this guide to add custom, performance-critical native operations in C++ and 
 Before writing any C++ code, ensure you adhere to the following principles:
 
 1. **Amdahl's Law & Premature Optimization**:
-   * Evaluate what percentage of total inference/pipeline time the processing step occupies. If the preprocessing/postprocessing step takes `< 5%` of the total inference budget, write it in **pure TypeScript** to reduce codebase complexity and maintenance overhead.
+   - Evaluate what percentage of total inference/pipeline time the processing step occupies. If the preprocessing/postprocessing step takes `< 5%` of the total inference budget, write it in **pure TypeScript** to reduce codebase complexity and maintenance overhead.
 
 2. **Destination Tensors & Local Memory**:
-   * **Local Memory is Allowed**: You can allocate temporary native C++ memory (such as stack variables, `std::vector`s, or dynamic memory cleaned up before the function exits) for intermediate calculations.
-   * **Destination Tensors**: If the operation writes dense output, the destination tensor must be pre-allocated by the caller (in TypeScript) and passed as an argument (e.g., `sigmoid(src, dst)`).
-   * **Primitive Array Returns**: If the operation produces variable-sized non-dense outputs (like bounding box indices in Non-Maximum Suppression (NMS)), return a plain `jsi::Array` of primitives (like indices or coordinates).
-     * *Example*: `nms(boxes, scores, options)` returns a `jsi::Array` of indices (e.g., `[0, 4, 12]`) rather than a new tensor. This avoids all native memory management overhead for variable-sized outputs.
+   - **Local Memory is Allowed**: You can allocate temporary native C++ memory (such as stack variables, `std::vector`s, or dynamic memory cleaned up before the function exits) for intermediate calculations.
+   - **Destination Tensors**: If the operation writes dense output, the destination tensor must be pre-allocated by the caller (in TypeScript) and passed as an argument (e.g., `sigmoid(src, dst)`).
+   - **Primitive Array Returns**: If the operation produces variable-sized non-dense outputs (like bounding box indices in Non-Maximum Suppression (NMS)), return a plain `jsi::Array` of primitives (like indices or coordinates).
+     - _Example_: `nms(boxes, scores, options)` returns a `jsi::Array` of indices (e.g., `[0, 4, 12]`) rather than a new tensor. This avoids all native memory management overhead for variable-sized outputs.
 
 ## 🚫 Avoid / Anti-Patterns
 
-* **Do NOT return implicitly allocated JSI Tensors:** Never return newly created `TensorHostObject` instances from C++. This forces the JavaScript layer to reason about their garbage collection and manual lifetimes, leading to native memory leaks.
-* **Do NOT define default parameters in C++:** Native C++ functions must never define default argument values (e.g. `axis = -1`). Define all default values explicitly in the TypeScript wrapper layer instead.
-* **Do NOT perform in-place mutation without safety checks:** Never allow inputs and outputs to share the same underlying instance.
+- **Do NOT return implicitly allocated JSI Tensors:** Never return newly created `TensorHostObject` instances from C++. This forces the JavaScript layer to reason about their garbage collection and manual lifetimes, leading to native memory leaks.
+- **Do NOT define default parameters in C++:** Native C++ functions must never define default argument values (e.g. `axis = -1`). Define all default values explicitly in the TypeScript wrapper layer instead.
+- **Do NOT perform in-place mutation without safety checks:** Never allow inputs and outputs to share the same underlying instance.
 
 ---
 
@@ -38,10 +38,13 @@ Before writing any C++ code, ensure you adhere to the following principles:
 ## 🛠️ Step-by-Step Implementation
 
 ### Step 1: Create the Native Operation Files
+
 Under `cpp/extensions/<domain>/`, create or modify the header and implementation files for your operations:
 
 #### 1. Header (`cpp/extensions/<domain>/operations.h`)
+
 Keep the header clean and specify exact JSI install functions:
+
 ```cpp
 #pragma once
 #include <jsi/jsi.h>
@@ -53,9 +56,10 @@ namespace rnexecutorch::extensions::<domain>
 ```
 
 #### 2. Source (`cpp/extensions/<domain>/operations.cpp`)
-* Extract input and output tensors as `TensorHostObject` pointers.
-* Check bounds, shapes, types, and verify that the output tensor is **not the same instance** as the input (no unsafely managed in-place mutation).
-* Lock tensors using `std::shared_lock` (for inputs) and `std::unique_lock` (for outputs).
+
+- Extract input and output tensors as `TensorHostObject` pointers.
+- Check bounds, shapes, types, and verify that the output tensor is **not the same instance** as the input (no unsafely managed in-place mutation).
+- Lock tensors using `std::shared_lock` (for inputs) and `std::unique_lock` (for outputs).
 
 ```cpp
 #include "operations.h"
@@ -139,6 +143,7 @@ namespace rnexecutorch::extensions::<domain>
 ### Step 2: Register in Extension and Core JSI Installs
 
 1. **Extension Register** (`cpp/extensions/<domain>/install.cpp`):
+
    ```cpp
    #include "install.h"
    #include "operations.h"
@@ -154,21 +159,23 @@ namespace rnexecutorch::extensions::<domain>
    }
    ```
 
-2. **Core Register** ([cpp/RnExecutorch.cpp](../cpp/RnExecutorch.cpp)):
+2. **Core Register** ([cpp/RnExecutorch.cpp](../../../packages/react-native-executorch/cpp/RnExecutorch.cpp)):
    ```cpp
    #include "extensions/<domain>/install.h"
    // ... inside rnexecutorch::install ...
-   rnexecutorch::extensions::<domain>::install(jsiRuntime, myModule);
+   rnexecutorch::extensions::<domain>::install(jsiRuntime, module);
    ```
 
 ---
 
 ### Step 3: TypeScript Bridge & Wrappers
+
 Under `src/extensions/<domain>.ts` or `src/extensions/<domain>/index.ts`:
-* **Use the `rnexecutorchJsi` Symbol**: You must import and interact with native bindings using the `rnexecutorchJsi` symbol exported from [src/native/bridge.ts](../src/native/bridge.ts). **Do not** reference the global `__rnexecutorch_jsi__` directly throughout your wrapper files.
-* Expose the TypeScript wrapper.
-* Handle default values here instead of the C++ layer.
-* Mark wrapper functions with the `"worklet";` directive.
+
+- **Use the `rnexecutorchJsi` Symbol**: You must import and interact with native bindings using the `rnexecutorchJsi` symbol exported from [src/native/bridge.ts](../../../packages/react-native-executorch/src/native/bridge.ts). **Do not** reference the global `__rnexecutorch_jsi__` directly throughout your wrapper files.
+- Expose the TypeScript wrapper.
+- Handle default values here instead of the C++ layer.
+- Mark wrapper functions with the `"worklet";` directive.
 
 ```typescript
 import { rnexecutorchJsi } from '../native/bridge';
@@ -191,11 +198,12 @@ export function customOp(src: Tensor, dst: Tensor, factor: number = 1.0): Tensor
 ## 📋 Verification Checklist
 
 When adding a native extension, verify that:
+
 - [ ] You only implemented in C++ if the operation takes `> 5%` of the total inference budget.
 - [ ] No JSI Tensors are implicitly allocated and returned in the C++ code.
 - [ ] Input and output tensors are locked using `std::shared_lock` and `std::unique_lock` respectively.
 - [ ] In-place mutation is explicitly prevented by checking that `src != dst`.
 - [ ] No default parameter values are defined in the C++ header/source files.
-- [ ] The custom operation install function is registered in both the domain `install` function and core [cpp/RnExecutorch.cpp](../cpp/RnExecutorch.cpp).
+- [ ] The custom operation install function is registered in both the domain `install` function and core [cpp/RnExecutorch.cpp](../../../packages/react-native-executorch/cpp/RnExecutorch.cpp).
 - [ ] The TypeScript wrapper imports and uses `rnexecutorchJsi` instead of the global `__rnexecutorch_jsi__`.
 - [ ] The TypeScript wrapper is marked with the `"worklet";` directive and defines all default parameter values.

--- a/.agents/skills/add-task-pipeline/SKILL.md
+++ b/.agents/skills/add-task-pipeline/SKILL.md
@@ -17,21 +17,18 @@ Use this guide to construct end-to-end task pipelines (e.g. classification, styl
 When implementing task constructors like `create<Task>` (e.g. `createClassifier`, `createStyleTransfer`), adhere to the following rules:
 
 1. **Pre-allocating Static Tensors (`as const`)**:
-   * Statically sized scratch/output tensors required for inference should be pre-allocated inside the constructor body.
-   * Allocate them using:
+   - Statically sized scratch/output tensors required for inference should be pre-allocated inside the constructor body.
+   - Allocate them using:
      ```typescript
-     const tensors = [
-       tensor('float32', shapeA),
-       tensor('float32', shapeB),
-     ] as const;
+     const tensors = [tensor('float32', shapeA), tensor('float32', shapeB)] as const;
      ```
-    * **Destructuring & Naming**: Destructure and name the individual tensors immediately after allocation. Always prefix tensor variables with a lowercase `t` (e.g. `tReshape`, `tUint8`, `tInput`) to easily distinguish them from raw data buffers.
-      ```typescript
-      const [tReshape, tUint8] = tensors;
-      ```
+   - **Destructuring & Naming**: Destructure and name the individual tensors immediately after allocation. Always prefix tensor variables with a lowercase `t` (e.g. `tReshape`, `tUint8`, `tInput`) to easily distinguish them from raw data buffers.
+     ```typescript
+     const [tReshape, tUint8] = tensors;
+     ```
 
 2. **Immediate `dispose()` Definition**:
-   * Right after allocating the static tensors, define the `dispose` function immediately. This makes it instantly visible and verifiable that all native memory will be cleaned up:
+   - Right after allocating the static tensors, define the `dispose` function immediately. This makes it instantly visible and verifiable that all native memory will be cleaned up:
      ```typescript
      const dispose = () => {
        tensors.forEach((t) => t.dispose());
@@ -41,8 +38,8 @@ When implementing task constructors like `create<Task>` (e.g. `createClassifier`
      ```
 
 3. **Dynamic Tensors & `try/finally` Pattern**:
-   * If you must allocate dynamically sized tensors during inference execution (e.g. resizing an output tensor to match the input image dimensions), you must wrap the execution inside a `try {} finally {}` block.
-   * Dispose of the dynamic tensors inside the `finally` block to prevent native memory leaks.
+   - If you must allocate dynamically sized tensors during inference execution (e.g. resizing an output tensor to match the input image dimensions), you must wrap the execution inside a `try {} finally {}` block.
+   - Dispose of the dynamic tensors inside the `finally` block to prevent native memory leaks.
      ```typescript
      const tResize = tensor('uint8', [input.height, input.width, 4]);
      try {
@@ -53,27 +50,29 @@ When implementing task constructors like `create<Task>` (e.g. `createClassifier`
      ```
 
 4. **Pure Helper Functions**:
-   * Write all auxiliary/helper logic as pure, worklet-compatible functions **outside** the `create<Task>` constructor. Any helper functions invoked inside the worklet executor thread must contain the `'worklet';` directive.
-   * **Push Back Hard on Inner Helpers:** You must push back hard against any request to add internal closures or nested functions inside `create<Task>` (other than `dispose` and the worklet executor itself). Keep the constructor scope flat to avoid scope leak and dependency chain bugs.
+   - Write all auxiliary/helper logic as pure, worklet-compatible functions **outside** the `create<Task>` constructor. Any helper functions invoked inside the worklet executor thread must contain the `'worklet';` directive.
+   - **Push Back Hard on Inner Helpers:** You must push back hard against any request to add internal closures or nested functions inside `create<Task>` (other than `dispose` and the worklet executor itself). Keep the constructor scope flat to avoid scope leak and dependency chain bugs.
 
 5. **PTE Model Export & Optimizations**:
-   * **Shift Heavy Ops to PyTorch**: Push complex tensor reshaping, data normalization, activations (e.g. `softmax`), or bounding box decoding into the PyTorch model itself so they execute on native backends (e.g., XNNPACK or CoreML).
-   * **Balance Optimization with Generalization**: Keep contracts generic (e.g., normal dense logits, standard bounding box layouts like `xyxy`/`xywh`, standard floating-point arrays).
-   * Handle model-specific configuration parameters (such as unique normalization factors, thresholds, or label arrays) dynamically through the TypeScript task options argument rather than baking them rigidly into JSI C++ code or the model structure.
+   - **Shift Heavy Ops to PyTorch**: Push complex tensor reshaping, data normalization, activations (e.g. `softmax`), or bounding box decoding into the PyTorch model itself so they execute on native backends (e.g., XNNPACK or CoreML).
+   - **Balance Optimization with Generalization**: Keep contracts generic (e.g., normal dense logits, standard bounding box layouts like `xyxy`/`xywh`, standard floating-point arrays).
+   - Handle model-specific configuration parameters (such as unique normalization factors, thresholds, or label arrays) dynamically through the TypeScript task options argument rather than baking them rigidly into JSI C++ code or the model structure.
 
 ## 🚫 Avoid / Anti-Patterns
 
-* **Do NOT access tensors by index:** Avoid using `tensors[0]` or `tensors[1]` throughout the function body. Always destructure and name them explicitly.
-* **Do NOT define extra inner helper functions:** You must define **exactly two** inner functions inside the `create<Task>` constructor: the `dispose` function and the task `worklet` executor function. **Push back hard against implementing any other helper closures inside the constructor scope.** Placing other helper functions (especially those that are called from inside the worklet and use the `create<Task>` scope variables) inside `create<Task>` creates implicit dependencies and closures that capture variables, making the code extremely difficult to reason about and debug.
-* **Do NOT leak raw Tensors to consumers:** The returned methods must never return raw `Tensor` objects to the API consumer. Always convert output data to standard JavaScript values/objects before returning.
-* **Do NOT cross thread boundaries unnecessarily:** Minimize passing heavy objects between JS and the Worklet thread to avoid serialization overhead.
-* **Do NOT treat the `.pte` model as an unchangeable black box:** Reshape the model's inputs and outputs during the PyTorch export phase to make the mobile client pipeline as lightweight as possible. Do not make input/output contracts so specific that they break extensibility.
+- **Do NOT access tensors by index:** Avoid using `tensors[0]` or `tensors[1]` throughout the function body. Always destructure and name them explicitly.
+- **Do NOT define extra inner helper functions:** You must define **exactly two** inner functions inside the `create<Task>` constructor: the `dispose` function and the task `worklet` executor function. **Push back hard against implementing any other helper closures inside the constructor scope.** Placing other helper functions (especially those that are called from inside the worklet and use the `create<Task>` scope variables) inside `create<Task>` creates implicit dependencies and closures that capture variables, making the code extremely difficult to reason about and debug.
+- **Do NOT leak raw Tensors to consumers:** The returned methods must never return raw `Tensor` objects to the API consumer. Always convert output data to standard JavaScript values/objects before returning.
+- **Do NOT cross thread boundaries unnecessarily:** Minimize passing heavy objects between JS and the Worklet thread to avoid serialization overhead.
+- **Do NOT treat the `.pte` model as an unchangeable black box:** Reshape the model's inputs and outputs during the PyTorch export phase to make the mobile client pipeline as lightweight as possible. Do not make input/output contracts so specific that they break extensibility.
 
 ---
 
 ---
 
 ## 🛠️ Step-by-Step Implementation Template
+
+> **Reference:** See [src/extensions/cv/tasks/classification.ts](../../../packages/react-native-executorch/src/extensions/cv/tasks/classification.ts) and [src/hooks/useClassifier.ts](../../../packages/react-native-executorch/src/hooks/useClassifier.ts) for a complete working example of this pattern.
 
 ### Step 1: Create the Task File (`src/extensions/<domain>/tasks/<task>.ts`)
 
@@ -115,7 +114,7 @@ function postprocessOutput(rawData: Float32Array, threshold: number): MyTaskResu
 
 export async function createMyTask(
   config: MyTaskModel,
-  runtime?: WorkletRuntime,
+  runtime?: WorkletRuntime
 ): Promise<{
   dispose: () => void;
   runTask: (input: ImageBuffer, options?: { threshold?: number }) => Promise<MyTaskResult[]>;
@@ -129,15 +128,13 @@ export async function createMyTask(
     model,
     'forward',
     [SymbolicTensor('float32', [1, 3, 'H', 'W'], [3, 'H', 'W'])],
-    [SymbolicTensor('float32', [1, 10], [10])],
+    [SymbolicTensor('float32', [1, 10], [10])]
   );
   const inpShape = meta.inputTensorMeta[0]!.shape;
   const outShape = meta.outputTensorMeta[0]!.shape;
 
   // 2. Pre-allocate static tensors
-  const tensors = [
-    tensor('float32', outShape),
-  ] as const;
+  const tensors = [tensor('float32', outShape)] as const;
 
   // Idiomatic destructuring and naming with "t" prefix
   const [tOutput] = tensors;
@@ -151,19 +148,16 @@ export async function createMyTask(
   };
 
   // 4. Define exactly two inner functions (dispose & runTaskWorklet)
-  const runTaskWorklet = (
-    input: ImageBuffer,
-    options?: { threshold?: number }
-  ): MyTaskResult[] => {
+  const runTaskWorklet = (input: ImageBuffer, options?: { threshold?: number }): MyTaskResult[] => {
     'worklet';
-    
+
     // Process input buffer to input tensor
     const tInput = preprocessor.process(input);
     model.execute('forward', [tInput], [tOutput]);
 
     const data = tOutput.getData(new Float32Array(tOutput.numel));
     const threshold = options?.threshold ?? taskOpts.defaultThreshold;
-    
+
     // 5. Return standard JS object, never raw Tensor
     return postprocessOutput(data, threshold);
   };
@@ -176,28 +170,25 @@ export async function createMyTask(
 
 ### Step 2: Create the React Hook Wrapper (`src/hooks/use<Task>.ts`)
 
-Wrap the task pipeline in a custom React Hook using the core hooks `useModelDownload` and `useModel`. This manages downloading, compilation, error tracking, and automatic cleanup of the native memory upon unmounting or config changes.
+Wrap the task pipeline in a custom React Hook using the core hooks `useResourceDownload` and `useModel`. This manages downloading, compilation, error tracking, and automatic cleanup of the native memory upon unmounting or config changes.
 
 ```typescript
 import { useModel } from './useModel';
-import { useModelDownload } from './useModelDownload';
+import { useResourceDownload } from './useResourceDownload';
 import { createMyTask, type MyTaskModel } from '../extensions/<domain>/tasks/<task>';
 
-export function useMyTask(
-  config: MyTaskModel, 
-  options?: { preventLoad?: boolean }
-) {
+export function useMyTask(config: MyTaskModel, options?: { preventLoad?: boolean }) {
   // 1. Resolve remote or local asset model path and download progress
-  const { localPath, downloadProgress, downloadError } = useModelDownload(
+  const { localPath, downloadProgress, downloadError } = useResourceDownload(
     config.modelPath,
-    options?.preventLoad,
+    options?.preventLoad
   );
 
   // 2. Instantiate and compile the task pipeline (with automatic lifecycle cleanup)
   const { model, error } = useModel(
     createMyTask,
     localPath ? { ...config, modelPath: localPath } : null,
-    [localPath],
+    [localPath]
   );
 
   return {
@@ -216,6 +207,7 @@ export function useMyTask(
 ## 📋 Verification Checklist
 
 When adding a task pipeline or React hook, verify that:
+
 - [ ] Scratch/output tensors are pre-allocated using `tensor() as const` and prefixed with lowercase `t` (e.g. `tInput`).
 - [ ] Static tensors are destructured and named (no index-based access in the body).
 - [ ] The `dispose` function is defined immediately after static allocations.

--- a/.agents/skills/core-guidelines/SKILL.md
+++ b/.agents/skills/core-guidelines/SKILL.md
@@ -6,21 +6,22 @@ metadata:
   scope: general
 ---
 
-# RNET-POC Agent Skills & Architecture Guide
+# React Native ExecuTorch Architecture Guide
 
-Welcome, Agent! This directory contains specialized "skills" (recipes) designed to help you extend this codebase in an idiomatic, clean, and consistent manner. 
+Welcome! This directory contains specialized "skills" (recipes) designed to help you extend this codebase in an idiomatic, clean, and consistent manner.
 
-Before implementing any feature or modifying code, please find the corresponding skill folder in `.agents/skills/` and read its `SKILL.md` using the `IsSkillFile: true` option to ensure you follow the correct patterns.
+Before implementing any feature or modifying code, please find the corresponding skill folder in `.agents/skills/` and review its `SKILL.md` to ensure you follow the correct patterns.
 
 ---
 
 ## 🎯 Design Philosophy
 
 The library is designed around the separation of responsibilities into two distinct layers:
-1. **Lower-Level API (Flexible & Domain-Agnostic)**: Exposes raw bindings to native ExecuTorch capabilities (tensors, models, runtime execution, and basic math/CV operations) in C++ without task-specific code. This layer is designed to be highly flexible, allowing developer customization directly in TypeScript.
-2. **Higher-Level API (Transparent & Orchestrated)**: Built as orchestration layers **entirely in TypeScript** on top of the lower-level native bindings. Preprocessing, running model inference, and output postprocessing are composed dynamically in TS. 
 
-* **Why this matters**: In contrast to opaque native pipelines, implementing pipelines in TypeScript makes them transparent, easy to debug, highly customizable, and easy to extend without writing complex native C++ code.
+1. **Lower-Level API (Flexible & Domain-Agnostic)**: Exposes raw bindings to native ExecuTorch capabilities (tensors, models, runtime execution, and basic math/CV operations) in C++ without task-specific code. This layer is designed to be highly flexible, allowing developer customization directly in TypeScript.
+2. **Higher-Level API (Transparent & Orchestrated)**: Built as orchestration layers **entirely in TypeScript** on top of the lower-level native bindings. Preprocessing, running model inference, and output postprocessing are composed dynamically in TS.
+
+- **Why this matters**: In contrast to opaque native pipelines, implementing pipelines in TypeScript makes them transparent, easy to debug, highly customizable, and easy to extend without writing complex native C++ code.
 
 ---
 
@@ -45,18 +46,20 @@ cpp/                                    │ src/
 ```
 
 ### 1. Core (`cpp/core/` and `src/core/`)
-* **Purpose**: Implements the absolute bare minimum required for the lower-level API.
-* **Responsibilities**: Primitives for `Tensor` and `Model` management, JSI bindings, and the ExecuTorch runtime execution logic.
-* **Rule**: Core is domain-agnostic. **Do not** add task-specific or domain-specific code (like computer vision ops, tokenizers, or speech preprocessing) here.
+
+- **Purpose**: Implements the absolute bare minimum required for the lower-level API.
+- **Responsibilities**: Primitives for `Tensor` and `Model` management, JSI bindings, and the ExecuTorch runtime execution logic.
+- **Rule**: Core is domain-agnostic. **Do not** add task-specific or domain-specific code (like computer vision ops, tokenizers, or speech preprocessing) here.
 
 ### 2. Extensions (`cpp/extensions/` and `src/extensions/`)
-* **Purpose**: Contains all domain-specific logic, organized by domain (e.g., `cv`, `math`, `llm`, `speech`).
-* **Symmetry Rules**:
-  * **Native operations** (e.g. image transformations, box math) go under `cpp/extensions/<domain>/`.
-  * **JSI Installation** is registered via `cpp/extensions/<domain>/install.cpp` and exposed on the global JSI object under `__rnexecutorch_jsi__.<domain>`.
-  * **TypeScript wrappers** for these native operations go in `src/extensions/<domain>.ts` or `src/extensions/<domain>/`.
-  * **Higher-level task pipelines** (orchestration of model loading, input pre-processing, running inference, and output post-processing) are written entirely in TypeScript under `src/extensions/<domain>/tasks/`.
-  * **React Hooks** (lightweight state/lifecycle wrappers around task pipelines) go in `src/hooks/`.
+
+- **Purpose**: Contains all domain-specific logic, organized by domain (e.g., `cv`, `math`, `llm`, `speech`).
+- **Symmetry Rules**:
+  - **Native operations** (e.g. image transformations, box math) go under `cpp/extensions/<domain>/`.
+  - **JSI Installation** is registered via `cpp/extensions/<domain>/install.cpp` and exposed on the global JSI object under `__rnexecutorch_jsi__.<domain>`.
+  - **TypeScript wrappers** for these native operations go in `src/extensions/<domain>.ts` or `src/extensions/<domain>/`.
+  - **Higher-level task pipelines** (orchestration of model loading, input pre-processing, running inference, and output post-processing) are written entirely in TypeScript under `src/extensions/<domain>/tasks/`.
+  - **React Hooks** (lightweight state/lifecycle wrappers around task pipelines) go in `src/hooks/`.
 
 ---
 
@@ -64,54 +67,45 @@ cpp/                                    │ src/
 
 Use the following index to locate the specific procedural guides for your task:
 
-| I want to... | Use this Skill File | Description |
-| :--- | :--- | :--- |
-| **Add a new native operator or C++ binding** | [SKILL.md](../add-native-extension/SKILL.md) | Procedural guide to implementing C++ functions, exposing them via JSI, and writing TypeScript bridge wrappers. |
-| **Create a task pipeline or hook** | [SKILL.md](../add-task-pipeline/SKILL.md) | Guide to building end-to-end TS pipelines (e.g. object detection) and exposing them via React hooks. |
-| **Verify, rebuild, or troubleshoot changes** | [SKILL.md](../verify-and-build/SKILL.md) | Workflows for rebuilding TS/C++ and resolving common JSI runtime errors. |
-| **Validate model constraints & schemas** | [SKILL.md](../model-schema-validation/SKILL.md) | Guide on specifying SymbolicTensor constraints and shapes for model signature validation. |
+| I want to...                                 | Use this Skill File                             | Description                                                                                                    |
+| :------------------------------------------- | :---------------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
+| **Add a new native operator or C++ binding** | [SKILL.md](../add-native-extension/SKILL.md)    | Procedural guide to implementing C++ functions, exposing them via JSI, and writing TypeScript bridge wrappers. |
+| **Create a task pipeline or hook**           | [SKILL.md](../add-task-pipeline/SKILL.md)       | Guide to building end-to-end TS pipelines (e.g. object detection) and exposing them via React hooks.           |
+| **Verify, rebuild, or troubleshoot changes** | [SKILL.md](../verify-and-build/SKILL.md)        | Workflows for rebuilding TS/C++ and resolving common JSI runtime errors.                                       |
+| **Validate model constraints & schemas**     | [SKILL.md](../model-schema-validation/SKILL.md) | Guide on specifying SymbolicTensor constraints and shapes for model signature validation.                      |
 
 ---
 
-## 💡 Key Coding Conventions for Agents
+## 💡 Key Coding Conventions
 
-* **Worklets**: Ensure all TypeScript functions directly wrapping native JSI calls start with the `"worklet";` directive so they are compatible with worklet-based libraries (e.g., React Native Reanimated).
-* **Memory Management**: When writing native C++ code with JSI, pay close attention to JSI reference management and handle ExecuTorch lifecycle states safely.
-* **Keep Core Clean**: Always build on top of core primitives. Do not modify files in `cpp/core/` or `src/core/` unless you are fixing a bug in the foundational runtime.
+- **Worklets**: Ensure all TypeScript functions directly wrapping native JSI calls start with the `"worklet";` directive so they are compatible with worklet-based libraries (e.g., React Native Reanimated).
+- **Memory Management**: When writing native C++ code with JSI, pay close attention to JSI reference management and handle ExecuTorch lifecycle states safely.
+- **Keep Core Clean**: Always build on top of core primitives. Do not modify files in `cpp/core/` or `src/core/` unless you are fixing a bug in the foundational runtime.
 
 ---
 
 ## 📢 Package Registration & Exports
 
 Whenever you add a new extension, task pipeline, or hook, you **must** register and export them at the package level to make them accessible to users:
-1. **TypeScript Exports** ([src/index.ts](../src/index.ts)): Export the new task pipelines (e.g. `export * from './extensions/cv/tasks/myTask'`) and hooks (e.g. `export * from './hooks/useMyTask'`).
-2. **Model Configurations** ([src/models.ts](../src/models.ts)) & **Constants** ([src/constants.ts](../src/constants.ts)):
-   * These **two files are the sole source of truth** for defining pre-exported models, their options, and their label structures. Do not define models or options ad-hoc anywhere else.
-   * **Model Registry Rule**: You must **only export the single `models` object registry** from `models.ts`. Do not export individual model configuration constants. Define them as internal (private) `const` variables inside `models.ts` and register them under the appropriate category nested inside the exported `models` registry object.
-   * If you are introducing a standard pre-configured model, add its metadata config and HuggingFace/local URI endpoint mapping here.
+
+1. **TypeScript Exports** ([src/index.ts](../../../packages/react-native-executorch/src/index.ts)): Export the new task pipelines (e.g. `export * from './extensions/cv/tasks/myTask'`) and hooks (e.g. `export * from './hooks/useMyTask'`).
+2. **Model Configurations** ([src/models.ts](../../../packages/react-native-executorch/src/models.ts)) & **Constants** ([src/constants.ts](../../../packages/react-native-executorch/src/constants.ts)):
+   - These **two files are the sole source of truth** for defining pre-exported models, their options, and their label structures. Do not define models or options ad-hoc anywhere else.
+   - **Model Registry Rule**: You must **only export the single `models` object registry** from `models.ts`. Do not export individual model configuration constants. Define them as internal (private) `const` variables inside `models.ts` and register them under the appropriate category nested inside the exported `models` registry object.
+   - If you are introducing a standard pre-configured model, add its metadata config and HuggingFace/local URI endpoint mapping here.
 
 ---
 
-## 🔍 Model Inspection & Testing via the Example App
+## 🔍 Model Inspection & Testing via Example Apps
 
-The example app under `example/` is the primary playground for inspecting models and testing your pipelines on-device:
-1. **Inspect Screen** ([InspectScreen.tsx](../example/src/InspectScreen.tsx)): Paste any arbitrary `.pte` model URL to load and print its metadata, inputs, and outputs dynamically.
-2. **Gallery Screen** ([GalleryScreen.tsx](../example/src/GalleryScreen.tsx)): Test task pipelines (classification, detection, style transfer, segmentation) on static assets/images. When adding a new task, you should add a corresponding interactive testing card/flow here.
-3. **Camera Screen** ([CameraScreen.tsx](../example/src/CameraScreen.tsx)): Run real-time camera-based inferences using the task pipelines.
+The workspace uses a monorepo structure with domain-specific example apps under `apps/` (e.g., `apps/computer-vision`, `apps/nlp`). These are the primary playgrounds for inspecting models and testing your pipelines on-device:
+
+1. **Inspect Screen** (e.g., `apps/computer-vision/app/inspect/index.tsx`): Paste any arbitrary `.pte` model URL to load and print its metadata, inputs, and outputs dynamically.
+2. **Interactive Testing Screens** (e.g., `apps/nlp/app/tokenizer/index.tsx`): Test task pipelines interactively. When adding a new task, you should add a corresponding interactive testing card/flow in the appropriate domain's app.
+3. **Camera Screen** (e.g., `apps/computer-vision/app/camera/index.tsx`): Run real-time camera-based inferences using the task pipelines.
 
 ---
 
-## 🛠️ Verification & Rebuilding Checklist
+## 🛠️ Verification & Rebuilding
 
-To test and compile your changes:
-1. **TS Build & Typecheck**:
-   * **Verify Types (Fast)**: `yarn typecheck`
-   * **Build Bundles**: `yarn prepare` *(runs `react-native-builder-bob` to bundle TS source into the `lib/` directory)*
-2. **Native Rebuilding (iOS)**:
-   Whenever native C++ files are added or modified:
-   ```bash
-   cd example/ios && pod install && cd ../..
-   ```
-   *Then run the example app using `yarn example ios` (or `yarn ios` from `example/`).*
-3. **Native Rebuilding (Android)**:
-   *Android builds handle C++ file changes automatically upon triggering `yarn example android` (or `yarn android` from `example/`).*
+Please refer to the [Verify & Build Skill](../verify-and-build/SKILL.md) for the complete checklist on compiling TS/C++, rebuilding iOS pods, and troubleshooting native changes.

--- a/.agents/skills/verify-and-build/SKILL.md
+++ b/.agents/skills/verify-and-build/SKILL.md
@@ -3,7 +3,7 @@ name: verify-and-build
 description: Use when compiling TS/C++, rebuilding iOS pods, troubleshooting JSI runtime errors, debugging native crashes, or sync'ing Android Gradle.
 metadata:
   id: verify_and_build
-  scope: general development, example/
+  scope: general development, apps/
 ---
 
 # Skill: Verification, Compilation & Troubleshooting
@@ -15,47 +15,51 @@ Use this guide to compile, test, verify, and troubleshoot your modifications to 
 ## 🛠️ Verification & Compilation Workflows
 
 ### 1. Build and Typecheck TypeScript
+
 To check types and compile the TypeScript source code:
-* **Verify Types (Fast)**:
+
+- **Verify Types (Fast)**:
   ```bash
   yarn typecheck
   ```
-* **Build Bundles**:
+- **Build Bundles**:
   ```bash
   yarn prepare
   ```
-  *This cleans target directories and builds modules into the `lib/` directory using `react-native-builder-bob`.*
-* **When**: After adding/updating TypeScript files under `src/`.
-* **Verification**: Ensure no compiler or type-checking errors are raised.
+  _This cleans target directories and builds modules into the `lib/` directory using `react-native-builder-bob`._
+- **When**: After adding/updating TypeScript files under `src/`.
+- **Verification**: Ensure no compiler or type-checking errors are raised.
 
 ### 2. Native Rebuilding
 
 #### iOS Development
+
 Whenever you modify native files under `cpp/` or update `.podspec`:
+
 ```bash
-cd example/ios && pod install && cd ../..
+cd apps/<domain-app>/ios && pod install && cd ../../..
 ```
-* **Rebuilding**: Re-run the app from the root workspace or from the `example/` folder:
+
+- **Rebuilding**: Re-run the app from within the appropriate app folder:
   ```bash
-  # From root:
-  yarn example ios
-  # OR from example/ directory:
-  yarn ios
+  cd apps/<domain-app>
+  yarn run ios
   ```
-* **Clean Build**: If files aren't being picked up:
-  * In Xcode: `Product` > `Clean Build Folder` (Cmd + Shift + K).
+- **Clean Build**: If files aren't being picked up:
+  - In Xcode: `Product` > `Clean Build Folder` (Cmd + Shift + K).
 
 #### Android Development
+
 Android compiles C++ source files on-demand during application builds:
+
 ```bash
-# From root:
-yarn example android
-# OR from example/ directory:
-yarn android
+cd apps/<domain-app>
+yarn run android
 ```
-* **Clean Build**: If caching issues occur:
+
+- **Clean Build**: If caching issues occur:
   ```bash
-  cd android && ./gradlew clean && cd ..
+  cd apps/<domain-app>/android && ./gradlew clean && cd ../../..
   ```
 
 ---
@@ -63,14 +67,18 @@ yarn android
 ## 🔍 Debugging & Log Access
 
 ### 1. TypeScript & Worklet Logging
+
 Logging inside worklets (functions annotated with `'worklet';`) behaves slightly differently as they run on a separate runtime thread.
-* Use standard `console.log(...)` inside worklets.
-* **Caution**: Worklet logs are piped back to the JS console, but passing complex circular objects to `console.log` from a worklet can fail or freeze. Stringify or log specific primitive properties instead.
+
+- Use standard `console.log(...)` inside worklets.
+- **Caution**: Worklet logs are piped back to the JS console, but passing complex circular objects to `console.log` from a worklet can fail or freeze. Stringify or log specific primitive properties instead.
 
 ### 2. Native C++ Debugging
+
 Native JSI crashes, standard outputs, or ExecuTorch errors can be caught in the native log streams:
-* **iOS**: Watch outputs directly inside the Xcode Console while running the example target.
-* **Android**: Use Android Studio's logcat or run:
+
+- **iOS**: Watch outputs directly inside the Xcode Console while running the app target.
+- **Android**: Use Android Studio's logcat or run:
   ```bash
   adb logcat *:S ReactNative:V ReactNativeJS:V rnexecutorch:V
   ```
@@ -80,15 +88,17 @@ Native JSI crashes, standard outputs, or ExecuTorch errors can be caught in the 
 ## 🚦 Common JSI Troubleshooting
 
 ### Symptom: `Error: JSI global object '__rnexecutorch_jsi__' is not registered.`
-* **Cause 1**: The native code wasn't linked or JSI installation failed during loading.
-  * *Fix*: Verify that you have registered your new extension/module in [cpp/RnExecutorch.cpp](../cpp/RnExecutorch.cpp).
-  * *Fix*: Re-run `pod install` (for iOS) or perform a Gradle sync/clean (for Android) to ensure your C++ changes compiled.
-* **Cause 2**: The bridge did not invoke the native installation.
-  * *Fix*: Ensure the JS entrypoint triggers the load (see [src/native/bridge.ts](../src/native/bridge.ts)).
+
+- **Cause 1**: The native code wasn't linked or JSI installation failed during loading.
+  - _Fix_: Verify that you have registered your new extension/module in [cpp/RnExecutorch.cpp](../../../packages/react-native-executorch/cpp/RnExecutorch.cpp).
+  - _Fix_: Re-run `pod install` (for iOS) or perform a Gradle sync/clean (for Android) to ensure your C++ changes compiled.
+- **Cause 2**: The bridge did not invoke the native installation.
+  - _Fix_: Ensure the JS entrypoint triggers the load (see [src/native/bridge.ts](../../../packages/react-native-executorch/src/native/bridge.ts)).
 
 ### Symptom: `TypeError: Cannot read property '<extension>' of undefined`
-* **Cause**: You added an extension in C++ but forgot to register it in your TypeScript bridge bindings.
-  * *Fix*: Check that `module.setProperty(rt, "<extension>", subModule)` is called in your native `install.cpp` and that your TS wrapper exports and references it under `rnexecutorchJsi.<extension>`.
+
+- **Cause**: You added an extension in C++ but forgot to register it in your TypeScript bridge bindings.
+  - _Fix_: Check that `module.setProperty(rt, "<extension>", subModule)` is called in your native `install.cpp` and that your TS wrapper exports and references it under `rnexecutorchJsi.<extension>`.
 
 ---
 
@@ -97,15 +107,16 @@ Native JSI crashes, standard outputs, or ExecuTorch errors can be caught in the 
 This project does **not** bundle local `.pte` model files inside the React Native application package. Instead, the standard workflow is:
 
 1. **Upload to Hugging Face**:
-   * Upload compiled/exported `.pte` models directly to our Hugging Face repository bucket.
-   * **Naming Convention**: All `.pte` files must follow the strict name contract:
+   - Upload compiled/exported `.pte` models directly to our Hugging Face repository bucket.
+   - **Naming Convention**: All `.pte` files must follow the strict name contract:
      `modelname_optionalsize_backend_precision.pte`
-     * *Example*: `efficientnet_v2_s_xnnpack_int8.pte`
-     * *Example*: `style_transfer_candy_xnnpack_fp32.pte`
+     - _Example_: `efficientnet_v2_s_xnnpack_int8.pte`
+     - _Example_: `style_transfer_candy_xnnpack_fp32.pte`
 
-2. **Define in Models Manifest** ([src/models.ts](../src/models.ts)):
-   * **Single Export Registry Rule**: Define the new model configuration as an internal (private) `const` inside `models.ts`. **Do not** export individual model configuration constants. Instead, expose them solely by registering them under the appropriate category nested inside the main `models` registry object, which is the only exported symbol from `models.ts`.
-   * *Example*:
+2. **Define in Models Manifest** ([src/models.ts](../../../packages/react-native-executorch/src/models.ts)):
+   - **Single Export Registry Rule**: Define the new model configuration as an internal (private) `const` inside `models.ts`. **Do not** export individual model configuration constants. Instead, expose them solely by registering them under the appropriate category nested inside the main `models` registry object, which is the only exported symbol from `models.ts`.
+   - _Example_:
+
      ```typescript
      // Defined internally (private)
      const MY_MODEL_XNNPACK_FP32: MyTaskModel = { ... };
@@ -122,27 +133,28 @@ This project does **not** bundle local `.pte` model files inside the React Nativ
      ```
 
 3. **Runtime Downloading & Caching**:
-   * The custom hook `useModelDownload(config.modelPath)` handles checks automatically:
-     * If the model file is not already in the device cache directory, it downloads it from the Hugging Face URL to `RNFS.CachesDirectoryPath`.
-     * If the model file exists in the cache, it bypasses the download and returns the cached local path immediately to load the model.
+   - The custom hook `useResourceDownload(config.modelPath)` handles checks automatically:
+     - If the model file is not already in the device cache directory, it downloads it from the Hugging Face URL to `RNFS.CachesDirectoryPath`.
+     - If the model file exists in the cache, it bypasses the download and returns the cached local path immediately to load the model.
 
 ---
 
 ## 🚫 Avoid / Anti-Patterns
 
-* **Do NOT run code without verification:** Do not test TypeScript changes in the example app without first running `yarn typecheck` (verify types) and `yarn prepare` (build target bundles).
-* **Do NOT skip native rebuilds after C++ edits:** If any C++ files or config bindings are added/modified, do not attempt to run the app without executing `pod install` (for iOS) or letting Gradle sync (for Android).
-* **Do NOT log complex objects inside worklets:** Avoid passing complex circular objects directly to `console.log()` inside functions annotated with `'worklet';` as it can hang or crash the worklet runtime thread.
-* **Do NOT bundle local `.pte` files in the repository:** Do not commit heavy model binaries to the git repository. Always host them on Hugging Face and register their metadata in `src/models.ts`.
+- **Do NOT run code without verification:** Do not test TypeScript changes in the app without first running `yarn typecheck` (verify types) and `yarn prepare` (build target bundles).
+- **Do NOT skip native rebuilds after C++ edits:** If any C++ files or config bindings are added/modified, do not attempt to run the app without executing `pod install` (for iOS) or letting Gradle sync (for Android).
+- **Do NOT log complex objects inside worklets:** Avoid passing complex circular objects directly to `console.log()` inside functions annotated with `'worklet';` as it can hang or crash the worklet runtime thread.
+- **Do NOT bundle local `.pte` files in the repository:** Do not commit heavy model binaries to the git repository. Always host them on Hugging Face and register their metadata in `src/models.ts`.
 
 ---
 
 ## 📋 Verification Checklist
 
 When verifying or compiling your modifications, check that:
+
 - [ ] TypeScript typechecking passes without errors (`yarn typecheck`).
 - [ ] Bundles compile successfully (`yarn prepare`).
-- [ ] `pod install` has been run inside `example/ios/` after any native C++ edits.
+- [ ] `pod install` has been run inside `apps/<domain-app>/ios/` after any native C++ edits.
 - [ ] No `.pte` files are staged or added to git history.
 - [ ] Model configurations are registered inside the single `models` object registry in `src/models.ts`.
 - [ ] Native runtime issues have been investigated using Xcode Console or `adb logcat`.

--- a/.agents/skills/verify-and-build/SKILL.md
+++ b/.agents/skills/verify-and-build/SKILL.md
@@ -37,7 +37,7 @@ To check types and compile the TypeScript source code:
 Whenever you modify native files under `cpp/` or update `.podspec`:
 
 ```bash
-cd apps/<domain-app>/ios && pod install && cd ../../..
+pushd apps/<domain-app>/ios && pod install && popd
 ```
 
 - **Rebuilding**: Re-run the app from within the appropriate app folder:
@@ -59,7 +59,7 @@ yarn run android
 
 - **Clean Build**: If caching issues occur:
   ```bash
-  cd apps/<domain-app>/android && ./gradlew clean && cd ../../..
+  pushd apps/<domain-app>/android && ./gradlew clean && popd
   ```
 
 ---

--- a/.cspell-wordlist.txt
+++ b/.cspell-wordlist.txt
@@ -239,3 +239,5 @@ podspec
 logcat
 modelname
 optionalsize
+pushd
+popd

--- a/.cspell-wordlist.txt
+++ b/.cspell-wordlist.txt
@@ -230,3 +230,12 @@ c10
 probas
 Probas
 Skia
+Amdahl
+Amdahl's
+xyxy
+xywh
+subfolders
+podspec
+logcat
+modelname
+optionalsize


### PR DESCRIPTION
## Description

Updates the  `.agents/skills`  repository guidelines to reflect recent monorepo structural changes and ensures they are fully agnostic for both human contributors and AI assistants.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->
N/A

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
