### PR TITLE
[RNE Rewrite] feat: add object detection task pipeline

### DIFF
--- a/.cspell-wordlist.txt
+++ b/.cspell-wordlist.txt
@@ -244,3 +244,5 @@ pushd
 popd
 yolov
 YOLOV
+XLARGE
+bhanc

--- a/.cspell-wordlist.txt
+++ b/.cspell-wordlist.txt
@@ -245,4 +245,3 @@ popd
 yolov
 YOLOV
 XLARGE
-bhanc

--- a/apps/computer-vision/app/_layout.tsx
+++ b/apps/computer-vision/app/_layout.tsx
@@ -28,6 +28,13 @@ export default function Layout() {
         }}
       />
       <Drawer.Screen
+        name="detection/index"
+        options={{
+          drawerLabel: 'Object Detection',
+          title: 'Object Detection',
+        }}
+      />
+      <Drawer.Screen
         name="styleTransfer/index"
         options={{
           drawerLabel: 'Style Transfer',

--- a/apps/computer-vision/app/detection/index.tsx
+++ b/apps/computer-vision/app/detection/index.tsx
@@ -1,0 +1,247 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, ScrollView, Dimensions, Platform } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { commonStyles, theme } from '../../theme';
+import { useImage } from '@shopify/react-native-skia';
+import { useObjectDetector, models, type ObjectDetection } from 'react-native-executorch';
+import ScreenWrapper from '../../components/ScreenWrapper';
+import { getImage } from '../../utils';
+import { ModelPicker, type ModelOption } from '../../components/ModelPicker';
+import { ImageViewport } from '../../components/ImageViewport';
+import { ModelStatus } from '../../components/ModelStatus';
+import { LatencyIndicator } from '../../components/LatencyIndicator';
+import { Button } from '../../components/Button';
+import { BoundingBox } from '../../components/BoundingBox';
+
+const MODEL_OPTIONS: ModelOption[] = [
+  {
+    label: 'SSDLite 320 MobileNet V3 Large (XNNPACK FP32)',
+    value: models.objectDetection.SSDLITE320_MOBILENET_V3_LARGE,
+  },
+  {
+    label: 'RF-DETR Nano (XNNPACK FP32)',
+    value: models.objectDetection.RFDETR_NANO,
+  },
+  {
+    label: 'RF-DETR Nano (CoreML INT8)',
+    value: models.objectDetection.RFDETR_NANO.COREML_INT8,
+    disabled: Platform.OS !== 'ios',
+  },
+  {
+    label: 'YOLO26 Nano 384 (XNNPACK FP32)',
+    value: models.objectDetection.YOLO26.NANO.SIZE_384.XNNPACK_FP32,
+  },
+  {
+    label: 'YOLO26 Nano 640 (XNNPACK FP32)',
+    value: models.objectDetection.YOLO26.NANO.SIZE_640.XNNPACK_FP32,
+  },
+  {
+    label: 'YOLO26 Small 640 (XNNPACK FP32)',
+    value: models.objectDetection.YOLO26.SMALL.SIZE_640.XNNPACK_FP32,
+  },
+  {
+    label: 'YOLO26 Medium 640 (XNNPACK FP32)',
+    value: models.objectDetection.YOLO26.MEDIUM.SIZE_640.XNNPACK_FP32,
+  },
+  {
+    label: 'YOLO26 Large 640 (XNNPACK FP32)',
+    value: models.objectDetection.YOLO26.LARGE.SIZE_640.XNNPACK_FP32,
+  },
+  {
+    label: 'YOLO26 X-Large 640 (XNNPACK FP32)',
+    value: models.objectDetection.YOLO26.XLARGE.SIZE_640.XNNPACK_FP32,
+  },
+];
+
+const VIEW_WIDTH = Dimensions.get('window').width - 32;
+const VIEW_HEIGHT = Math.round((VIEW_WIDTH * 16) / 9);
+
+function DetectionContent() {
+  const insets = useSafeAreaInsets();
+  const [selectedModel, setSelectedModel] = useState<any>(MODEL_OPTIONS[0].value);
+  const [imageUri, setImageUri] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [results, setResults] = useState<ObjectDetection<'xyxy', string>[]>([]);
+  const [latency, setLatency] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const skiaImage = useImage(imageUri, (err) => setError(err.message || String(err)));
+
+  const {
+    isReady,
+    downloadProgress,
+    error: loadError,
+    detectObjects,
+    detectObjectsWorklet,
+  } = useObjectDetector(selectedModel);
+
+  const handlePickImage = async (useCamera: boolean) => {
+    setError(null);
+    try {
+      const uri = await getImage(useCamera);
+      if (uri) {
+        setImageUri(uri);
+        setResults([]);
+        setLatency(null);
+      }
+    } catch (e: any) {
+      setError(e.message || String(e));
+    }
+  };
+
+  const runDetection = async (sync: boolean) => {
+    if (!skiaImage || !detectObjects || !detectObjectsWorklet) return;
+    if (!sync) setIsProcessing(true);
+    setError(null);
+    try {
+      const pixels = skiaImage.readPixels();
+      if (!pixels) {
+        throw new Error('Failed to read pixels from image');
+      }
+      if (!(pixels instanceof Uint8Array)) {
+        throw new Error('Expected Uint8Array from readPixels');
+      }
+      const buffer = {
+        data: pixels,
+        width: skiaImage.width(),
+        height: skiaImage.height(),
+        format: 'rgba' as const,
+        layout: 'hwc' as const,
+      };
+      const start = Date.now();
+      const output = (
+        sync ? detectObjectsWorklet(buffer) : await detectObjects(buffer)
+      ) as ObjectDetection<'xyxy', string>[];
+
+      setLatency(Date.now() - start);
+      setResults(output);
+    } catch (e: any) {
+      setError(e.message || String(e));
+    } finally {
+      if (!sync) setIsProcessing(false);
+    }
+  };
+
+  let scaleX = 1;
+  let scaleY = 1;
+  let offsetX = 0;
+  let offsetY = 0;
+
+  if (skiaImage) {
+    const imgW = skiaImage.width();
+    const imgH = skiaImage.height();
+    const scale = Math.min(VIEW_WIDTH / imgW, VIEW_HEIGHT / imgH);
+    const displayedW = imgW * scale;
+    const displayedH = imgH * scale;
+    offsetX = (VIEW_WIDTH - displayedW) / 2;
+    offsetY = (VIEW_HEIGHT - displayedH) / 2;
+    scaleX = scale;
+    scaleY = scale;
+  }
+
+  const activeError = loadError ? String(loadError) : error;
+
+  return (
+    <ScrollView
+      style={commonStyles.container}
+      contentContainerStyle={[
+        commonStyles.contentContainer,
+        { paddingBottom: insets.bottom + theme.spacing.large },
+      ]}
+    >
+      <Text style={commonStyles.description}>
+        Upload or capture an image to run object detection.
+      </Text>
+
+      <ModelPicker
+        label="Model"
+        options={MODEL_OPTIONS}
+        selectedValue={selectedModel}
+        onValueChange={(model) => {
+          setSelectedModel(model);
+          setResults([]);
+          setLatency(null);
+          setError(null);
+        }}
+      />
+
+      <ModelStatus
+        isReady={isReady}
+        downloadProgress={downloadProgress}
+        error={activeError}
+        modelTypeLabel="detector model"
+      />
+
+      <ImageViewport skiaImage={skiaImage} onPressPlaceholder={() => handlePickImage(false)}>
+        {skiaImage && results.length > 0 && (
+          <View style={styles.overlayContainer} pointerEvents="none">
+            {results.map((det, index: number) => {
+              const strokeColor = '#00ff00';
+              const bgColor = 'rgba(0, 255, 0, 0.15)';
+
+              const left = offsetX + det.box.xmin * scaleX;
+              const top = offsetY + det.box.ymin * scaleY;
+              const width = (det.box.xmax - det.box.xmin) * scaleX;
+              const height = (det.box.ymax - det.box.ymin) * scaleY;
+
+              return (
+                <BoundingBox
+                  key={index}
+                  left={left}
+                  top={top}
+                  width={width}
+                  height={height}
+                  borderColor={strokeColor}
+                  backgroundColor={bgColor}
+                  label={`${det.label} ${Math.round(det.confidence * 100)}%`}
+                  labelTextColor="#fff"
+                />
+              );
+            })}
+          </View>
+        )}
+      </ImageViewport>
+
+      <View style={commonStyles.buttonRow}>
+        <Button title="Gallery" onPress={() => handlePickImage(false)} variant="secondary" />
+        <Button title="Camera" onPress={() => handlePickImage(true)} variant="secondary" />
+      </View>
+
+      <View style={commonStyles.buttonRow}>
+        <Button
+          title="Run Async"
+          onPress={() => runDetection(false)}
+          disabled={!skiaImage || !isReady || isProcessing}
+          loading={isProcessing}
+        />
+        <Button
+          title="Run Sync"
+          onPress={() => runDetection(true)}
+          disabled={!skiaImage || !isReady || isProcessing}
+          variant="accent"
+        />
+      </View>
+
+      <LatencyIndicator latency={latency} />
+    </ScrollView>
+  );
+}
+
+export default function DetectionScreen() {
+  return (
+    <ScreenWrapper>
+      <DetectionContent />
+    </ScreenWrapper>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlayContainer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+    overflow: 'hidden',
+  },
+});

--- a/apps/computer-vision/app/index.tsx
+++ b/apps/computer-vision/app/index.tsx
@@ -14,6 +14,9 @@ export default function Home() {
         <TouchableOpacity style={styles.button} onPress={() => router.navigate('classification/')}>
           <Text style={styles.buttonText}>Classification</Text>
         </TouchableOpacity>
+        <TouchableOpacity style={styles.button} onPress={() => router.navigate('detection/')}>
+          <Text style={styles.buttonText}>Object Detection</Text>
+        </TouchableOpacity>
         <TouchableOpacity style={styles.button} onPress={() => router.navigate('styleTransfer/')}>
           <Text style={styles.buttonText}>Style Transfer</Text>
         </TouchableOpacity>

--- a/packages/react-native-executorch/src/constants.ts
+++ b/packages/react-native-executorch/src/constants.ts
@@ -1034,6 +1034,104 @@ export const PASCAL_VOC_LABELS = [
 ] as const;
 
 /**
+ * COCO classes list.
+ * @category Constants
+ */
+export const COCO_CLASSES = [
+  'background',
+  'person',
+  'bicycle',
+  'car',
+  'motorcycle',
+  'airplane',
+  'bus',
+  'train',
+  'truck',
+  'boat',
+  'traffic light',
+  'fire hydrant',
+  'N/A',
+  'stop sign',
+  'parking meter',
+  'bench',
+  'bird',
+  'cat',
+  'dog',
+  'horse',
+  'sheep',
+  'cow',
+  'elephant',
+  'bear',
+  'zebra',
+  'giraffe',
+  'N/A',
+  'backpack',
+  'umbrella',
+  'N/A',
+  'N/A',
+  'handbag',
+  'tie',
+  'suitcase',
+  'frisbee',
+  'skis',
+  'snowboard',
+  'sports ball',
+  'kite',
+  'baseball bat',
+  'baseball glove',
+  'skateboard',
+  'surfboard',
+  'tennis racket',
+  'bottle',
+  'N/A',
+  'wine glass',
+  'cup',
+  'fork',
+  'knife',
+  'spoon',
+  'bowl',
+  'banana',
+  'apple',
+  'sandwich',
+  'orange',
+  'broccoli',
+  'carrot',
+  'hot dog',
+  'pizza',
+  'donut',
+  'cake',
+  'chair',
+  'couch',
+  'potted plant',
+  'bed',
+  'N/A',
+  'dining table',
+  'N/A',
+  'N/A',
+  'toilet',
+  'N/A',
+  'tv',
+  'laptop',
+  'mouse',
+  'remote',
+  'keyboard',
+  'cell phone',
+  'microwave',
+  'oven',
+  'toaster',
+  'sink',
+  'refrigerator',
+  'N/A',
+  'book',
+  'clock',
+  'vase',
+  'scissors',
+  'teddy bear',
+  'hair drier',
+  'toothbrush',
+] as const;
+
+/**
  * Type representing a valid ImageNet 1K label string.
  * @category Types
  */
@@ -1044,6 +1142,105 @@ export type ImageNet1KLabel = (typeof IMAGENET1K_LABELS)[number];
  * @category Types
  */
 export type PascalVocLabel = (typeof PASCAL_VOC_LABELS)[number];
+
+/**
+ * Type representing a valid COCO class string.
+ * @category Types
+ */
+export type CocoClass = (typeof COCO_CLASSES)[number];
+
+/**
+ * COCO classes list specifically for YOLO models (80 classes, 0-indexed).
+ * @category Constants
+ */
+export const COCO_CLASSES_YOLO = [
+  'person',
+  'bicycle',
+  'car',
+  'motorcycle',
+  'airplane',
+  'bus',
+  'train',
+  'truck',
+  'boat',
+  'traffic light',
+  'fire hydrant',
+  'stop sign',
+  'parking meter',
+  'bench',
+  'bird',
+  'cat',
+  'dog',
+  'horse',
+  'sheep',
+  'cow',
+  'elephant',
+  'bear',
+  'zebra',
+  'giraffe',
+  'backpack',
+  'umbrella',
+  'handbag',
+  'tie',
+  'suitcase',
+  'frisbee',
+  'skis',
+  'snowboard',
+  'sports ball',
+  'kite',
+  'baseball bat',
+  'baseball glove',
+  'skateboard',
+  'surfboard',
+  'tennis racket',
+  'bottle',
+  'wine glass',
+  'cup',
+  'fork',
+  'knife',
+  'spoon',
+  'bowl',
+  'banana',
+  'apple',
+  'sandwich',
+  'orange',
+  'broccoli',
+  'carrot',
+  'hot dog',
+  'pizza',
+  'donut',
+  'cake',
+  'chair',
+  'couch',
+  'potted plant',
+  'bed',
+  'dining table',
+  'toilet',
+  'tv',
+  'laptop',
+  'mouse',
+  'remote',
+  'keyboard',
+  'cell phone',
+  'microwave',
+  'oven',
+  'toaster',
+  'sink',
+  'refrigerator',
+  'book',
+  'clock',
+  'vase',
+  'scissors',
+  'teddy bear',
+  'hair drier',
+  'toothbrush',
+] as const;
+
+/**
+ * Type representing a valid YOLO COCO class label string.
+ * @category Types
+ */
+export type CocoClassYolo = (typeof COCO_CLASSES_YOLO)[number];
 
 /**
  * ImageNet standard normalization options containing alpha and beta
@@ -1093,5 +1290,14 @@ export const COCO_LANDMARKS = [
   'rightAnkle',
 ] as const;
 
+/**
+ * Type representing a valid BlazeFace landmark string.
+ * @category Types
+ */
 export type BlazeFaceLandmark = (typeof BLAZEFACE_LANDMARKS)[number];
+
+/**
+ * Type representing a valid COCO human pose landmark string.
+ * @category Types
+ */
 export type CocoLandmark = (typeof COCO_LANDMARKS)[number];

--- a/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts
@@ -5,6 +5,7 @@ import { loadModel } from '../../../core/model';
 import { validateModelSchema, SymbolicTensor } from '../../../core/modelSchema';
 import { wrapAsync } from '../../../core/runtime';
 
+import type { ResizeMode } from '../ops/image';
 import type { ImageBuffer } from '../image';
 import { createImagePreprocessor, type ImagePreprocessorOptions } from './preprocessing';
 import { nms, scaleBox, decodeBox, type BoundingBox, type BoxFormat } from '../ops/boxes';
@@ -20,7 +21,7 @@ export type ObjectDetectorOptions<F extends BoxFormat, L> = Omit<
   ImagePreprocessorOptions,
   'resizeMode'
 > & {
-  readonly resizeMode: 'stretch';
+  readonly resizeMode: Exclude<ResizeMode, 'crop'>;
   readonly labels: readonly L[];
   readonly boxFormat: F;
   readonly defaultIouThreshold: number;

--- a/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts
@@ -1,0 +1,191 @@
+import type { WorkletRuntime } from 'react-native-worklets';
+
+import { tensor } from '../../../core/tensor';
+import { loadModel } from '../../../core/model';
+import { validateModelSchema, SymbolicTensor } from '../../../core/modelSchema';
+import { wrapAsync } from '../../../core/runtime';
+
+import type { ImageBuffer } from '../image';
+import { createImagePreprocessor, type ImagePreprocessorOptions } from './preprocessing';
+import { nms, scaleBox, decodeBox, type BoundingBox, type BoxFormat } from '../ops/boxes';
+
+export type { BoxFormat };
+
+/**
+ * Options for configuring an object detector preprocessor, label vocabulary,
+ * and detection thresholds.
+ * @category Types
+ */
+export type ObjectDetectorOptions<F extends BoxFormat, L> = Omit<
+  ImagePreprocessorOptions,
+  'resizeMode'
+> & {
+  readonly resizeMode: 'stretch';
+  readonly labels: readonly L[];
+  readonly boxFormat: F;
+  readonly defaultIouThreshold: number;
+  readonly defaultConfidenceThreshold: number;
+};
+
+/**
+ * Model configuration required to instantiate an object detector task runner.
+ * @category Types
+ */
+export type ObjectDetectorModel<F extends BoxFormat, L> = {
+  readonly modelPath: string;
+  readonly opts: ObjectDetectorOptions<F, L>;
+};
+
+/**
+ * Result structure representing a single object detection prediction.
+ * @category Types
+ */
+export type ObjectDetection<F extends BoxFormat, L> = {
+  readonly box: BoundingBox<F>;
+  readonly label: L;
+  readonly confidence: number;
+};
+
+/**
+ * Creates an object detector runner for executing local Object Detection
+ * models.
+ *
+ * It validates the model inputs and outputs requirements, pre-allocates the
+ * necessary static execution tensors (boxes, scores, classes), sets up an image
+ * preprocessor, and registers clean disposal hooks to clear all native memory.
+ * @category Typescript API
+ * @typeParam F The bounding box format.
+ * @typeParam L The type representing the class labels.
+ * @param config Object detector task configuration containing path and options.
+ * @param runtime Optional worklet runtime thread on which to run the model
+ * execution.
+ * @returns A promise resolving to an object containing object detection and
+ * disposal controls.
+ */
+export async function createObjectDetector<F extends BoxFormat, L>(
+  config: ObjectDetectorModel<F, L>,
+  runtime?: WorkletRuntime
+): Promise<{
+  /**
+   * Releases all allocated native resources.
+   */
+  dispose: () => void;
+  /**
+   * Performs asynchronous object detection on the given input image.
+   * @param input The input image buffer.
+   * @param options Configuration options for object detection.
+   * @param options.confidenceThreshold Minimum confidence score for returned
+   * detections.
+   * @param options.iouThreshold Non-maximum suppression IoU threshold.
+   * @returns A promise resolving to the list of object detections.
+   */
+  detectObjects: (
+    input: ImageBuffer,
+    options?: { confidenceThreshold?: number; iouThreshold?: number }
+  ) => Promise<ObjectDetection<F, L>[]>;
+  /**
+   * Synchronous version of {@link detectObjects} to be executed directly on the
+   * caller or worklet thread.
+   */
+  detectObjectsWorklet: (
+    input: ImageBuffer,
+    options?: { confidenceThreshold?: number; iouThreshold?: number }
+  ) => ObjectDetection<F, L>[];
+}> {
+  const { modelPath, opts } = config;
+  const model = await wrapAsync(loadModel, runtime)(modelPath);
+
+  const meta = validateModelSchema(
+    model,
+    'forward',
+    [SymbolicTensor('float32', [1, 3, 'H', 'W'], [3, 'H', 'W'])],
+    [
+      SymbolicTensor('float32', ['N', 4]),
+      SymbolicTensor('float32', ['N']),
+      SymbolicTensor('float32', ['N']),
+    ]
+  );
+
+  const inpShape = meta.inputTensorMeta[0]!.shape;
+  const outBoxesShape = meta.outputTensorMeta[0]!.shape;
+  const outScoresShape = meta.outputTensorMeta[1]!.shape;
+  const outClassesShape = meta.outputTensorMeta[2]!.shape;
+
+  const targetH = inpShape.at(-2)!;
+  const targetW = inpShape.at(-1)!;
+
+  const tensors = [
+    tensor('float32', outBoxesShape),
+    tensor('float32', outScoresShape),
+    tensor('float32', outClassesShape),
+  ] as const;
+
+  const [tBoxes, tScores, tClasses] = tensors;
+  const preprocessor = createImagePreprocessor(opts, inpShape);
+
+  const { boxFormat } = opts;
+
+  const dispose = () => {
+    preprocessor.dispose();
+    tensors.forEach((t) => t.dispose());
+    model.dispose();
+  };
+
+  const detectObjectsWorklet = (
+    input: ImageBuffer,
+    options?: { confidenceThreshold?: number; iouThreshold?: number }
+  ): ObjectDetection<F, L>[] => {
+    'worklet';
+    const tInput = preprocessor.process(input);
+    model.execute('forward', [tInput], [tBoxes, tScores, tClasses]);
+
+    const boxes = tBoxes.getData(new Float32Array(tBoxes.numel));
+    const scores = tScores.getData(new Float32Array(tScores.numel));
+    const classes = tClasses.getData(new Float32Array(tClasses.numel));
+
+    const iouThreshold = options?.iouThreshold ?? opts.defaultIouThreshold;
+    const confidenceThreshold = options?.confidenceThreshold ?? opts.defaultConfidenceThreshold;
+
+    const results: ObjectDetection<F, L>[] = [];
+    const indices = nms(tBoxes, tScores, {
+      boxFormat,
+      iouThreshold,
+      confidenceThreshold,
+      nmsType: 'standard',
+    });
+
+    for (const index of indices) {
+      const confidence = scores[index]!;
+      const classIdx = Math.round(classes[index]!);
+      const label = opts.labels[classIdx];
+
+      if (label === undefined) {
+        throw new Error(
+          `ObjectDetector: Predicted class index ${classIdx} is out of bounds for` +
+            `labels array of size ${opts.labels.length}.`
+        );
+      }
+
+      const a = boxes[index * 4]!;
+      const b = boxes[index * 4 + 1]!;
+      const c = boxes[index * 4 + 2]!;
+      const d = boxes[index * 4 + 3]!;
+
+      results.push({
+        label,
+        confidence,
+        box: scaleBox(decodeBox([a, b, c, d], boxFormat), {
+          from: { width: targetW, height: targetH },
+          to: { width: input.width, height: input.height },
+          ...opts,
+        }),
+      });
+    }
+
+    return results;
+  };
+
+  const detectObjects = wrapAsync(detectObjectsWorklet, runtime);
+
+  return { detectObjects, detectObjectsWorklet, dispose };
+}

--- a/packages/react-native-executorch/src/hooks/useObjectDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useObjectDetector.ts
@@ -1,0 +1,49 @@
+import { useModel } from './useModel';
+import { useResourceDownload } from './useResourceDownload';
+import {
+  createObjectDetector,
+  type ObjectDetectorModel,
+  type BoxFormat,
+} from '../extensions/cv/tasks/objectDetection';
+
+/**
+ * React hook to load and run an object detection model.
+ *
+ * This hook manages downloading (if it's a remote URL) and loading the model
+ * file, compiling it, tracking download progress and compilation errors, and
+ * cleaning up native model memory when the component unmounts or configuration
+ * changes.
+ * @category Hooks
+ * @typeParam L The type representing the object class labels.
+ * @typeParam F The bounding box format.
+ * @param config The object detection model configuration.
+ * @param options Hook options.
+ * @param options.preventLoad If true, prevents downloading and compiling the
+ * model.
+ * @returns An object containing the model's loading state, error, download
+ * progress, and object detection functions.
+ */
+export function useObjectDetector<F extends BoxFormat, L>(
+  config: ObjectDetectorModel<F, L>,
+  options?: { preventLoad?: boolean }
+) {
+  const { localPath, downloadProgress, downloadError } = useResourceDownload(
+    config.modelPath,
+    options?.preventLoad
+  );
+  const { model, error } = useModel(
+    createObjectDetector<F, L>,
+    localPath ? { ...config, modelPath: localPath } : null,
+    [localPath]
+  );
+
+  return {
+    isReady: !!model,
+    error: downloadError || error,
+    downloadProgress,
+    localPath,
+    labels: config.opts.labels,
+    detectObjects: model?.detectObjects,
+    detectObjectsWorklet: model?.detectObjectsWorklet,
+  };
+}

--- a/packages/react-native-executorch/src/index.ts
+++ b/packages/react-native-executorch/src/index.ts
@@ -3,6 +3,7 @@ export * from './hooks/useClassifier';
 export * from './hooks/useStyleTransfer';
 export * from './hooks/useSemanticSegmenter';
 export * from './hooks/useKeypointDetector';
+export * from './hooks/useObjectDetector';
 export * from './hooks/useTokenizer';
 export * from './hooks/useResourceDownload';
 export * from './hooks/useModel';
@@ -16,6 +17,7 @@ export * from './extensions/cv/tasks/classification';
 export * from './extensions/cv/tasks/styleTransfer';
 export * from './extensions/cv/tasks/semanticSegmentation';
 export * from './extensions/cv/tasks/keypointDetection';
+export * from './extensions/cv/tasks/objectDetection';
 export * from './extensions/nlp/tasks/tokenization';
 
 // Core primitives — for library builders and power users

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -317,7 +317,6 @@ const YOLO26_LARGE_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> 
   opts: YOLO26_DETECTOR_OPTS,
 };
 
-// X-Large
 const YOLO26_XLARGE_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/x/xnnpack/yolo26x_384_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -266,67 +266,68 @@ const YOLO26_DETECTOR_OPTS = {
 };
 
 const YOLO26_NANO_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
-  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26n_384_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/n/xnnpack/yolo26n_384_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_NANO_512_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
-  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26n_512_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/n/xnnpack/yolo26n_512_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_NANO_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
-  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26n_640_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/n/xnnpack/yolo26n_640_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,
 };
 
 const YOLO26_SMALL_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
-  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26s_384_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/s/xnnpack/yolo26s_384_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_SMALL_512_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
-  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26s_512_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/s/xnnpack/yolo26s_512_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_SMALL_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
-  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26s_640_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/s/xnnpack/yolo26s_640_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,
 };
 
 const YOLO26_MEDIUM_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
-  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26m_384_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/m/xnnpack/yolo26m_384_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_MEDIUM_512_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
-  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26m_512_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/m/xnnpack/yolo26m_512_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_MEDIUM_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
-  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26m_640_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/m/xnnpack/yolo26m_640_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,
 };
 
 const YOLO26_LARGE_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
-  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26l_384_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/l/xnnpack/yolo26l_384_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_LARGE_512_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
-  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26l_512_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/l/xnnpack/yolo26l_512_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_LARGE_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
-  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26l_640_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/l/xnnpack/yolo26l_640_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,
 };
 
+// X-Large
 const YOLO26_XLARGE_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
-  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26x_384_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/x/xnnpack/yolo26x_384_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_XLARGE_512_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
-  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26x_512_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/x/xnnpack/yolo26x_512_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_XLARGE_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
-  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26x_640_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/x/xnnpack/yolo26x_640_xnnpack_fp32.pte`,
   opts: YOLO26_DETECTOR_OPTS,
 };
 

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -257,7 +257,7 @@ const RFDETR_NANO_DETECTOR_COREML_INT8: ObjectDetectorModel<'xyxy', CocoClass> =
 const YOLO26_DETECTOR_OPTS = {
   labels: COCO_CLASSES_YOLO,
   boxFormat: 'xyxy' as const,
-  resizeMode: 'stretch' as const,
+  resizeMode: 'letterbox' as const,
   interpolation: 'linear' as const,
   alpha: 1 / 255.0,
   beta: 0.0,

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -1,4 +1,5 @@
 import type { ClassifierModel } from './extensions/cv/tasks/classification';
+import type { ObjectDetectorModel } from './extensions/cv/tasks/objectDetection';
 import type { StyleTransferModel } from './extensions/cv/tasks/styleTransfer';
 import type { SemanticSegmentationModel } from './extensions/cv/tasks/semanticSegmentation';
 import type { KeypointDetectorModel } from './extensions/cv/tasks/keypointDetection';
@@ -6,10 +7,14 @@ import {
   IMAGENET_NORM,
   IMAGENET1K_LABELS,
   PASCAL_VOC_LABELS,
+  COCO_CLASSES,
+  COCO_CLASSES_YOLO,
   BLAZEFACE_LANDMARKS,
   COCO_LANDMARKS,
   type ImageNet1KLabel,
   type PascalVocLabel,
+  type CocoClass,
+  type CocoClassYolo,
   type BlazeFaceLandmark,
   type CocoLandmark,
 } from './constants';
@@ -206,6 +211,126 @@ const FCN_RESNET101_XNNPACK_INT8: SemanticSegmentationModel<PascalVocLabel> = {
 };
 
 // =============================================================================
+// Object Detection
+// =============================================================================
+const SSDLITE320_MOBILENET_V3_LARGE_OPTS = {
+  labels: COCO_CLASSES,
+  boxFormat: 'xyxy' as const,
+  resizeMode: 'stretch' as const,
+  interpolation: 'linear' as const,
+  alpha: 1 / 255.0,
+  beta: 0.0,
+  defaultConfidenceThreshold: 0.5,
+  defaultIouThreshold: 0.55,
+};
+const SSDLITE320_MOBILENET_V3_LARGE_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClass> = {
+  modelPath: `${BASE_URL}-ssdlite320-mobilenet-v3-large/${VERSION_TAG}/xnnpack/ssdlite320_mobilenet_v3_large_xnnpack_fp32.pte`,
+  opts: SSDLITE320_MOBILENET_V3_LARGE_OPTS,
+};
+const SSDLITE320_MOBILENET_V3_LARGE_COREML_FP16: ObjectDetectorModel<'xyxy', CocoClass> = {
+  modelPath: `${BASE_URL}-ssdlite320-mobilenet-v3-large/${VERSION_TAG}/coreml/ssdlite320_mobilenet_v3_large_coreml_fp16.pte`,
+  opts: SSDLITE320_MOBILENET_V3_LARGE_OPTS,
+};
+const SSDLITE320_MOBILENET_V3_LARGE_COREML_FP32: ObjectDetectorModel<'xyxy', CocoClass> = {
+  modelPath: `${BASE_URL}-ssdlite320-mobilenet-v3-large/${VERSION_TAG}/coreml/ssdlite320_mobilenet_v3_large_coreml_fp32.pte`,
+  opts: SSDLITE320_MOBILENET_V3_LARGE_OPTS,
+};
+
+const RFDETR_NANO_DETECTOR_OPTS = {
+  labels: COCO_CLASSES,
+  boxFormat: 'xyxy' as const,
+  resizeMode: 'stretch' as const,
+  interpolation: 'linear' as const,
+  ...IMAGENET_NORM,
+  defaultConfidenceThreshold: 0.5,
+  defaultIouThreshold: 0.55,
+};
+const RFDETR_NANO_DETECTOR_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClass> = {
+  modelPath: `${BASE_URL}-rfdetr-nano-detector/${VERSION_TAG}/xnnpack/rfdetr_nano_xnnpack_fp32.pte`,
+  opts: RFDETR_NANO_DETECTOR_OPTS,
+};
+const RFDETR_NANO_DETECTOR_COREML_INT8: ObjectDetectorModel<'xyxy', CocoClass> = {
+  modelPath: `${BASE_URL}-rfdetr-nano-detector/${VERSION_TAG}/coreml/rfdetr_nano_coreml_int8.pte`,
+  opts: RFDETR_NANO_DETECTOR_OPTS,
+};
+
+const YOLO26_DETECTOR_OPTS = {
+  labels: COCO_CLASSES_YOLO,
+  boxFormat: 'xyxy' as const,
+  resizeMode: 'stretch' as const,
+  interpolation: 'linear' as const,
+  alpha: 1 / 255.0,
+  beta: 0.0,
+  defaultConfidenceThreshold: 0.25,
+  defaultIouThreshold: 0.7,
+};
+
+const YOLO26_NANO_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
+  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26n_384_xnnpack_fp32.pte`,
+  opts: YOLO26_DETECTOR_OPTS,
+};
+const YOLO26_NANO_512_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
+  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26n_512_xnnpack_fp32.pte`,
+  opts: YOLO26_DETECTOR_OPTS,
+};
+const YOLO26_NANO_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
+  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26n_640_xnnpack_fp32.pte`,
+  opts: YOLO26_DETECTOR_OPTS,
+};
+
+const YOLO26_SMALL_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
+  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26s_384_xnnpack_fp32.pte`,
+  opts: YOLO26_DETECTOR_OPTS,
+};
+const YOLO26_SMALL_512_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
+  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26s_512_xnnpack_fp32.pte`,
+  opts: YOLO26_DETECTOR_OPTS,
+};
+const YOLO26_SMALL_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
+  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26s_640_xnnpack_fp32.pte`,
+  opts: YOLO26_DETECTOR_OPTS,
+};
+
+const YOLO26_MEDIUM_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
+  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26m_384_xnnpack_fp32.pte`,
+  opts: YOLO26_DETECTOR_OPTS,
+};
+const YOLO26_MEDIUM_512_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
+  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26m_512_xnnpack_fp32.pte`,
+  opts: YOLO26_DETECTOR_OPTS,
+};
+const YOLO26_MEDIUM_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
+  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26m_640_xnnpack_fp32.pte`,
+  opts: YOLO26_DETECTOR_OPTS,
+};
+
+const YOLO26_LARGE_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
+  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26l_384_xnnpack_fp32.pte`,
+  opts: YOLO26_DETECTOR_OPTS,
+};
+const YOLO26_LARGE_512_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
+  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26l_512_xnnpack_fp32.pte`,
+  opts: YOLO26_DETECTOR_OPTS,
+};
+const YOLO26_LARGE_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
+  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26l_640_xnnpack_fp32.pte`,
+  opts: YOLO26_DETECTOR_OPTS,
+};
+
+const YOLO26_XLARGE_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
+  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26x_384_xnnpack_fp32.pte`,
+  opts: YOLO26_DETECTOR_OPTS,
+};
+const YOLO26_XLARGE_512_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
+  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26x_512_xnnpack_fp32.pte`,
+  opts: YOLO26_DETECTOR_OPTS,
+};
+const YOLO26_XLARGE_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
+  modelPath: `/Users/bhanc/workspace/export-scripts/exports/yolo/OUTPUT_DIR/xnnpack/yolo26x_640_xnnpack_fp32.pte`,
+  opts: YOLO26_DETECTOR_OPTS,
+};
+
+// =============================================================================
 // Keypoint Detection
 // =============================================================================
 const BLAZEFACE_XNNPACK_FP32: KeypointDetectorModel<'xyxy', BlazeFaceLandmark> = {
@@ -353,6 +478,52 @@ export const models = {
       ...FCN_RESNET101_XNNPACK_INT8,
       XNNPACK_FP32: FCN_RESNET101_XNNPACK_FP32,
       XNNPACK_INT8: FCN_RESNET101_XNNPACK_INT8,
+    },
+  },
+  objectDetection: {
+    SSDLITE320_MOBILENET_V3_LARGE: {
+      ...SSDLITE320_MOBILENET_V3_LARGE_XNNPACK_FP32,
+      XNNPACK_FP32: SSDLITE320_MOBILENET_V3_LARGE_XNNPACK_FP32,
+      COREML_FP16: SSDLITE320_MOBILENET_V3_LARGE_COREML_FP16,
+      COREML_FP32: SSDLITE320_MOBILENET_V3_LARGE_COREML_FP32,
+    },
+    RFDETR_NANO: {
+      ...RFDETR_NANO_DETECTOR_XNNPACK_FP32,
+      XNNPACK_FP32: RFDETR_NANO_DETECTOR_XNNPACK_FP32,
+      COREML_INT8: RFDETR_NANO_DETECTOR_COREML_INT8,
+    },
+    YOLO26: {
+      ...YOLO26_NANO_384_XNNPACK_FP32,
+      NANO: {
+        ...YOLO26_NANO_384_XNNPACK_FP32,
+        SIZE_384: { XNNPACK_FP32: YOLO26_NANO_384_XNNPACK_FP32 },
+        SIZE_512: { XNNPACK_FP32: YOLO26_NANO_512_XNNPACK_FP32 },
+        SIZE_640: { XNNPACK_FP32: YOLO26_NANO_640_XNNPACK_FP32 },
+      },
+      SMALL: {
+        ...YOLO26_SMALL_384_XNNPACK_FP32,
+        SIZE_384: { XNNPACK_FP32: YOLO26_SMALL_384_XNNPACK_FP32 },
+        SIZE_512: { XNNPACK_FP32: YOLO26_SMALL_512_XNNPACK_FP32 },
+        SIZE_640: { XNNPACK_FP32: YOLO26_SMALL_640_XNNPACK_FP32 },
+      },
+      MEDIUM: {
+        ...YOLO26_MEDIUM_384_XNNPACK_FP32,
+        SIZE_384: { XNNPACK_FP32: YOLO26_MEDIUM_384_XNNPACK_FP32 },
+        SIZE_512: { XNNPACK_FP32: YOLO26_MEDIUM_512_XNNPACK_FP32 },
+        SIZE_640: { XNNPACK_FP32: YOLO26_MEDIUM_640_XNNPACK_FP32 },
+      },
+      LARGE: {
+        ...YOLO26_LARGE_384_XNNPACK_FP32,
+        SIZE_384: { XNNPACK_FP32: YOLO26_LARGE_384_XNNPACK_FP32 },
+        SIZE_512: { XNNPACK_FP32: YOLO26_LARGE_512_XNNPACK_FP32 },
+        SIZE_640: { XNNPACK_FP32: YOLO26_LARGE_640_XNNPACK_FP32 },
+      },
+      XLARGE: {
+        ...YOLO26_XLARGE_384_XNNPACK_FP32,
+        SIZE_384: { XNNPACK_FP32: YOLO26_XLARGE_384_XNNPACK_FP32 },
+        SIZE_512: { XNNPACK_FP32: YOLO26_XLARGE_512_XNNPACK_FP32 },
+        SIZE_640: { XNNPACK_FP32: YOLO26_XLARGE_640_XNNPACK_FP32 },
+      },
     },
   },
   keypointDetection: {


### PR DESCRIPTION
## Description

Adds object detection pipeline implementation and corresponding example screen in computer-vision app.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

- [ ] Build the computer-vision example app on both Android and iOS.
- [ ] Test the newly added object detection screen.
- [ ] Check the updated HuggingFace repos:
        - https://huggingface.co/software-mansion/react-native-executorch-yolo26

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

Closes #1239 

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
