### PR TITLE
[RNE Rewrite] chore: set up clangd for C++ sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ jsconfig.json
 .cache/
 compile_commands.json
 compile_flags.txt
+# ...but the core package ships a shared, committed clangd config for its C++ sources:
+!/packages/react-native-executorch/.clangd
+!/packages/react-native-executorch/compile_flags.txt
 
 # Xcode
 #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,34 @@ Found a model you would like to use in your app but it is not currently supplied
 Do you have a neat example use case and want to share it with us? You can just drop us a message on Discord server and/or open a PR to `apps` directory here.
 If you found some inconsistencies in our documentation or just something is missing just open a PR with suggested changes (remember to add changes to previous docs versions too, e.g `docs/versioned_docs/version-0.3.x`, `docs/versioned_docs/version-0.4.x`).
 
+# C++ tooling (clangd)
+
+The core package ships a committed [clangd](https://clangd.llvm.org/) setup so the
+C/C++ sources under `packages/react-native-executorch/cpp` get code intelligence and
+a strict, shared set of compiler warnings:
+
+- `packages/react-native-executorch/compile_flags.txt` — the compilation database:
+  language standard, preprocessor defines, and include roots (paths are relative to
+  the package, so the config is portable). ExecuTorch/torch/JSI headers are added as
+  system includes so their internal warnings don't pollute diagnostics for our code.
+- `packages/react-native-executorch/.clangd` — the warning policy layered on top.
+
+For clangd to resolve the `<executorch/...>` and `<jsi/jsi.h>` includes you need the
+same prerequisites as a native build:
+
+1. `yarn install` at the repo root (provides the JSI headers under `node_modules`).
+2. ExecuTorch headers provisioned under `packages/react-native-executorch/third-party/include`
+   (see [third-party/README.md](./packages/react-native-executorch/third-party/README.md)).
+
+Without them clangd still lints your own code; the third-party includes simply stay
+unresolved until the headers are present.
+
+Editor setup: install the official **clangd** extension (e.g. `llvm-vs-code-extensions.vscode-clangd`
+for VS Code) and disable the default Microsoft C/C++ IntelliSense engine so the two
+don't conflict. clangd discovers `compile_flags.txt`/`.clangd` automatically from the
+open file's directory. If you produce a `compile_commands.json` from a native build,
+clangd will prefer it — it's gitignored and takes precedence over `compile_flags.txt`.
+
 # Creating a Pull Request
 
 Before writing any code reach out to us to make sure no one is currently working on it, you can always open an issue first.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,12 @@ same prerequisites as a native build:
 Without them clangd still lints your own code; the third-party includes simply stay
 unresolved until the headers are present.
 
+A `pre-commit` hook (lefthook) compiles staged `cpp/` sources with this same warning set
+and aborts the commit if any warning is introduced — the editor and the commit gate stay
+in sync. It skips automatically when no compiler or the provisioned headers are available,
+so it never blocks contributors who don't build the native code; bypass with
+`git commit --no-verify`.
+
 Editor setup: install the official **clangd** extension (e.g. `llvm-vs-code-extensions.vscode-clangd`
 for VS Code) and disable the default Microsoft C/C++ IntelliSense engine so the two
 don't conflict. clangd discovers `compile_flags.txt`/`.clangd` automatically from the

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,6 +13,9 @@ pre-commit:
     format-objc:
       glob: '*.{h,hpp,m,mm,c,cpp}'
       run: clang-format -i {staged_files} && git add {staged_files}
+    cpp-warnings:
+      glob: '*.{h,hpp,c,cpp}'
+      run: packages/react-native-executorch/scripts/check-cpp-warnings.sh {staged_files}
     format-kotlin:
       glob: '*.{kt}'
       run: ktlint -F {staged_files} && git add {staged_files}

--- a/packages/react-native-executorch/.clangd
+++ b/packages/react-native-executorch/.clangd
@@ -1,0 +1,33 @@
+# clangd configuration for the react-native-executorch C/C++ sources.
+#
+# Include roots, the language standard, and preprocessor defines live in
+# `compile_flags.txt` (the compilation database). This file layers the project's
+# warning policy on top and configures clangd's diagnostics.
+#
+# The warning set is intentionally strict to surface bugs early during the
+# rewrite. Third-party headers are included as `-isystem` (see compile_flags.txt),
+# so these warnings only apply to our own code in `cpp/`.
+CompileFlags:
+  Add:
+    - -Wall
+    - -Wextra
+    - -Wpedantic
+    - -Wshadow
+    - -Wnon-virtual-dtor
+    - -Woverloaded-virtual
+    - -Wold-style-cast
+    - -Wcast-align
+    - -Wunused
+    - -Wnull-dereference
+    - -Wimplicit-fallthrough
+    - -Wextra-semi
+    - -Wformat=2
+    - -Wconversion
+    - -Wsign-conversion
+    - -Wdouble-promotion
+
+Diagnostics:
+  # ExecuTorch/torch rely heavily on umbrella headers, which clangd's include
+  # cleaner misreports as unused/missing. Disable it to avoid false positives.
+  UnusedIncludes: None
+  MissingIncludes: None

--- a/packages/react-native-executorch/compile_flags.txt
+++ b/packages/react-native-executorch/compile_flags.txt
@@ -1,0 +1,11 @@
+-xc++
+-std=c++20
+-DC10_USING_CUSTOM_GENERATED_MACROS=1
+-DEXECUTORCH_ENABLE_EXECUTION_PROFILING=1
+-Icpp
+-isystem../../node_modules/react-native/ReactCommon/jsi
+-isystemthird-party/include
+-isystemthird-party/include/executorch/extension/llm/tokenizers/include
+-isystemthird-party/include/executorch/extension/llm/tokenizers/third-party/json/include
+-isystemthird-party/include/executorch/extension/llm/tokenizers/third-party/re2
+-isystemthird-party/include/executorch/extension/llm/tokenizers/third-party/abseil-cpp

--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -27,7 +27,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
 
     if (nameStr == "getMethodNames") {
         auto self = shared_from_this();
-        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value * /*args*/, size_t count) -> jsi::Value {
             if (count != 0) {
                 throw jsi::JSError(rt, "getMethodNames: Usage: getMethodNames()");
             }
@@ -61,7 +61,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
 
     if (nameStr == "getMethodMeta") {
         auto self = shared_from_this();
-        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
             if (count != 1) {
                 throw jsi::JSError(rt, "getMethodMeta: Usage: getMethodMeta(methodName)");
             }
@@ -176,7 +176,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
 
     if (nameStr == "execute") {
         auto self = shared_from_this();
-        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
             if (count != 3) {
                 throw jsi::JSError(rt, "execute: Usage: execute(methodName, inputs, outputTensors)");
             }
@@ -435,7 +435,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
 
     if (nameStr == "dispose") {
         auto self = shared_from_this();
-        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value * /*args*/, size_t count) -> jsi::Value {
             if (count != 0) {
                 throw jsi::JSError(rt, "dispose: Usage: dispose()");
             }
@@ -468,7 +468,7 @@ std::vector<facebook::jsi::PropNameID> ModelHostObject::getPropertyNames(jsi::Ru
 
 void install_loadModel(jsi::Runtime &rt, jsi::Object &module) {
     auto name = "loadModel";
-    auto fnBody = [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 1) {
             throw jsi::JSError(rt, "loadModel: Usage: loadModel(arg0)");
         }

--- a/packages/react-native-executorch/cpp/core/tensor.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor.cpp
@@ -38,7 +38,7 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
 
     if (nameStr == "copyTo") {
         auto self = shared_from_this();
-        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
             if (count != 1) {
                 throw jsi::JSError(rt, "copyTo: Usage: copyTo(dst)");
             }
@@ -143,7 +143,7 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
 
     if (nameStr == "getData") {
         auto self = shared_from_this();
-        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
             if (count != 1) {
                 throw jsi::JSError(rt, "getData: Usage: getData(array)");
             }
@@ -259,7 +259,7 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
 
     if (nameStr == "dispose") {
         auto self = shared_from_this();
-        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value * /*args*/, size_t count) -> jsi::Value {
             if (count != 0) {
                 throw jsi::JSError(rt, "dispose: Usage: dispose()");
             }
@@ -297,7 +297,7 @@ std::vector<facebook::jsi::PropNameID> TensorHostObject::getPropertyNames(jsi::R
 
 void install_createTensor(jsi::Runtime &rt, jsi::Object &module) {
     auto name = "createTensor";
-    auto fnBody = [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 2) {
             throw jsi::JSError(rt, "createTensor: Usage: createTensor(shape, dtype)");
         }

--- a/packages/react-native-executorch/cpp/core/utils.cpp
+++ b/packages/react-native-executorch/cpp/core/utils.cpp
@@ -10,7 +10,7 @@ namespace jsi = facebook::jsi;
 
 void install_getExecuTorchRegisteredBackends(jsi::Runtime &rt, jsi::Object &module) {
     auto name = "getExecuTorchRegisteredBackends";
-    auto fnBody = [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value * /*args*/, size_t count) -> jsi::Value {
         if (count != 0) {
             throw jsi::JSError(rt, "Usage: getExecuTorchRegisteredBackends()");
         }

--- a/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
@@ -67,7 +67,7 @@ std::array<float, 4> decodeToXyxy(
 
 void install_nms(jsi::Runtime &rt, jsi::Object &module) {
     auto name = "nms";
-    auto fnBody = [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count < 3) {
             throw jsi::JSError(rt, "Usage: nms(boxes, scores, options)");
         }
@@ -143,7 +143,7 @@ void install_nms(jsi::Runtime &rt, jsi::Object &module) {
         const float *scoresPtr = reinterpret_cast<const float *>(scores->data_.get());
 
         std::vector<std::pair<std::int32_t, float>> candidates;
-        candidates.reserve(numAnchors);
+        candidates.reserve(static_cast<size_t>(numAnchors));
 
         for (size_t idx = 0; std::cmp_less(idx, numAnchors); ++idx) {
             float score = scoresPtr[idx];

--- a/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
@@ -65,7 +65,7 @@ FitBox computeFit(int32_t srcW, int32_t srcH, int32_t dstW, int32_t dstH, bool i
 
 void install_resize(jsi::Runtime &rt, jsi::Object &module) {
     auto name = "resize";
-    auto fnBody = [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 3) {
             throw jsi::JSError(rt, "Usage: resize(src, dst, options)");
         }
@@ -233,7 +233,7 @@ int codeToColorConversionFlag(const std::string &code) {
 
 void install_cvtColor(jsi::Runtime &rt, jsi::Object &module) {
     auto name = "cvtColor";
-    auto fnBody = [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 3) {
             throw jsi::JSError(rt, "Usage: cvtColor(src, dst, code)");
         }
@@ -319,7 +319,7 @@ void install_cvtColor(jsi::Runtime &rt, jsi::Object &module) {
 
 void install_toChannelsFirst(jsi::Runtime &rt, jsi::Object &module) {
     auto name = "toChannelsFirst";
-    auto fnBody = [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 2) {
             throw jsi::JSError(rt, "Usage: toChannelsFirst(src, dst)");
         }
@@ -391,7 +391,7 @@ void install_toChannelsFirst(jsi::Runtime &rt, jsi::Object &module) {
         std::vector<::cv::Mat> channels;
         ::cv::split(srcMat, channels);
 
-        int32_t hw = srcH * srcW;
+        size_t hw = static_cast<size_t>(srcH) * static_cast<size_t>(srcW);
         size_t elemSize = rnexecutorch::core::types::elementSize(src->dtype_);
         uint8_t *dstPtr = dst->data_.get();
 
@@ -407,7 +407,7 @@ void install_toChannelsFirst(jsi::Runtime &rt, jsi::Object &module) {
 
 void install_toChannelsLast(jsi::Runtime &rt, jsi::Object &module) {
     auto name = "toChannelsLast";
-    auto fnBody = [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 2) {
             throw jsi::JSError(rt, "Usage: toChannelsLast(src, dst)");
         }
@@ -475,7 +475,7 @@ void install_toChannelsLast(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "toChannelsLast: " + std::string(e.what()));
         }
 
-        int32_t hw = srcH * srcW;
+        size_t hw = static_cast<size_t>(srcH) * static_cast<size_t>(srcW);
         size_t elemSize = rnexecutorch::core::types::elementSize(src->dtype_);
         uint8_t *srcPtr = src->data_.get();
 
@@ -495,7 +495,7 @@ void install_toChannelsLast(jsi::Runtime &rt, jsi::Object &module) {
 
 void install_normalize(jsi::Runtime &rt, jsi::Object &module) {
     auto name = "normalize";
-    auto fnBody = [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 3) {
             throw jsi::JSError(rt, "Usage: normalize(src, dst, options)");
         }
@@ -541,7 +541,7 @@ void install_normalize(jsi::Runtime &rt, jsi::Object &module) {
             }
 
             auto val = opts.getProperty(rt, name);
-            std::vector<double> result(c);
+            std::vector<double> result(static_cast<size_t>(c));
 
             if (val.isNumber()) {
                 std::ranges::fill(result, val.asNumber());
@@ -602,9 +602,10 @@ void install_normalize(jsi::Runtime &rt, jsi::Object &module) {
         uint8_t *srcPtr = src->data_.get();
         uint8_t *dstPtr = dst->data_.get();
 
+        const size_t plane = static_cast<size_t>(h) * static_cast<size_t>(w);
         for (size_t ch = 0; std::cmp_less(ch, c); ++ch) {
-            ::cv::Mat srcChannel(h, w, srcDepthType, srcPtr + ch * h * w * srcElemSize);
-            ::cv::Mat dstChannel(h, w, dstDepthType, dstPtr + ch * h * w * dstElemSize);
+            ::cv::Mat srcChannel(h, w, srcDepthType, srcPtr + ch * plane * srcElemSize);
+            ::cv::Mat dstChannel(h, w, dstDepthType, dstPtr + ch * plane * dstElemSize);
 
             srcChannel.convertTo(dstChannel, dstDepthType, alpha[ch], beta[ch]);
         }
@@ -617,7 +618,7 @@ void install_normalize(jsi::Runtime &rt, jsi::Object &module) {
 
 void install_applyColormap(jsi::Runtime &rt, jsi::Object &module) {
     auto name = "applyColormap";
-    auto fnBody = [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 3) {
             throw jsi::JSError(rt, "Usage: applyColormap(src, dst, colormap)");
         }
@@ -695,7 +696,7 @@ void install_applyColormap(jsi::Runtime &rt, jsi::Object &module) {
                                            std::to_string(numColors) + ")");
             }
             for (size_t c = 0; c < numRgbaChannels; ++c) {
-                dstData[i * numRgbaChannels + c] = lut[idx][c];
+                dstData[i * numRgbaChannels + c] = lut[static_cast<size_t>(idx)][c];
             }
         }
 

--- a/packages/react-native-executorch/cpp/extensions/math/operations.cpp
+++ b/packages/react-native-executorch/cpp/extensions/math/operations.cpp
@@ -13,7 +13,7 @@ using TensorHostObject = rnexecutorch::core::tensor::TensorHostObject;
 
 void install_sigmoid(jsi::Runtime &rt, jsi::Object &module) {
     auto name = "sigmoid";
-    auto fnBody = [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 2) {
             throw jsi::JSError(rt, "Usage: sigmoid(src, dst)");
         }
@@ -79,7 +79,7 @@ void install_sigmoid(jsi::Runtime &rt, jsi::Object &module) {
 
 void install_softmax(jsi::Runtime &rt, jsi::Object &module) {
     auto name = "softmax";
-    auto fnBody = [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 3) {
             throw jsi::JSError(rt, "Usage: softmax(src, dst, axis)");
         }
@@ -130,6 +130,7 @@ void install_softmax(jsi::Runtime &rt, jsi::Object &module) {
         if (axis < 0 || axis >= rank) {
             throw jsi::JSError(rt, "softmax: axis is out of range");
         }
+        const size_t axisIdx = static_cast<size_t>(axis);
 
         std::shared_lock<std::shared_mutex> srcLock(src->mutex_, std::try_to_lock);
         if (!srcLock.owns_lock()) {
@@ -152,7 +153,7 @@ void install_softmax(jsi::Runtime &rt, jsi::Object &module) {
         const auto *srcData = reinterpret_cast<const float *>(src->data_.get());
         auto *dstData = reinterpret_cast<float *>(dst->data_.get());
 
-        const size_t axisDim = static_cast<size_t>(src->shape_[axis]);
+        const size_t axisDim = static_cast<size_t>(src->shape_[axisIdx]);
         if (axisDim == 0) {
             throw jsi::JSError(rt, "softmax: axis dimension must be greater than zero");
         }
@@ -163,7 +164,7 @@ void install_softmax(jsi::Runtime &rt, jsi::Object &module) {
         }
 
         size_t inner = 1;
-        for (size_t i = axis + 1; std::cmp_less(i, rank); ++i) {
+        for (size_t i = axisIdx + 1; std::cmp_less(i, rank); ++i) {
             inner *= static_cast<size_t>(src->shape_[i]);
         }
 
@@ -197,7 +198,7 @@ void install_softmax(jsi::Runtime &rt, jsi::Object &module) {
 
 void install_argmax(jsi::Runtime &rt, jsi::Object &module) {
     auto name = "argmax";
-    auto fnBody = [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 3) {
             throw jsi::JSError(rt, "Usage: argmax(src, dst, axis)");
         }
@@ -240,9 +241,10 @@ void install_argmax(jsi::Runtime &rt, jsi::Object &module) {
         if (axis < 0 || axis >= rank) {
             throw jsi::JSError(rt, "argmax: axis is out of range");
         }
+        const size_t axisIdx = static_cast<size_t>(axis);
 
         auto dstExpectedShape = src->shape_;
-        dstExpectedShape[axis] = 1;
+        dstExpectedShape[axisIdx] = 1;
         if (dst->shape_ != dstExpectedShape) {
             throw jsi::JSError(rt, "argmax: dst shape must match src shape but with axis dimension 1");
         }
@@ -263,17 +265,17 @@ void install_argmax(jsi::Runtime &rt, jsi::Object &module) {
 
         const float *srcData = reinterpret_cast<const float *>(src->data_.get());
 
-        size_t axisDim = src->shape_[axis];
+        const size_t axisDim = static_cast<size_t>(src->shape_[axisIdx]);
         if (axisDim == 0) {
             throw jsi::JSError(rt, "argmax: axis dimension must be greater than zero");
         }
 
         size_t outer = 1, inner = 1;
         for (size_t i = 0; std::cmp_less(i, axis); ++i) {
-            outer *= src->shape_[i];
+            outer *= static_cast<size_t>(src->shape_[i]);
         }
-        for (size_t i = axis + 1; std::cmp_less(i, rank); ++i) {
-            inner *= src->shape_[i];
+        for (size_t i = axisIdx + 1; std::cmp_less(i, rank); ++i) {
+            inner *= static_cast<size_t>(src->shape_[i]);
         }
 
         int32_t *dstData = reinterpret_cast<int32_t *>(dst->data_.get());

--- a/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
+++ b/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
@@ -18,29 +18,29 @@ constexpr uint64_t kNumAddedEosTokens = 0;
 // tokenizers::Error is its own enum (not executorch::runtime::Error), and the
 // tokenizers library ships no to_string for it, so map it to a readable name.
 std::string toString(tokenizers::Error error) {
-  switch (error) {
-  case tokenizers::Error::Ok:
-    return "Ok";
-  case tokenizers::Error::Internal:
-    return "Internal";
-  case tokenizers::Error::Uninitialized:
-    return "Uninitialized";
-  case tokenizers::Error::OutOfRange:
-    return "OutOfRange";
-  case tokenizers::Error::LoadFailure:
-    return "LoadFailure";
-  case tokenizers::Error::EncodeFailure:
-    return "EncodeFailure";
-  case tokenizers::Error::Base64DecodeFailure:
-    return "Base64DecodeFailure";
-  case tokenizers::Error::ParseFailure:
-    return "ParseFailure";
-  case tokenizers::Error::DecodeFailure:
-    return "DecodeFailure";
-  case tokenizers::Error::RegexFailure:
-    return "RegexFailure";
-  }
-  return "Unknown(" + std::to_string(static_cast<int32_t>(error)) + ")";
+    switch (error) {
+    case tokenizers::Error::Ok:
+        return "Ok";
+    case tokenizers::Error::Internal:
+        return "Internal";
+    case tokenizers::Error::Uninitialized:
+        return "Uninitialized";
+    case tokenizers::Error::OutOfRange:
+        return "OutOfRange";
+    case tokenizers::Error::LoadFailure:
+        return "LoadFailure";
+    case tokenizers::Error::EncodeFailure:
+        return "EncodeFailure";
+    case tokenizers::Error::Base64DecodeFailure:
+        return "Base64DecodeFailure";
+    case tokenizers::Error::ParseFailure:
+        return "ParseFailure";
+    case tokenizers::Error::DecodeFailure:
+        return "DecodeFailure";
+    case tokenizers::Error::RegexFailure:
+        return "RegexFailure";
+    }
+    return "Unknown(" + std::to_string(static_cast<int32_t>(error)) + ")";
 }
 } // namespace
 
@@ -63,7 +63,7 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
 
     if (nameStr == "encode") {
         auto self = shared_from_this();
-        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
             if (count != 1) {
                 throw jsi::JSError(rt, "encode: Usage: encode(text)");
             }
@@ -101,7 +101,7 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
 
     if (nameStr == "decode") {
         auto self = shared_from_this();
-        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
             if (count < 1 || count > 2) {
                 throw jsi::JSError(rt, "decode: Usage: decode(tokens, skipSpecialTokens?)");
             }
@@ -157,7 +157,7 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
 
     if (nameStr == "getVocabSize") {
         auto self = shared_from_this();
-        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value * /*args*/, size_t count) -> jsi::Value {
             if (count != 0) {
                 throw jsi::JSError(rt, "getVocabSize: Usage: getVocabSize()");
             }
@@ -178,7 +178,7 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
 
     if (nameStr == "idToToken") {
         auto self = shared_from_this();
-        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
             if (count != 1) {
                 throw jsi::JSError(rt, "idToToken: Usage: idToToken(id)");
             }
@@ -210,7 +210,7 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
 
     if (nameStr == "tokenToId") {
         auto self = shared_from_this();
-        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
             if (count != 1) {
                 throw jsi::JSError(rt, "tokenToId: Usage: tokenToId(token)");
             }
@@ -242,7 +242,7 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
 
     if (nameStr == "dispose") {
         auto self = shared_from_this();
-        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+        auto fnBody = [self](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value * /*args*/, size_t count) -> jsi::Value {
             if (count != 0) {
                 throw jsi::JSError(rt, "dispose: Usage: dispose()");
             }
@@ -277,7 +277,7 @@ std::vector<facebook::jsi::PropNameID> TokenizerHostObject::getPropertyNames(jsi
 
 void install_loadTokenizer(jsi::Runtime &rt, jsi::Object &module) {
     auto name = "loadTokenizer";
-    auto fnBody = [](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 1) {
             throw jsi::JSError(rt, "loadTokenizer: Usage: loadTokenizer(arg0)");
         }

--- a/packages/react-native-executorch/scripts/check-cpp-warnings.sh
+++ b/packages/react-native-executorch/scripts/check-cpp-warnings.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Pre-commit guard: fail the commit when staged C/C++ sources in the core package
+# produce compiler warnings under the project's clangd warning set — i.e. the
+# include flags in compile_flags.txt plus the -W flags in .clangd. This mirrors
+# what clangd shows in the editor, so a commit can't introduce a warning that the
+# editor would have flagged.
+#
+# It skips gracefully (without blocking the commit) when a C++ compiler or the
+# provisioned ExecuTorch/JSI headers are not available, so contributors who don't
+# build the native code are never blocked. Bypass explicitly with `git commit
+# --no-verify`. Override the compiler with CXX=/path/to/clang++.
+#
+# Usage: check-cpp-warnings.sh <staged file> [<staged file> ...]
+set -uo pipefail
+
+PKG_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PKG_PREFIX="packages/react-native-executorch/"
+
+# Keep only staged files inside this package's cpp/ tree, relative to PKG_DIR.
+rel_files=()
+for f in "$@"; do
+  case "$f" in
+    "${PKG_PREFIX}"cpp/*) rel_files+=("${f#"$PKG_PREFIX"}") ;;
+    cpp/*)                rel_files+=("$f") ;;
+  esac
+done
+[ "${#rel_files[@]}" -eq 0 ] && exit 0
+
+CXX="${CXX:-clang++}"
+if ! command -v "$CXX" >/dev/null 2>&1; then
+  echo "ℹ C++ warning check skipped: no compiler ('$CXX') on PATH (set CXX to override)."
+  exit 0
+fi
+
+cd "$PKG_DIR"
+
+if [ ! -d third-party/include/executorch ] ||
+   [ ! -f ../../node_modules/react-native/ReactCommon/jsi/jsi/jsi.h ]; then
+  echo "ℹ C++ warning check skipped: provision third-party/include and run 'yarn install' to enable it."
+  exit 0
+fi
+
+# Compilation database (includes / std / defines) + the .clangd warning set.
+db_flags=()
+while IFS= read -r line; do
+  [ -n "$line" ] && db_flags+=("$line")
+done < compile_flags.txt
+warn_flags=()
+while IFS= read -r w; do warn_flags+=("$w"); done < <(grep -oE '\-W[A-Za-z0-9=-]+' .clangd)
+
+status=0
+for f in "${rel_files[@]}"; do
+  [ -f "$f" ] || continue  # skip deleted/renamed entries
+  if out="$("$CXX" -fsyntax-only "${db_flags[@]}" "${warn_flags[@]}" "$f" 2>&1)" && [ -z "$out" ]; then
+    continue
+  fi
+  if printf '%s\n' "$out" | grep -qE '(warning|error):'; then
+    printf '%s\n' "$out" >&2
+    status=1
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  echo >&2
+  echo "✖ C++ warnings in staged sources (above). Fix them, or bypass with 'git commit --no-verify'." >&2
+fi
+exit "$status"

--- a/packages/react-native-executorch/scripts/check-cpp-warnings.sh
+++ b/packages/react-native-executorch/scripts/check-cpp-warnings.sh
@@ -35,6 +35,11 @@ fi
 
 cd "$PKG_DIR"
 
+if [ ! -f compile_flags.txt ] || [ ! -f .clangd ]; then
+  echo "ℹ C++ warning check skipped: compile_flags.txt or .clangd not found."
+  exit 0
+fi
+
 if [ ! -d third-party/include/executorch ] ||
    [ ! -f ../../node_modules/react-native/ReactCommon/jsi/jsi/jsi.h ]; then
   echo "ℹ C++ warning check skipped: provision third-party/include and run 'yarn install' to enable it."
@@ -42,12 +47,15 @@ if [ ! -d third-party/include/executorch ] ||
 fi
 
 # Compilation database (includes / std / defines) + the .clangd warning set.
+# The `|| [ -n "$line" ]` keeps the final line even if the file has no trailing newline.
 db_flags=()
-while IFS= read -r line; do
+while IFS= read -r line || [ -n "$line" ]; do
   [ -n "$line" ] && db_flags+=("$line")
 done < compile_flags.txt
 warn_flags=()
-while IFS= read -r w; do warn_flags+=("$w"); done < <(grep -oE '\-W[A-Za-z0-9=-]+' .clangd)
+while IFS= read -r w || [ -n "$w" ]; do
+  [ -n "$w" ] && warn_flags+=("$w")
+done < <(grep -oE '\-W[A-Za-z0-9=-]+' .clangd)
 
 status=0
 for f in "${rel_files[@]}"; do


### PR DESCRIPTION
## Description

Sets up a committed [clangd](https://clangd.llvm.org/) config for the core package's C/C++ sources so the rewrite gets code intelligence and a shared, strict warning set, and enforces that set at commit time. First step of #1271; clang-tidy CI is a follow-up (#1286).

- `compile_flags.txt` — include roots / `-std=c++20` / defines, with third-party headers (ExecuTorch/torch/JSI) as `-isystem` so their warnings don't pollute our diagnostics. Relative paths anchored to the package dir, so it is portable with no per-machine generation.
- `.clangd` — strict warning set layered on top (incl. `-Wconversion`/`-Wsign-conversion`), with clangd's include cleaner disabled (ExecuTorch umbrella headers misreport includes).
- `scripts/check-cpp-warnings.sh` + `lefthook.yml` — a `pre-commit` command that compiles staged `cpp/` sources with the same warning set and aborts the commit on any warning, keeping the editor and the commit gate in sync. It skips gracefully (never blocks) when no compiler or the provisioned headers are available; bypass with `git commit --no-verify`.
- `.gitignore` — track the shared config while keeping generated `compile_commands.json` local.
- `CONTRIBUTING.md` — prerequisites (provisioned `third-party/include` + `yarn install`), editor setup, and the pre-commit behavior.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

1. Provision `packages/react-native-executorch/third-party/include` and run `yarn install`.
2. Open a file under `packages/react-native-executorch/cpp` in an editor with the clangd extension (MS C/C++ IntelliSense disabled); confirm the `<executorch/...>`/`<jsi/jsi.h>` includes resolve and the current sources are clean.
3. Confirm the strict flags fire by introducing a deliberate violation, e.g. in `cpp/core/dtype.cpp`:
   ```cpp
   int rne_probe(float f) {
       int casted = (int)f;   // expect -Wold-style-cast + -Wconversion
       int unused = 7;        // expect -Wunused-variable
       return casted;
   }
   ```
   clangd should flag these on our code (third-party headers stay quiet thanks to `-isystem`).
4. `git add` that change and `git commit` — the pre-commit hook aborts with the warning printed. Verified end-to-end via lefthook: warning → `cpp-warnings ❌` (exit 1); clean → `✔️` (exit 0). Revert afterwards.

### Related issues

#1271

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings