### PR TITLE
[RNE Rewrite] chore: add clang-tidy static checks

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,49 @@
+name: clang-tidy
+
+on:
+  pull_request:
+    branches:
+      - main
+      - rne-rewrite
+    paths:
+      - 'packages/react-native-executorch/cpp/**'
+      - 'packages/react-native-executorch/.clang-tidy'
+      - 'packages/react-native-executorch/compile_flags.txt'
+      - 'packages/react-native-executorch/scripts/clang-tidy.sh'
+      - '.github/workflows/clang-tidy.yml'
+  workflow_dispatch:
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-latest
+    # Dormant until the on-demand header artifact is published (#1283): clang-tidy
+    # must parse the sources, which needs the ExecuTorch/torch headers that are not
+    # committed. Enable by setting the repo variable ENABLE_CLANG_TIDY=true once a
+    # release carrying headers.tar.gz exists for the package version.
+    if: ${{ vars.ENABLE_CLANG_TIDY == 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Install clang-tidy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-tidy
+          clang-tidy --version
+
+      - name: Provision ExecuTorch headers
+        # Reuse the on-demand download flow (#1283). clang-tidy only needs headers
+        # (it syntax-checks, no linking), so RNET_HEADERS_ONLY fetches just
+        # headers.tar.gz; RNET_TARGET avoids host platform auto-detection.
+        working-directory: packages/react-native-executorch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RNET_HEADERS_ONLY: '1'
+          RNET_TARGET: android-arm64-v8a
+        run: node scripts/download-libs.js
+
+      - name: Run clang-tidy
+        run: yarn workspace react-native-executorch lint:cpp

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -43,6 +43,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RNET_HEADERS_ONLY: '1'
           RNET_TARGET: android-arm64-v8a
+          # TODO(#1291, @msluszniak): drop this override once a real versioned
+          # release exists. download-libs.js resolves the tag from the package
+          # version (v${PACKAGE_VERSION} == v0.0.0), but the placeholder 0.0.0 has
+          # no release; headers.tar.gz currently lives only on the test pre-release.
+          RNET_BASE_URL: https://github.com/software-mansion/react-native-executorch/releases/download/v0.0.0-rewrite-libs-test
         run: node scripts/download-libs.js
 
       - name: Run clang-tidy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,20 @@ don't conflict. clangd discovers `compile_flags.txt`/`.clangd` automatically fro
 open file's directory. If you produce a `compile_commands.json` from a native build,
 clangd will prefer it — it's gitignored and takes precedence over `compile_flags.txt`.
 
+## clang-tidy
+
+`packages/react-native-executorch/.clang-tidy` adds a conservative, high-signal set of
+static checks (bugprone / performance / clang-analyzer) on top of the same database. The
+clangd extension surfaces these inline; you can also run them from the command line:
+
+```
+yarn workspace react-native-executorch lint:cpp           # all C++ sources
+CLANG_TIDY=$(brew --prefix llvm)/bin/clang-tidy yarn workspace react-native-executorch lint:cpp
+```
+
+It needs the same provisioned headers as clangd. Suppress an intentional, reviewed finding
+with a commented `// NOLINTNEXTLINE(check-name)` rather than loosening the shared config.
+
 # Creating a Pull Request
 
 Before writing any code reach out to us to make sure no one is currently working on it, you can always open an issue first.

--- a/packages/react-native-executorch/.clang-tidy
+++ b/packages/react-native-executorch/.clang-tidy
@@ -21,6 +21,7 @@ Checks: >
   performance-*,
   clang-analyzer-*,
   cppcoreguidelines-*,
+  google-*,
   -bugprone-easily-swappable-parameters,
   -performance-enum-size,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,

--- a/packages/react-native-executorch/.clang-tidy
+++ b/packages/react-native-executorch/.clang-tidy
@@ -1,21 +1,33 @@
 # clang-tidy configuration for the react-native-executorch C/C++ sources.
 #
-# This is the first, deliberately conservative step toward a clang-tidy CI gate
-# (issue #1271): a tight, high-signal set focused on correctness and performance
-# bugs rather than opinionated style. It is expected to stay green on our own
-# code; grow the check list over time.
+# A high-signal set focused on correctness/performance bugs and modern C++
+# guidelines (issue #1271). Check groups are enabled one at a time and the
+# findings fixed; it is expected to stay green on our own code.
 #
 # clang-tidy reads the include flags / standard / defines from compile_flags.txt
 # (the same database clangd uses), so it needs the same prerequisites: a provisioned
 # third-party/include and `yarn install`. The clangd extension also surfaces these
 # checks inline in the editor.
+#
+# Excluded checks (incompatible with a native tensor/buffer library that interops
+# with ExecuTorch over raw pointers, or purely opinionated):
+#   pro-bounds-pointer-arithmetic / -avoid-unchecked-container-access /
+#   -constant-array-index — raw buffer pointer math and hot-loop indexing are by design
+#   pro-type-reinterpret-cast — type-erased byte buffers cast to typed pointers
+#   avoid-magic-numbers / easily-swappable-parameters / enum-size — opinionated / noisy
 Checks: >
   -*,
   bugprone-*,
   performance-*,
   clang-analyzer-*,
+  cppcoreguidelines-*,
   -bugprone-easily-swappable-parameters,
-  -performance-enum-size
+  -performance-enum-size,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-avoid-magic-numbers
 
 # Restrict analysis to this package's own cpp/ tree. Anchored on the full package
 # path so it can never match an unrelated directory that merely contains "cpp"

--- a/packages/react-native-executorch/.clang-tidy
+++ b/packages/react-native-executorch/.clang-tidy
@@ -26,6 +26,12 @@
 #     (it flags RAII lock guards as const-able); not enforced going forward
 #   modernize-use-trailing-return-type — the codebase uses traditional return types
 #   modernize-return-braced-init-list — `return {…}` hides the (JSI) return type
+#   readability-identifier-length — short names (i, rt, h, w, …) are idiomatic here
+#   readability-math-missing-parentheses — flags standard array-offset arithmetic
+#   readability-function-cognitive-complexity — the JSI get() dispatchers and the
+#     image/tensor kernels are inherently above the threshold
+#   readability-uppercase-literal-suffix — the codebase uses lowercase (1.0f) consistently
+#   readability-magic-numbers — opinionated (same as cppcoreguidelines-avoid-magic-numbers)
 Checks: >
   -*,
   bugprone-*,
@@ -36,6 +42,7 @@ Checks: >
   llvm-*,
   misc-*,
   modernize-*,
+  readability-*,
   -bugprone-easily-swappable-parameters,
   -performance-enum-size,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
@@ -50,7 +57,12 @@ Checks: >
   -misc-non-private-member-variables-in-classes,
   -misc-const-correctness,
   -modernize-use-trailing-return-type,
-  -modernize-return-braced-init-list
+  -modernize-return-braced-init-list,
+  -readability-identifier-length,
+  -readability-math-missing-parentheses,
+  -readability-function-cognitive-complexity,
+  -readability-uppercase-literal-suffix,
+  -readability-magic-numbers
 
 # Restrict analysis to this package's own cpp/ tree. Anchored on the full package
 # path so it can never match an unrelated directory that merely contains "cpp"

--- a/packages/react-native-executorch/.clang-tidy
+++ b/packages/react-native-executorch/.clang-tidy
@@ -1,0 +1,27 @@
+# clang-tidy configuration for the react-native-executorch C/C++ sources.
+#
+# This is the first, deliberately conservative step toward a clang-tidy CI gate
+# (issue #1271): a tight, high-signal set focused on correctness and performance
+# bugs rather than opinionated style. It is expected to stay green on our own
+# code; grow the check list over time.
+#
+# clang-tidy reads the include flags / standard / defines from compile_flags.txt
+# (the same database clangd uses), so it needs the same prerequisites: a provisioned
+# third-party/include and `yarn install`. The clangd extension also surfaces these
+# checks inline in the editor.
+Checks: >
+  -*,
+  bugprone-*,
+  performance-*,
+  clang-analyzer-*,
+  -bugprone-easily-swappable-parameters,
+  -performance-enum-size
+
+# Restrict analysis to this package's own cpp/ tree. Anchored on the full package
+# path so it can never match an unrelated directory that merely contains "cpp"
+# (e.g. third-party/.../abseil-cpp/, or another package's cpp/). Third-party headers
+# are also -isystem in compile_flags.txt, so clang-tidy does not analyze them anyway.
+HeaderFilterRegex: 'packages/react-native-executorch/cpp/.*\.(h|hpp)$'
+
+# Treat findings as warnings (CI decides failure via --warnings-as-errors).
+WarningsAsErrors: ''

--- a/packages/react-native-executorch/.clang-tidy
+++ b/packages/react-native-executorch/.clang-tidy
@@ -15,6 +15,9 @@
 #   -constant-array-index — raw buffer pointer math and hot-loop indexing are by design
 #   pro-type-reinterpret-cast — type-erased byte buffers cast to typed pointers
 #   avoid-magic-numbers / easily-swappable-parameters / enum-size — opinionated / noisy
+#   llvm-header-guard — the project uses #pragma once by convention
+#   llvm-prefer-static-over-anonymous-namespace — anonymous namespaces are a valid
+#     idiom here and also hold the helpers' shared types/constants
 Checks: >
   -*,
   bugprone-*,
@@ -22,13 +25,16 @@ Checks: >
   clang-analyzer-*,
   cppcoreguidelines-*,
   google-*,
+  llvm-*,
   -bugprone-easily-swappable-parameters,
   -performance-enum-size,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
   -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-type-reinterpret-cast,
-  -cppcoreguidelines-avoid-magic-numbers
+  -cppcoreguidelines-avoid-magic-numbers,
+  -llvm-header-guard,
+  -llvm-prefer-static-over-anonymous-namespace
 
 # Restrict analysis to this package's own cpp/ tree. Anchored on the full package
 # path so it can never match an unrelated directory that merely contains "cpp"

--- a/packages/react-native-executorch/.clang-tidy
+++ b/packages/react-native-executorch/.clang-tidy
@@ -24,6 +24,8 @@
 #     data carriers read across extensions
 #   misc-const-correctness — applied once as a cleanup, but too aggressive to gate on
 #     (it flags RAII lock guards as const-able); not enforced going forward
+#   modernize-use-trailing-return-type — the codebase uses traditional return types
+#   modernize-return-braced-init-list — `return {…}` hides the (JSI) return type
 Checks: >
   -*,
   bugprone-*,
@@ -33,6 +35,7 @@ Checks: >
   google-*,
   llvm-*,
   misc-*,
+  modernize-*,
   -bugprone-easily-swappable-parameters,
   -performance-enum-size,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
@@ -45,7 +48,9 @@ Checks: >
   -misc-include-cleaner,
   -misc-multiple-inheritance,
   -misc-non-private-member-variables-in-classes,
-  -misc-const-correctness
+  -misc-const-correctness,
+  -modernize-use-trailing-return-type,
+  -modernize-return-braced-init-list
 
 # Restrict analysis to this package's own cpp/ tree. Anchored on the full package
 # path so it can never match an unrelated directory that merely contains "cpp"

--- a/packages/react-native-executorch/.clang-tidy
+++ b/packages/react-native-executorch/.clang-tidy
@@ -18,6 +18,12 @@
 #   llvm-header-guard — the project uses #pragma once by convention
 #   llvm-prefer-static-over-anonymous-namespace — anonymous namespaces are a valid
 #     idiom here and also hold the helpers' shared types/constants
+#   misc-include-cleaner — ExecuTorch umbrella headers make it misreport includes
+#   misc-multiple-inheritance — the JSI HostObject + enable_shared_from_this pattern
+#   misc-non-private-member-variables-in-classes — HostObjects are deliberate public
+#     data carriers read across extensions
+#   misc-const-correctness — applied once as a cleanup, but too aggressive to gate on
+#     (it flags RAII lock guards as const-able); not enforced going forward
 Checks: >
   -*,
   bugprone-*,
@@ -26,6 +32,7 @@ Checks: >
   cppcoreguidelines-*,
   google-*,
   llvm-*,
+  misc-*,
   -bugprone-easily-swappable-parameters,
   -performance-enum-size,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
@@ -34,7 +41,11 @@ Checks: >
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -cppcoreguidelines-avoid-magic-numbers,
   -llvm-header-guard,
-  -llvm-prefer-static-over-anonymous-namespace
+  -llvm-prefer-static-over-anonymous-namespace,
+  -misc-include-cleaner,
+  -misc-multiple-inheritance,
+  -misc-non-private-member-variables-in-classes,
+  -misc-const-correctness
 
 # Restrict analysis to this package's own cpp/ tree. Anchored on the full package
 # path so it can never match an unrelated directory that merely contains "cpp"

--- a/packages/react-native-executorch/.clangd
+++ b/packages/react-native-executorch/.clangd
@@ -25,6 +25,11 @@ CompileFlags:
     - -Wconversion
     - -Wsign-conversion
     - -Wdouble-promotion
+    # compile_flags.txt forces -xc++, so clangd opens headers as main-file
+    # translation units and flags their `#pragma once`. Silence that
+    # editor-only false positive (the guard is correct when the header is
+    # #included normally, which is the only context clang-tidy ever sees).
+    - -Wno-pragma-once-outside-header
 
 Diagnostics:
   # ExecuTorch/torch rely heavily on umbrella headers, which clangd's include

--- a/packages/react-native-executorch/cpp/RnExecutorch.cpp
+++ b/packages/react-native-executorch/cpp/RnExecutorch.cpp
@@ -8,7 +8,7 @@
 #include "extensions/cv/install.h"
 #endif
 
-using namespace facebook;
+namespace jsi = facebook::jsi;
 
 namespace rnexecutorch {
 void install(jsi::Runtime &jsiRuntime) {

--- a/packages/react-native-executorch/cpp/core/dtype.cpp
+++ b/packages/react-native-executorch/cpp/core/dtype.cpp
@@ -54,8 +54,7 @@ size_t elementSize(DType dtype) {
     switch (dtype) {
     case DType::uint8:
         return 1;
-    // int32 and float32 are both 4 bytes; the identical branches are intentional.
-    // NOLINTNEXTLINE(bugprone-branch-clone)
+    // NOLINTNEXTLINE(bugprone-branch-clone): int32 and float32 are both 4 bytes; the identical branches are intentional.
     case DType::int32:
         return 4;
     case DType::float32:

--- a/packages/react-native-executorch/cpp/core/dtype.cpp
+++ b/packages/react-native-executorch/cpp/core/dtype.cpp
@@ -54,6 +54,8 @@ size_t elementSize(DType dtype) {
     switch (dtype) {
     case DType::uint8:
         return 1;
+    // int32 and float32 are both 4 bytes; the identical branches are intentional.
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     case DType::int32:
         return 4;
     case DType::float32:

--- a/packages/react-native-executorch/cpp/core/dtype.h
+++ b/packages/react-native-executorch/cpp/core/dtype.h
@@ -5,7 +5,7 @@
 #include <string>
 
 namespace rnexecutorch::core::types {
-enum DType {
+enum class DType {
     uint8,
     int32,
     float32

--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -467,7 +467,7 @@ std::vector<facebook::jsi::PropNameID> ModelHostObject::getPropertyNames(jsi::Ru
 }
 
 void install_loadModel(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "loadModel";
+    const auto *name = "loadModel";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 1) {
             throw jsi::JSError(rt, "loadModel: Usage: loadModel(arg0)");

--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -43,7 +43,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
 
             auto methodNames = self->etModule_->method_names();
             if (!methodNames.ok()) {
-                std::string errorMsg = executorch::runtime::to_string(methodNames.error());
+                const std::string errorMsg = executorch::runtime::to_string(methodNames.error());
                 throw jsi::JSError(rt, "getMethodNames: Failed to get method names: " + errorMsg);
             }
 
@@ -82,7 +82,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             auto methodName = args[0].asString(rt).utf8(rt);
             auto methodMeta = self->etModule_->method_meta(methodName);
             if (!methodMeta.ok()) {
-                std::string errorMsg = executorch::runtime::to_string(methodMeta.error());
+                const std::string errorMsg = executorch::runtime::to_string(methodMeta.error());
                 throw jsi::JSError(rt, "getMethodMeta: Failed to get method meta: " + errorMsg);
             }
 
@@ -90,7 +90,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             for (size_t i = 0; i < methodMeta->num_inputs(); ++i) {
                 auto tag = methodMeta->input_tag(i);
                 if (!tag.ok()) {
-                    std::string errorMsg = executorch::runtime::to_string(tag.error());
+                    const std::string errorMsg = executorch::runtime::to_string(tag.error());
                     throw jsi::JSError(rt, "getMethodMeta: Failed to get input tag for input " + std::to_string(i) + ": " + errorMsg);
                 }
                 inputTagsArray.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, executorch::runtime::tag_to_string(tag.get())));
@@ -100,7 +100,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             for (size_t i = 0; i < methodMeta->num_outputs(); ++i) {
                 auto tag = methodMeta->output_tag(i);
                 if (!tag.ok()) {
-                    std::string errorMsg = executorch::runtime::to_string(tag.error());
+                    const std::string errorMsg = executorch::runtime::to_string(tag.error());
                     throw jsi::JSError(rt, "getMethodMeta: Failed to get output tag for output " + std::to_string(i) + ": " + errorMsg);
                 }
                 outputTagsArray.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, executorch::runtime::tag_to_string(tag.get())));
@@ -110,7 +110,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             for (size_t i = 0; i < methodMeta->num_backends(); ++i) {
                 auto backendName = methodMeta->get_backend_name(i);
                 if (!backendName.ok()) {
-                    std::string errorMsg = executorch::runtime::to_string(backendName.error());
+                    const std::string errorMsg = executorch::runtime::to_string(backendName.error());
                     throw jsi::JSError(rt, "getMethodMeta: Failed to get backend name for backend " + std::to_string(i) + ": " + errorMsg);
                 }
                 usesBackendMap.setProperty(rt, backendName.get(), methodMeta->uses_backend(backendName.get()));
@@ -123,7 +123,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 jsTensorMeta.setProperty(rt, "nbytes", static_cast<double>(tensorMeta.nbytes()));
 
                 try {
-                    std::string dtypeStr = rnexecutorch::core::types::toString(rnexecutorch::core::types::fromScalarType(tensorMeta.scalar_type()));
+                    const std::string dtypeStr = rnexecutorch::core::types::toString(rnexecutorch::core::types::fromScalarType(tensorMeta.scalar_type()));
                     jsTensorMeta.setProperty(rt, "dtype", jsi::String::createFromUtf8(rt, dtypeStr));
                 } catch (const std::exception &) {
                     jsTensorMeta.setProperty(rt, "dtype", jsi::String::createFromUtf8(rt, "not supported"));
@@ -142,7 +142,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             for (size_t i = 0; i < methodMeta->num_inputs(); ++i) {
                 auto tensorMeta = methodMeta->input_tensor_meta(i);
                 if (!tensorMeta.ok()) {
-                    std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
+                    const std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
                     throw jsi::JSError(rt, "getMethodMeta: Failed to get tensor meta for input " + std::to_string(i) + ": " + errorMsg);
                 }
                 inputTensorMetaArray.setValueAtIndex(rt, i, tensorMetaToJS(rt, tensorMeta.get()));
@@ -152,7 +152,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             for (size_t i = 0; i < methodMeta->num_outputs(); ++i) {
                 auto tensorMeta = methodMeta->output_tensor_meta(i);
                 if (!tensorMeta.ok()) {
-                    std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
+                    const std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
                     throw jsi::JSError(rt, "getMethodMeta: Failed to get tensor meta for output " + std::to_string(i) + ": " + errorMsg);
                 }
                 outputTensorMetaArray.setValueAtIndex(rt, i, tensorMetaToJS(rt, tensorMeta.get()));
@@ -207,14 +207,14 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             auto inputsArray = args[1].asObject(rt).asArray(rt);
 
             if (!methodMeta.ok()) {
-                std::string errorMsg = executorch::runtime::to_string(methodMeta.error());
+                const std::string errorMsg = executorch::runtime::to_string(methodMeta.error());
                 throw jsi::JSError(rt, "execute: Failed to get method meta for '" + methodName + "': " + errorMsg);
             }
 
             if (inputsArray.size(rt) != methodMeta->num_inputs()) {
-                std::string errorMsg = "execute: Incorrect size for inputs: got " +
-                                       std::to_string(inputsArray.size(rt)) +
-                                       ", expected " + std::to_string(methodMeta->num_inputs());
+                const std::string errorMsg = "execute: Incorrect size for inputs: got " +
+                                             std::to_string(inputsArray.size(rt)) +
+                                             ", expected " + std::to_string(methodMeta->num_inputs());
                 throw jsi::JSError(rt, errorMsg);
             }
 
@@ -252,7 +252,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 auto val = inputsArray.getValueAtIndex(rt, i);
 
                 if (!tag.ok()) {
-                    std::string errorMsg = executorch::runtime::to_string(tag.error());
+                    const std::string errorMsg = executorch::runtime::to_string(tag.error());
                     throw jsi::JSError(rt, "execute: Failed to get input tag for inputs[" +
                                                std::to_string(i) + "]: " + errorMsg);
                 }
@@ -290,7 +290,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                     auto tensorMeta = methodMeta->input_tensor_meta(i);
 
                     if (!tensorMeta.ok()) {
-                        std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
+                        const std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
                         throw jsi::JSError(rt, "execute: Failed to get tensor meta for inputs[" +
                                                    std::to_string(i) + "]: " + errorMsg);
                     }
@@ -343,7 +343,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
 #endif
 
             if (!result.ok()) {
-                std::string errorMsg = executorch::runtime::to_string(result.error());
+                const std::string errorMsg = executorch::runtime::to_string(result.error());
                 throw jsi::JSError(rt, "execute: Method '" + methodName + "' execution failed: " + errorMsg +
                                            ". This may be due to missing required backends - use getMethodMeta()" +
                                            " to check required backends and getExecuTorchRegisteredBackends()" +
@@ -392,7 +392,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                     auto tensorMeta = methodMeta->output_tensor_meta(index);
 
                     if (!tensorMeta.ok()) {
-                        std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
+                        const std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
                         throw jsi::JSError(rt, "execute: Failed to get tensor meta for output at index " +
                                                    std::to_string(index) + ": " + errorMsg);
                     }
@@ -482,7 +482,7 @@ void install_loadModel(jsi::Runtime &rt, jsi::Object &module) {
 
         auto error = modelInstance->etModule_->load();
         if (!modelInstance->etModule_->is_loaded()) {
-            std::string errorMsg = executorch::runtime::to_string(error);
+            const std::string errorMsg = executorch::runtime::to_string(error);
             throw jsi::JSError(rt, "loadModel: Failed to load model: " + errorMsg);
         }
 

--- a/packages/react-native-executorch/cpp/core/model.h
+++ b/packages/react-native-executorch/cpp/core/model.h
@@ -24,7 +24,7 @@ public:
     std::unique_ptr<executorch::extension::Module> etModule_;
     std::mutex mutex_;
 
-    ModelHostObject(const std::string &modelPath);
+    explicit ModelHostObject(const std::string &modelPath);
 
     facebook::jsi::Value get(facebook::jsi::Runtime &rt, const facebook::jsi::PropNameID &name) override;
     std::vector<facebook::jsi::PropNameID> getPropertyNames(facebook::jsi::Runtime &rt) override;

--- a/packages/react-native-executorch/cpp/core/tensor.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor.cpp
@@ -8,11 +8,11 @@ namespace jsi = facebook::jsi;
 TensorHostObject::TensorHostObject(const std::vector<std::int32_t> &shape, rnexecutorch::core::types::DType dtype)
     : dtype_(dtype),
       shape_(shape),
-      numel_(std::accumulate(shape.begin(), shape.end(), static_cast<size_t>(1), std::multiplies<size_t>())) {
+      numel_(std::accumulate(shape.begin(), shape.end(), static_cast<size_t>(1), std::multiplies<>())) {
     const auto elemSize = rnexecutorch::core::types::elementSize(dtype);
 
     size_ = numel_ * elemSize;
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays) — owning runtime-sized byte buffer
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays) — owning runtime-sized byte buffer
     data_ = std::make_unique<std::uint8_t[]>(size_);
     tensor_ = executorch::extension::from_blob(data_.get(), shape_, rnexecutorch::core::types::toScalarType(dtype));
 }
@@ -235,9 +235,9 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
 
             std::vector<jsi::Value> fnArgs;
             fnArgs.reserve(count);
-            fnArgs.push_back(jsi::Value(rt, thisVal));
+            fnArgs.emplace_back(rt, thisVal);
             for (size_t i = 1; i < count; ++i) {
-                fnArgs.push_back(jsi::Value(rt, args[i]));
+                fnArgs.emplace_back(rt, args[i]);
             }
 
             return fn.call(rt, static_cast<const jsi::Value *>(fnArgs.data()), fnArgs.size());
@@ -266,9 +266,9 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
 
             std::vector<jsi::Value> fnArgs;
             fnArgs.reserve(count - 1);
-            fnArgs.push_back(jsi::Value(rt, thisVal));
+            fnArgs.emplace_back(rt, thisVal);
             for (size_t i = 2; i < count; ++i) {
-                fnArgs.push_back(jsi::Value(rt, args[i]));
+                fnArgs.emplace_back(rt, args[i]);
             }
 
             return fn.call(rt, static_cast<const jsi::Value *>(fnArgs.data()), fnArgs.size());

--- a/packages/react-native-executorch/cpp/core/tensor.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor.cpp
@@ -316,7 +316,7 @@ std::vector<facebook::jsi::PropNameID> TensorHostObject::getPropertyNames(jsi::R
 }
 
 void install_createTensor(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "createTensor";
+    const auto *name = "createTensor";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 2) {
             throw jsi::JSError(rt, "createTensor: Usage: createTensor(shape, dtype)");

--- a/packages/react-native-executorch/cpp/core/tensor.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor.cpp
@@ -12,7 +12,7 @@ TensorHostObject::TensorHostObject(const std::vector<std::int32_t> &shape, rnexe
     const auto elemSize = rnexecutorch::core::types::elementSize(dtype);
 
     size_ = numel_ * elemSize;
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays) — owning runtime-sized byte buffer
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays): owning runtime-sized byte buffer
     data_ = std::make_unique<std::uint8_t[]>(size_);
     tensor_ = executorch::extension::from_blob(data_.get(), shape_, rnexecutorch::core::types::toScalarType(dtype));
 }

--- a/packages/react-native-executorch/cpp/core/tensor.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor.cpp
@@ -8,7 +8,7 @@ namespace jsi = facebook::jsi;
 TensorHostObject::TensorHostObject(const std::vector<std::int32_t> &shape, rnexecutorch::core::types::DType dtype)
     : dtype_(dtype),
       shape_(shape),
-      numel_(std::accumulate(shape.begin(), shape.end(), size_t(1), std::multiplies<size_t>())) {
+      numel_(std::accumulate(shape.begin(), shape.end(), static_cast<size_t>(1), std::multiplies<size_t>())) {
     const auto elemSize = rnexecutorch::core::types::elementSize(dtype);
 
     size_ = numel_ * elemSize;

--- a/packages/react-native-executorch/cpp/core/tensor.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor.cpp
@@ -113,12 +113,12 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "setData: Expected array to be an object (TypedArray)");
             }
 
-            jsi::Object dataObj = args[0].asObject(rt);
+            const jsi::Object dataObj = args[0].asObject(rt);
             if (!dataObj.hasProperty(rt, "buffer")) {
                 throw jsi::JSError(rt, "setData: Expected a TypedArray with a 'buffer' property");
             }
 
-            jsi::ArrayBuffer buffer = dataObj.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt);
+            const jsi::ArrayBuffer buffer = dataObj.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt);
             size_t byteOffset = 0;
             size_t byteLength = buffer.size(rt);
 
@@ -148,9 +148,9 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
             }
 
             if (byteLength != self->size_) {
-                std::string errorMsg = "setData: Data size mismatch: TypedArray is " + std::to_string(byteLength) +
-                                       " bytes, but Tensor requires " + std::to_string(self->size_) +
-                                       " bytes.";
+                const std::string errorMsg = "setData: Data size mismatch: TypedArray is " + std::to_string(byteLength) +
+                                             " bytes, but Tensor requires " + std::to_string(self->size_) +
+                                             " bytes.";
                 throw jsi::JSError(rt, errorMsg);
             }
 
@@ -172,12 +172,12 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "getData: Expected array to be an object (TypedArray)");
             }
 
-            jsi::Object dataObj = args[0].asObject(rt);
+            const jsi::Object dataObj = args[0].asObject(rt);
             if (!dataObj.hasProperty(rt, "buffer")) {
                 throw jsi::JSError(rt, "getData: Expected a TypedArray with a 'buffer' property");
             }
 
-            jsi::ArrayBuffer buffer = dataObj.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt);
+            const jsi::ArrayBuffer buffer = dataObj.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt);
             size_t byteOffset = 0;
             size_t byteLength = buffer.size(rt);
 
@@ -207,9 +207,9 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
             }
 
             if (byteLength != self->size_) {
-                std::string errorMsg = "getData: Data size mismatch: TypedArray is " + std::to_string(byteLength) +
-                                       " bytes, but Tensor requires " + std::to_string(self->size_) +
-                                       " bytes.";
+                const std::string errorMsg = "getData: Data size mismatch: TypedArray is " + std::to_string(byteLength) +
+                                             " bytes, but Tensor requires " + std::to_string(self->size_) +
+                                             " bytes.";
                 throw jsi::JSError(rt, errorMsg);
             }
 
@@ -253,7 +253,7 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "throughIf: Usage: throughIf(pred, fn, ...args)");
             }
 
-            bool pred = args[0].asBool();
+            const bool pred = args[0].asBool();
             if (!pred) {
                 return jsi::Value(rt, thisVal);
             }

--- a/packages/react-native-executorch/cpp/core/tensor.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor.cpp
@@ -5,14 +5,14 @@
 namespace rnexecutorch::core::tensor {
 namespace jsi = facebook::jsi;
 
-TensorHostObject::TensorHostObject(const std::vector<std::int32_t> &shape, rnexecutorch::core::types::DType dtype) {
+TensorHostObject::TensorHostObject(const std::vector<std::int32_t> &shape, rnexecutorch::core::types::DType dtype)
+    : dtype_(dtype),
+      shape_(shape),
+      numel_(std::accumulate(shape.begin(), shape.end(), size_t(1), std::multiplies<size_t>())) {
     const auto elemSize = rnexecutorch::core::types::elementSize(dtype);
 
-    dtype_ = dtype;
-    shape_ = shape;
-    numel_ = std::accumulate(shape.begin(), shape.end(), size_t(1), std::multiplies<size_t>());
-
     size_ = numel_ * elemSize;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays) — owning runtime-sized byte buffer
     data_ = std::make_unique<std::uint8_t[]>(size_);
     tensor_ = executorch::extension::from_blob(data_.get(), shape_, rnexecutorch::core::types::toScalarType(dtype));
 }

--- a/packages/react-native-executorch/cpp/core/tensor.h
+++ b/packages/react-native-executorch/cpp/core/tensor.h
@@ -28,7 +28,7 @@ public:
     size_t numel_;
 
     size_t size_;
-    std::unique_ptr<std::uint8_t[]> data_; // NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+    std::unique_ptr<std::uint8_t[]> data_; // NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays): owning runtime-sized byte buffer
     executorch::extension::TensorPtr tensor_;
 
     std::shared_mutex mutex_;

--- a/packages/react-native-executorch/cpp/core/tensor.h
+++ b/packages/react-native-executorch/cpp/core/tensor.h
@@ -28,7 +28,7 @@ public:
     size_t numel_;
 
     size_t size_;
-    std::unique_ptr<std::uint8_t[]> data_;
+    std::unique_ptr<std::uint8_t[]> data_; // NOLINT(cppcoreguidelines-avoid-c-arrays)
     executorch::extension::TensorPtr tensor_;
 
     std::shared_mutex mutex_;

--- a/packages/react-native-executorch/cpp/core/tensor.h
+++ b/packages/react-native-executorch/cpp/core/tensor.h
@@ -28,7 +28,7 @@ public:
     size_t numel_;
 
     size_t size_;
-    std::unique_ptr<std::uint8_t[]> data_; // NOLINT(cppcoreguidelines-avoid-c-arrays)
+    std::unique_ptr<std::uint8_t[]> data_; // NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
     executorch::extension::TensorPtr tensor_;
 
     std::shared_mutex mutex_;

--- a/packages/react-native-executorch/cpp/core/utils.cpp
+++ b/packages/react-native-executorch/cpp/core/utils.cpp
@@ -9,7 +9,7 @@ namespace rnexecutorch::core::utils {
 namespace jsi = facebook::jsi;
 
 void install_getExecuTorchRegisteredBackends(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "getExecuTorchRegisteredBackends";
+    const auto *name = "getExecuTorchRegisteredBackends";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value * /*args*/, size_t count) -> jsi::Value {
         if (count != 0) {
             throw jsi::JSError(rt, "Usage: getExecuTorchRegisteredBackends()");

--- a/packages/react-native-executorch/cpp/core/utils.cpp
+++ b/packages/react-native-executorch/cpp/core/utils.cpp
@@ -20,7 +20,7 @@ void install_getExecuTorchRegisteredBackends(jsi::Runtime &rt, jsi::Object &modu
         for (size_t i = 0; i < registeredCount; ++i) {
             auto backendName = executorch::runtime::get_backend_name(i);
             if (!backendName.ok()) {
-                std::string errorMsg = executorch::runtime::to_string(backendName.error());
+                const std::string errorMsg = executorch::runtime::to_string(backendName.error());
                 throw jsi::JSError(rt, "Failed to get backend name: " + errorMsg);
             }
             jsArray.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, backendName.get()));

--- a/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
@@ -99,11 +99,11 @@ void install_nms(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "nms: options must specify iouThreshold, boxFormat, confidenceThreshold, and nmsType");
         }
 
-        float iouThreshold = static_cast<float>(opts.getProperty(rt, "iouThreshold").asNumber());
-        float confidenceThreshold = static_cast<float>(opts.getProperty(rt, "confidenceThreshold").asNumber());
+        const float iouThreshold = static_cast<float>(opts.getProperty(rt, "iouThreshold").asNumber());
+        const float confidenceThreshold = static_cast<float>(opts.getProperty(rt, "confidenceThreshold").asNumber());
 
-        std::string nmsTypeStr = opts.getProperty(rt, "nmsType").asString(rt).utf8(rt);
-        std::string boxFormatStr = opts.getProperty(rt, "boxFormat").asString(rt).utf8(rt);
+        const std::string nmsTypeStr = opts.getProperty(rt, "nmsType").asString(rt).utf8(rt);
+        const std::string boxFormatStr = opts.getProperty(rt, "boxFormat").asString(rt).utf8(rt);
 
         NmsType nmsType{};
         BoxFormat boxFormat{};
@@ -179,7 +179,7 @@ void install_nms(jsi::Runtime &rt, jsi::Object &module) {
                 boxesPtr[idxI * 4 + 3],
                 boxFormat);
 
-            float areaA = (xmaxA - xminA) * (ymaxA - yminA);
+            const float areaA = (xmaxA - xminA) * (ymaxA - yminA);
 
             std::vector<std::int32_t> overlapping = {idxI};
 
@@ -197,19 +197,19 @@ void install_nms(jsi::Runtime &rt, jsi::Object &module) {
                     boxesPtr[idxJ * 4 + 3],
                     boxFormat);
 
-                float areaB = (xmaxB - xminB) * (ymaxB - yminB);
+                const float areaB = (xmaxB - xminB) * (ymaxB - yminB);
 
-                float interYMin = std::max(yminA, yminB);
-                float interXMin = std::max(xminA, xminB);
-                float interYMax = std::min(ymaxA, ymaxB);
-                float interXMax = std::min(xmaxA, xmaxB);
+                const float interYMin = std::max(yminA, yminB);
+                const float interXMin = std::max(xminA, xminB);
+                const float interYMax = std::min(ymaxA, ymaxB);
+                const float interXMax = std::min(xmaxA, xmaxB);
 
-                float interH = std::max(0.0f, interYMax - interYMin);
-                float interW = std::max(0.0f, interXMax - interXMin);
-                float intersection = interH * interW;
+                const float interH = std::max(0.0f, interYMax - interYMin);
+                const float interW = std::max(0.0f, interXMax - interXMin);
+                const float intersection = interH * interW;
 
-                float unionArea = areaA + areaB - intersection;
-                float iou = (unionArea > 0.0f) ? (intersection / unionArea) : 0.0f;
+                const float unionArea = areaA + areaB - intersection;
+                const float iou = (unionArea > 0.0f) ? (intersection / unionArea) : 0.0f;
 
                 if (iou > iouThreshold) {
                     if (nmsType == NmsType::Weighted) {
@@ -233,7 +233,7 @@ void install_nms(jsi::Runtime &rt, jsi::Object &module) {
         case NmsType::Weighted: {
             jsi::Array resultGroups = jsi::Array(rt, groups.size());
             for (size_t i = 0; i < groups.size(); ++i) {
-                jsi::Array singleGroup = jsi::Array(rt, groups[i].size());
+                const jsi::Array singleGroup = jsi::Array(rt, groups[i].size());
                 for (size_t j = 0; j < groups[i].size(); ++j) {
                     singleGroup.setValueAtIndex(rt, j, jsi::Value(static_cast<double>(groups[i][j])));
                 }

--- a/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
@@ -69,7 +69,7 @@ std::array<float, 4> decodeToXyxy(
 } // namespace
 
 void install_nms(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "nms";
+    const auto *name = "nms";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count < 3) {
             throw jsi::JSError(rt, "Usage: nms(boxes, scores, options)");

--- a/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
@@ -142,8 +142,8 @@ void install_nms(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "nms: boxes and scores must have dtype float32");
         }
 
-        const float *boxesPtr = reinterpret_cast<const float *>(boxes->data_.get());
-        const float *scoresPtr = reinterpret_cast<const float *>(scores->data_.get());
+        const auto *boxesPtr = reinterpret_cast<const float *>(boxes->data_.get());
+        const auto *scoresPtr = reinterpret_cast<const float *>(scores->data_.get());
 
         std::vector<std::pair<std::int32_t, float>> candidates;
         candidates.reserve(static_cast<size_t>(numAnchors));

--- a/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
@@ -248,7 +248,7 @@ void install_nms(jsi::Runtime &rt, jsi::Object &module) {
 }
 
 void install_restrictToBox(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "restrictToBox";
+    const auto *name = "restrictToBox";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 4) {
             throw jsi::JSError(rt, "Usage: restrictToBox(src, dst, boxTuple, format)");
@@ -279,7 +279,7 @@ void install_restrictToBox(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "restrictToBox: boxTuple must contain exactly 4 coordinates");
         }
 
-        BoxFormat boxFormat;
+        BoxFormat boxFormat{};
         try {
             boxFormat = parseBoxFormat(boxFormatStr);
         } catch (const std::invalid_argument &e) {
@@ -309,10 +309,10 @@ void install_restrictToBox(jsi::Runtime &rt, jsi::Object &module) {
         int32_t W = src->shape_[1];
         int32_t C = src->shape_[2];
 
-        int32_t x1 = static_cast<int32_t>(std::ceil(xmin));
-        int32_t y1 = static_cast<int32_t>(std::ceil(ymin));
-        int32_t x2 = static_cast<int32_t>(std::floor(xmax));
-        int32_t y2 = static_cast<int32_t>(std::floor(ymax));
+        auto x1 = static_cast<int32_t>(std::ceil(xmin));
+        auto y1 = static_cast<int32_t>(std::ceil(ymin));
+        auto x2 = static_cast<int32_t>(std::floor(xmax));
+        auto y2 = static_cast<int32_t>(std::floor(ymax));
 
         x1 = std::max(0, x1);
         y1 = std::max(0, y1);
@@ -335,7 +335,7 @@ void install_restrictToBox(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "restrictToBox: tensors must not be disposed");
         }
 
-        int32_t cvType;
+        int32_t cvType{};
         try {
             cvType = CV_MAKETYPE(dtypeToCvDepth(src->dtype_), C);
         } catch (const std::invalid_argument &e) {

--- a/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
@@ -105,8 +105,8 @@ void install_nms(jsi::Runtime &rt, jsi::Object &module) {
         std::string nmsTypeStr = opts.getProperty(rt, "nmsType").asString(rt).utf8(rt);
         std::string boxFormatStr = opts.getProperty(rt, "boxFormat").asString(rt).utf8(rt);
 
-        NmsType nmsType;
-        BoxFormat boxFormat;
+        NmsType nmsType{};
+        BoxFormat boxFormat{};
         try {
             nmsType = parseNmsType(nmsTypeStr);
             boxFormat = parseBoxFormat(boxFormatStr);

--- a/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
@@ -45,10 +45,10 @@ FitBox computeFit(int32_t srcW, int32_t srcH, int32_t dstW, int32_t dstH, bool i
     const double scaleH = static_cast<double>(dstH) / srcH;
     const double scale = inner ? std::min(scaleW, scaleH) : std::max(scaleW, scaleH);
 
-    const int32_t w = static_cast<int32_t>(std::round(srcW * scale));
-    const int32_t h = static_cast<int32_t>(std::round(srcH * scale));
+    const auto w = static_cast<int32_t>(std::round(srcW * scale));
+    const auto h = static_cast<int32_t>(std::round(srcH * scale));
     const int32_t sign = inner ? 1 : -1; // letterbox centers padding, crop centers the crop
-    return {w, h, sign * (dstW - w) / 2, sign * (dstH - h) / 2};
+    return {.w = w, .h = h, .offX = sign * (dstW - w) / 2, .offY = sign * (dstH - h) / 2};
 }
 } // namespace
 
@@ -488,7 +488,7 @@ void install_toChannelsLast(jsi::Runtime &rt, jsi::Object &module) {
 
         std::vector<::cv::Mat> channels;
         for (size_t i = 0; std::cmp_less(i, srcC); ++i) {
-            channels.push_back(::cv::Mat(srcH, srcW, cvDepth, srcPtr + i * hw * elemSize));
+            channels.emplace_back(srcH, srcW, cvDepth, srcPtr + i * hw * elemSize);
         }
 
         ::cv::Mat dstMat(dstH, dstW, CV_MAKETYPE(cvDepth, dstC), dst->data_.get());
@@ -692,12 +692,12 @@ void install_applyColormap(jsi::Runtime &rt, jsi::Object &module) {
 
         const size_t pixels = src->numel_;
 
-        const int32_t *srcData = reinterpret_cast<const int32_t *>(src->data_.get());
+        const auto *srcData = reinterpret_cast<const int32_t *>(src->data_.get());
         uint8_t *dstData = dst->data_.get();
 
         for (size_t i = 0; i < pixels; ++i) {
             const int32_t idx = srcData[i];
-            if (idx < 0 || static_cast<size_t>(idx) >= numColors) {
+            if (idx < 0 || std::cmp_greater_equal(idx, numColors)) {
                 throw jsi::JSError(rt, "applyColormap: tensor contains class index (" +
                                            std::to_string(idx) + ") that exceeds provided colormap size (" +
                                            std::to_string(numColors) + ")");

--- a/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
@@ -137,7 +137,7 @@ void install_resize(jsi::Runtime &rt, jsi::Object &module) {
         int32_t dstH = dst->shape_[0];
         int32_t dstW = dst->shape_[1];
 
-        int cvType, interpFlag;
+        int cvType{}, interpFlag{};
         try {
             cvType = CV_MAKETYPE(dtypeToCvDepth(src->dtype_), channels);
             interpFlag = interpToFlag(interp);
@@ -304,7 +304,7 @@ void install_cvtColor(jsi::Runtime &rt, jsi::Object &module) {
         int32_t srcC = src->shape_[2];
         int32_t dstC = dst->shape_[2];
 
-        int cvSrcType, cvDstType, flag;
+        int cvSrcType{}, cvDstType{}, flag{};
         try {
             cvSrcType = CV_MAKETYPE(dtypeToCvDepth(src->dtype_), srcC);
             cvDstType = CV_MAKETYPE(dtypeToCvDepth(dst->dtype_), dstC);
@@ -387,7 +387,7 @@ void install_toChannelsFirst(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "toChannelsFirst: dst tensor has been disposed");
         }
 
-        int cvType;
+        int cvType{};
         try {
             cvType = CV_MAKETYPE(dtypeToCvDepth(src->dtype_), srcC);
         } catch (const std::invalid_argument &e) {
@@ -475,7 +475,7 @@ void install_toChannelsLast(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "toChannelsLast: dst tensor has been disposed");
         }
 
-        int cvDepth;
+        int cvDepth{};
         try {
             cvDepth = dtypeToCvDepth(src->dtype_);
         } catch (const std::invalid_argument &e) {
@@ -595,8 +595,8 @@ void install_normalize(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "normalize: dst tensor has been disposed");
         }
 
-        int srcDepthType;
-        int dstDepthType;
+        int srcDepthType{};
+        int dstDepthType{};
         try {
             srcDepthType = dtypeToCvDepth(src->dtype_);
             dstDepthType = dtypeToCvDepth(dst->dtype_);

--- a/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
@@ -137,7 +137,8 @@ void install_resize(jsi::Runtime &rt, jsi::Object &module) {
         const int32_t dstH = dst->shape_[0];
         const int32_t dstW = dst->shape_[1];
 
-        int cvType{}, interpFlag{};
+        int cvType{};
+        int interpFlag{};
         try {
             cvType = CV_MAKETYPE(dtypeToCvDepth(src->dtype_), channels);
             interpFlag = interpToFlag(interp);
@@ -304,7 +305,9 @@ void install_cvtColor(jsi::Runtime &rt, jsi::Object &module) {
         const int32_t srcC = src->shape_[2];
         const int32_t dstC = dst->shape_[2];
 
-        int cvSrcType{}, cvDstType{}, flag{};
+        int cvSrcType{};
+        int cvDstType{};
+        int flag{};
         try {
             cvSrcType = CV_MAKETYPE(dtypeToCvDepth(src->dtype_), srcC);
             cvDstType = CV_MAKETYPE(dtypeToCvDepth(dst->dtype_), dstC);

--- a/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
@@ -53,7 +53,7 @@ FitBox computeFit(int32_t srcW, int32_t srcH, int32_t dstW, int32_t dstH, bool i
 } // namespace
 
 void install_resize(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "resize";
+    const auto *name = "resize";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 3) {
             throw jsi::JSError(rt, "Usage: resize(src, dst, options)");
@@ -239,7 +239,7 @@ int codeToColorConversionFlag(const std::string &code) {
 } // namespace
 
 void install_cvtColor(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "cvtColor";
+    const auto *name = "cvtColor";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 3) {
             throw jsi::JSError(rt, "Usage: cvtColor(src, dst, code)");
@@ -325,7 +325,7 @@ void install_cvtColor(jsi::Runtime &rt, jsi::Object &module) {
 }
 
 void install_toChannelsFirst(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "toChannelsFirst";
+    const auto *name = "toChannelsFirst";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 2) {
             throw jsi::JSError(rt, "Usage: toChannelsFirst(src, dst)");
@@ -413,7 +413,7 @@ void install_toChannelsFirst(jsi::Runtime &rt, jsi::Object &module) {
 }
 
 void install_toChannelsLast(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "toChannelsLast";
+    const auto *name = "toChannelsLast";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 2) {
             throw jsi::JSError(rt, "Usage: toChannelsLast(src, dst)");
@@ -501,7 +501,7 @@ void install_toChannelsLast(jsi::Runtime &rt, jsi::Object &module) {
 }
 
 void install_normalize(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "normalize";
+    const auto *name = "normalize";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 3) {
             throw jsi::JSError(rt, "Usage: normalize(src, dst, options)");
@@ -624,7 +624,7 @@ void install_normalize(jsi::Runtime &rt, jsi::Object &module) {
 }
 
 void install_applyColormap(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "applyColormap";
+    const auto *name = "applyColormap";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 3) {
             throw jsi::JSError(rt, "Usage: applyColormap(src, dst, colormap)");

--- a/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
@@ -41,13 +41,13 @@ struct FitBox {
 };
 
 FitBox computeFit(int32_t srcW, int32_t srcH, int32_t dstW, int32_t dstH, bool inner) {
-    double scaleW = static_cast<double>(dstW) / srcW;
-    double scaleH = static_cast<double>(dstH) / srcH;
-    double scale = inner ? std::min(scaleW, scaleH) : std::max(scaleW, scaleH);
+    const double scaleW = static_cast<double>(dstW) / srcW;
+    const double scaleH = static_cast<double>(dstH) / srcH;
+    const double scale = inner ? std::min(scaleW, scaleH) : std::max(scaleW, scaleH);
 
-    int32_t w = static_cast<int32_t>(std::round(srcW * scale));
-    int32_t h = static_cast<int32_t>(std::round(srcH * scale));
-    int32_t sign = inner ? 1 : -1; // letterbox centers padding, crop centers the crop
+    const int32_t w = static_cast<int32_t>(std::round(srcW * scale));
+    const int32_t h = static_cast<int32_t>(std::round(srcH * scale));
+    const int32_t sign = inner ? 1 : -1; // letterbox centers padding, crop centers the crop
     return {w, h, sign * (dstW - w) / 2, sign * (dstH - h) / 2};
 }
 } // namespace
@@ -93,7 +93,7 @@ void install_resize(jsi::Runtime &rt, jsi::Object &module) {
 
         auto mode = opts.getProperty(rt, "mode").asString(rt).utf8(rt);
         auto interp = opts.getProperty(rt, "interpolation").asString(rt).utf8(rt);
-        double padValue = opts.getProperty(rt, "padValue").asNumber();
+        const double padValue = opts.getProperty(rt, "padValue").asNumber();
 
         if (src->shape_.size() != 3) {
             throw jsi::JSError(rt, "resize: src must be [H, W, C]");
@@ -131,11 +131,11 @@ void install_resize(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "resize: dst tensor has been disposed");
         }
 
-        int32_t srcH = src->shape_[0];
-        int32_t srcW = src->shape_[1];
-        int32_t channels = src->shape_[2];
-        int32_t dstH = dst->shape_[0];
-        int32_t dstW = dst->shape_[1];
+        const int32_t srcH = src->shape_[0];
+        const int32_t srcW = src->shape_[1];
+        const int32_t channels = src->shape_[2];
+        const int32_t dstH = dst->shape_[0];
+        const int32_t dstW = dst->shape_[1];
 
         int cvType{}, interpFlag{};
         try {
@@ -145,19 +145,19 @@ void install_resize(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "resize: " + std::string(e.what()));
         }
 
-        ::cv::Mat srcMat(srcH, srcW, cvType, src->data_.get());
+        const ::cv::Mat srcMat(srcH, srcW, cvType, src->data_.get());
         ::cv::Mat dstMat(dstH, dstW, cvType, dst->data_.get());
 
         if (mode == "stretch") {
             ::cv::resize(srcMat, dstMat, dstMat.size(), 0, 0, interpFlag);
         } else if (mode == "letterbox") {
-            FitBox fit = computeFit(srcW, srcH, dstW, dstH, /*inner=*/true);
+            const FitBox fit = computeFit(srcW, srcH, dstW, dstH, /*inner=*/true);
 
             dstMat.setTo(::cv::Scalar::all(padValue));
             ::cv::Mat roi = dstMat(::cv::Rect(fit.offX, fit.offY, fit.w, fit.h));
             ::cv::resize(srcMat, roi, roi.size(), 0, 0, interpFlag);
         } else if (mode == "crop") {
-            FitBox fit = computeFit(srcW, srcH, dstW, dstH, /*inner=*/false);
+            const FitBox fit = computeFit(srcW, srcH, dstW, dstH, /*inner=*/false);
 
             ::cv::Mat scaled;
             ::cv::resize(srcMat, scaled, ::cv::Size(fit.w, fit.h), 0, 0, interpFlag);
@@ -299,10 +299,10 @@ void install_cvtColor(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "cvtColor: dst tensor has been disposed");
         }
 
-        int32_t srcH = src->shape_[0];
-        int32_t srcW = src->shape_[1];
-        int32_t srcC = src->shape_[2];
-        int32_t dstC = dst->shape_[2];
+        const int32_t srcH = src->shape_[0];
+        const int32_t srcW = src->shape_[1];
+        const int32_t srcC = src->shape_[2];
+        const int32_t dstC = dst->shape_[2];
 
         int cvSrcType{}, cvDstType{}, flag{};
         try {
@@ -310,7 +310,7 @@ void install_cvtColor(jsi::Runtime &rt, jsi::Object &module) {
             cvDstType = CV_MAKETYPE(dtypeToCvDepth(dst->dtype_), dstC);
             flag = codeToColorConversionFlag(code);
 
-            ::cv::Mat srcMat(srcH, srcW, cvSrcType, src->data_.get());
+            const ::cv::Mat srcMat(srcH, srcW, cvSrcType, src->data_.get());
             ::cv::Mat dstMat(srcH, srcW, cvDstType, dst->data_.get());
 
             ::cv::cvtColor(srcMat, dstMat, flag);
@@ -354,16 +354,16 @@ void install_toChannelsFirst(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "toChannelsFirst: src and dst must have the same dtype");
         }
 
-        int32_t srcH = src->shape_[0];
-        int32_t srcW = src->shape_[1];
-        int32_t srcC = src->shape_[2];
+        const int32_t srcH = src->shape_[0];
+        const int32_t srcW = src->shape_[1];
+        const int32_t srcC = src->shape_[2];
 
         if (dst->shape_.size() != 3) {
             throw jsi::JSError(rt, "toChannelsFirst: dst must be a 3D tensor [C, H, W]");
         }
-        int32_t dstC = dst->shape_[0];
-        int32_t dstH = dst->shape_[1];
-        int32_t dstW = dst->shape_[2];
+        const int32_t dstC = dst->shape_[0];
+        const int32_t dstH = dst->shape_[1];
+        const int32_t dstW = dst->shape_[2];
 
         if (srcH != dstH || srcW != dstW || srcC != dstC) {
             throw jsi::JSError(rt, "toChannelsFirst: src and dst spatial dimensions and channel counts must match");
@@ -394,12 +394,12 @@ void install_toChannelsFirst(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "toChannelsFirst: " + std::string(e.what()));
         }
 
-        ::cv::Mat srcMat(srcH, srcW, cvType, src->data_.get());
+        const ::cv::Mat srcMat(srcH, srcW, cvType, src->data_.get());
         std::vector<::cv::Mat> channels;
         ::cv::split(srcMat, channels);
 
-        size_t hw = static_cast<size_t>(srcH) * static_cast<size_t>(srcW);
-        size_t elemSize = rnexecutorch::core::types::elementSize(src->dtype_);
+        const size_t hw = static_cast<size_t>(srcH) * static_cast<size_t>(srcW);
+        const size_t elemSize = rnexecutorch::core::types::elementSize(src->dtype_);
         uint8_t *dstPtr = dst->data_.get();
 
         for (size_t i = 0; std::cmp_less(i, srcC); ++i) {
@@ -442,16 +442,16 @@ void install_toChannelsLast(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "toChannelsLast: src and dst must have the same dtype");
         }
 
-        int32_t srcC = src->shape_[0];
-        int32_t srcH = src->shape_[1];
-        int32_t srcW = src->shape_[2];
+        const int32_t srcC = src->shape_[0];
+        const int32_t srcH = src->shape_[1];
+        const int32_t srcW = src->shape_[2];
 
         if (dst->shape_.size() != 3) {
             throw jsi::JSError(rt, "toChannelsLast: dst must be a 3D tensor [H, W, C]");
         }
-        int32_t dstH = dst->shape_[0];
-        int32_t dstW = dst->shape_[1];
-        int32_t dstC = dst->shape_[2];
+        const int32_t dstH = dst->shape_[0];
+        const int32_t dstW = dst->shape_[1];
+        const int32_t dstC = dst->shape_[2];
 
         if (srcH != dstH || srcW != dstW || srcC != dstC) {
             throw jsi::JSError(rt, "toChannelsLast: src and dst spatial dimensions and channel counts must match");
@@ -482,8 +482,8 @@ void install_toChannelsLast(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "toChannelsLast: " + std::string(e.what()));
         }
 
-        size_t hw = static_cast<size_t>(srcH) * static_cast<size_t>(srcW);
-        size_t elemSize = rnexecutorch::core::types::elementSize(src->dtype_);
+        const size_t hw = static_cast<size_t>(srcH) * static_cast<size_t>(srcW);
+        const size_t elemSize = rnexecutorch::core::types::elementSize(src->dtype_);
         uint8_t *srcPtr = src->data_.get();
 
         std::vector<::cv::Mat> channels;
@@ -532,8 +532,8 @@ void install_normalize(jsi::Runtime &rt, jsi::Object &module) {
         }
 
         int32_t c = src->shape_[0];
-        int32_t h = src->shape_[1];
-        int32_t w = src->shape_[2];
+        const int32_t h = src->shape_[1];
+        const int32_t w = src->shape_[2];
 
         if (dst->shape_.size() != 3 ||
             dst->shape_[0] != c ||
@@ -604,14 +604,14 @@ void install_normalize(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "normalize: " + std::string(e.what()));
         }
 
-        size_t srcElemSize = rnexecutorch::core::types::elementSize(src->dtype_);
-        size_t dstElemSize = rnexecutorch::core::types::elementSize(dst->dtype_);
+        const size_t srcElemSize = rnexecutorch::core::types::elementSize(src->dtype_);
+        const size_t dstElemSize = rnexecutorch::core::types::elementSize(dst->dtype_);
         uint8_t *srcPtr = src->data_.get();
         uint8_t *dstPtr = dst->data_.get();
 
         const size_t plane = static_cast<size_t>(h) * static_cast<size_t>(w);
         for (size_t ch = 0; std::cmp_less(ch, c); ++ch) {
-            ::cv::Mat srcChannel(h, w, srcDepthType, srcPtr + ch * plane * srcElemSize);
+            const ::cv::Mat srcChannel(h, w, srcDepthType, srcPtr + ch * plane * srcElemSize);
             ::cv::Mat dstChannel(h, w, dstDepthType, dstPtr + ch * plane * dstElemSize);
 
             srcChannel.convertTo(dstChannel, dstDepthType, alpha[ch], beta[ch]);
@@ -656,7 +656,7 @@ void install_applyColormap(jsi::Runtime &rt, jsi::Object &module) {
         }
 
         auto colormapArray = args[2].asObject(rt).asArray(rt);
-        size_t numColors = colormapArray.size(rt);
+        const size_t numColors = colormapArray.size(rt);
         std::vector<std::array<uint8_t, numRgbaChannels>> lut(numColors);
         for (size_t i = 0; i < numColors; ++i) {
             auto colorVal = colormapArray.getValueAtIndex(rt, i);
@@ -672,7 +672,7 @@ void install_applyColormap(jsi::Runtime &rt, jsi::Object &module) {
                 if (!channelVal.isNumber()) {
                     throw jsi::JSError(rt, "applyColormap: colormap channel value must be a number");
                 }
-                double val = channelVal.asNumber();
+                const double val = channelVal.asNumber();
                 if (std::isnan(val) || val < 0.0 || val > 255.0) {
                     throw jsi::JSError(rt, "applyColormap: colormap channel value must be between 0 and 255");
                 }
@@ -690,13 +690,13 @@ void install_applyColormap(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "applyColormap: tensor has been disposed");
         }
 
-        size_t pixels = src->numel_;
+        const size_t pixels = src->numel_;
 
         const int32_t *srcData = reinterpret_cast<const int32_t *>(src->data_.get());
         uint8_t *dstData = dst->data_.get();
 
         for (size_t i = 0; i < pixels; ++i) {
-            int32_t idx = srcData[i];
+            const int32_t idx = srcData[i];
             if (idx < 0 || static_cast<size_t>(idx) >= numColors) {
                 throw jsi::JSError(rt, "applyColormap: tensor contains class index (" +
                                            std::to_string(idx) + ") that exceeds provided colormap size (" +

--- a/packages/react-native-executorch/cpp/extensions/math/operations.cpp
+++ b/packages/react-native-executorch/cpp/extensions/math/operations.cpp
@@ -304,7 +304,7 @@ void install_argmax(jsi::Runtime &rt, jsi::Object &module) {
 }
 
 void install_threshold(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "threshold";
+    const auto *name = "threshold";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 3) {
             throw jsi::JSError(rt, "Usage: threshold(src, dst, threshold)");
@@ -324,7 +324,7 @@ void install_threshold(jsi::Runtime &rt, jsi::Object &module) {
 
         auto src = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
         auto dst = args[1].asObject(rt).getHostObject<TensorHostObject>(rt);
-        float thresholdVal = static_cast<float>(args[2].asNumber());
+        auto thresholdVal = static_cast<float>(args[2].asNumber());
 
         if (src.get() == dst.get()) {
             throw jsi::JSError(rt, "threshold: In-place operations (src == dst) are not supported.");

--- a/packages/react-native-executorch/cpp/extensions/math/operations.cpp
+++ b/packages/react-native-executorch/cpp/extensions/math/operations.cpp
@@ -130,7 +130,7 @@ void install_softmax(jsi::Runtime &rt, jsi::Object &module) {
         if (axis < 0 || axis >= rank) {
             throw jsi::JSError(rt, "softmax: axis is out of range");
         }
-        const size_t axisIdx = static_cast<size_t>(axis);
+        const auto axisIdx = static_cast<size_t>(axis);
 
         std::shared_lock<std::shared_mutex> srcLock(src->mutex_, std::try_to_lock);
         if (!srcLock.owns_lock()) {
@@ -153,7 +153,7 @@ void install_softmax(jsi::Runtime &rt, jsi::Object &module) {
         const auto *srcData = reinterpret_cast<const float *>(src->data_.get());
         auto *dstData = reinterpret_cast<float *>(dst->data_.get());
 
-        const size_t axisDim = static_cast<size_t>(src->shape_[axisIdx]);
+        const auto axisDim = static_cast<size_t>(src->shape_[axisIdx]);
         if (axisDim == 0) {
             throw jsi::JSError(rt, "softmax: axis dimension must be greater than zero");
         }
@@ -241,7 +241,7 @@ void install_argmax(jsi::Runtime &rt, jsi::Object &module) {
         if (axis < 0 || axis >= rank) {
             throw jsi::JSError(rt, "argmax: axis is out of range");
         }
-        const size_t axisIdx = static_cast<size_t>(axis);
+        const auto axisIdx = static_cast<size_t>(axis);
 
         auto dstExpectedShape = src->shape_;
         dstExpectedShape[axisIdx] = 1;
@@ -263,9 +263,9 @@ void install_argmax(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "argmax: dst tensor has been disposed");
         }
 
-        const float *srcData = reinterpret_cast<const float *>(src->data_.get());
+        const auto *srcData = reinterpret_cast<const float *>(src->data_.get());
 
-        const size_t axisDim = static_cast<size_t>(src->shape_[axisIdx]);
+        const auto axisDim = static_cast<size_t>(src->shape_[axisIdx]);
         if (axisDim == 0) {
             throw jsi::JSError(rt, "argmax: axis dimension must be greater than zero");
         }
@@ -278,7 +278,7 @@ void install_argmax(jsi::Runtime &rt, jsi::Object &module) {
             inner *= static_cast<size_t>(src->shape_[i]);
         }
 
-        int32_t *dstData = reinterpret_cast<int32_t *>(dst->data_.get());
+        auto *dstData = reinterpret_cast<int32_t *>(dst->data_.get());
 
         // DO NOT swap loop order. This structure intentionally prioritizes the
         // most common case (axis = -1, inner = 1) for sequential access.

--- a/packages/react-native-executorch/cpp/extensions/math/operations.cpp
+++ b/packages/react-native-executorch/cpp/extensions/math/operations.cpp
@@ -270,7 +270,8 @@ void install_argmax(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "argmax: axis dimension must be greater than zero");
         }
 
-        size_t outer = 1, inner = 1;
+        size_t outer = 1;
+        size_t inner = 1;
         for (size_t i = 0; std::cmp_less(i, axis); ++i) {
             outer *= static_cast<size_t>(src->shape_[i]);
         }

--- a/packages/react-native-executorch/cpp/extensions/math/operations.cpp
+++ b/packages/react-native-executorch/cpp/extensions/math/operations.cpp
@@ -12,7 +12,7 @@ namespace jsi = facebook::jsi;
 using TensorHostObject = rnexecutorch::core::tensor::TensorHostObject;
 
 void install_sigmoid(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "sigmoid";
+    const auto *name = "sigmoid";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 2) {
             throw jsi::JSError(rt, "Usage: sigmoid(src, dst)");
@@ -78,7 +78,7 @@ void install_sigmoid(jsi::Runtime &rt, jsi::Object &module) {
 }
 
 void install_softmax(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "softmax";
+    const auto *name = "softmax";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 3) {
             throw jsi::JSError(rt, "Usage: softmax(src, dst, axis)");
@@ -197,7 +197,7 @@ void install_softmax(jsi::Runtime &rt, jsi::Object &module) {
 }
 
 void install_argmax(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "argmax";
+    const auto *name = "argmax";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 3) {
             throw jsi::JSError(rt, "Usage: argmax(src, dst, axis)");

--- a/packages/react-native-executorch/cpp/extensions/math/operations.cpp
+++ b/packages/react-native-executorch/cpp/extensions/math/operations.cpp
@@ -120,7 +120,7 @@ void install_softmax(jsi::Runtime &rt, jsi::Object &module) {
         }
 
         int axis = static_cast<int>(args[2].asNumber());
-        int rank = static_cast<int>(src->shape_.size());
+        const int rank = static_cast<int>(src->shape_.size());
 
         // Support negative axis indices like numpy (e.g., axis=-1 means last
         // axis, -2 means second to last, etc.)
@@ -231,7 +231,7 @@ void install_argmax(jsi::Runtime &rt, jsi::Object &module) {
         }
 
         int axis = static_cast<int>(args[2].asNumber());
-        int rank = static_cast<int>(src->shape_.size());
+        const int rank = static_cast<int>(src->shape_.size());
 
         // Support negative axis indices like numpy (e.g., axis=-1 means last
         // axis, -2 means second to last, etc.)

--- a/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
+++ b/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
@@ -276,7 +276,7 @@ std::vector<facebook::jsi::PropNameID> TokenizerHostObject::getPropertyNames(jsi
 }
 
 void install_loadTokenizer(jsi::Runtime &rt, jsi::Object &module) {
-    auto name = "loadTokenizer";
+    const auto *name = "loadTokenizer";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 1) {
             throw jsi::JSError(rt, "loadTokenizer: Usage: loadTokenizer(arg0)");

--- a/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
+++ b/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <stdexcept>
+#include <utility>
 
 #include <pytorch/tokenizers/error.h>
 
@@ -44,8 +45,8 @@ std::string toString(tokenizers::Error error) {
 }
 } // namespace
 
-TokenizerHostObject::TokenizerHostObject(const std::string &tokenizerPath)
-    : tokenizerPath_(tokenizerPath),
+TokenizerHostObject::TokenizerHostObject(std::string tokenizerPath)
+    : tokenizerPath_(std::move(tokenizerPath)),
       tokenizer_(std::make_unique<tokenizers::HFTokenizer>()) {
     auto error = tokenizer_->load(tokenizerPath_);
     if (error != tokenizers::Error::Ok) {

--- a/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.h
+++ b/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.h
@@ -14,7 +14,7 @@ class TokenizerHostObject : public facebook::jsi::HostObject,
                             public std::enable_shared_from_this<TokenizerHostObject> {
 public:
     // Loads the tokenizer from `tokenizerPath`; throws std::runtime_error on failure.
-    explicit TokenizerHostObject(const std::string &tokenizerPath);
+    explicit TokenizerHostObject(std::string tokenizerPath);
 
     facebook::jsi::Value get(facebook::jsi::Runtime &rt, const facebook::jsi::PropNameID &name) override;
     std::vector<facebook::jsi::PropNameID> getPropertyNames(facebook::jsi::Runtime &rt) override;

--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -45,6 +45,7 @@
     "prepare": "bob build",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
+    "lint:cpp": "./scripts/clang-tidy.sh",
     "prepack": "cp ../../README.md ./README.md",
     "postpack": "rm ./README.md",
     "postinstall": "node scripts/download-libs.js && yarn run -T patch-package --patch-dir ../../patches"

--- a/packages/react-native-executorch/scripts/clang-tidy.sh
+++ b/packages/react-native-executorch/scripts/clang-tidy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Runs clang-tidy over the package's own C/C++ sources, using the checks in
+# .clang-tidy and the include flags from compile_flags.txt (the same database
+# clangd uses). Any finding fails the run (--warnings-as-errors).
+#
+# Usage:
+#   scripts/clang-tidy.sh [file ...]   # defaults to every *.cpp under cpp/
+#
+# Prerequisites (same as a native build): a provisioned third-party/include and
+# `yarn install` at the repo root, so the third-party / JSI includes resolve.
+# Override the binary with CLANG_TIDY=/path/to/clang-tidy (e.g. Homebrew LLVM).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+CLANG_TIDY="${CLANG_TIDY:-clang-tidy}"
+
+if ! command -v "$CLANG_TIDY" >/dev/null 2>&1; then
+  echo "error: '$CLANG_TIDY' not found. Install LLVM (e.g. 'brew install llvm' or" \
+       "'apt-get install clang-tidy') or set CLANG_TIDY to its path." >&2
+  exit 127
+fi
+
+if [ "$#" -gt 0 ]; then
+  files=("$@")
+else
+  files=()
+  while IFS= read -r f; do files+=("$f"); done < <(find cpp -name '*.cpp' | sort)
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "No C++ sources to check."
+  exit 0
+fi
+
+echo "Running clang-tidy on ${#files[@]} file(s)…"
+exec "$CLANG_TIDY" --warnings-as-errors='*' "${files[@]}"


### PR DESCRIPTION
## Description

Adds clang-tidy static analysis for the core package's C/C++ sources. Second step of #1271 (clangd setup landed in #1285). Rebased onto `rne-rewrite`, so this is clang-tidy-only.

- `.clang-tidy` — a high-signal check set enabled group by group (one commit each): `bugprone-*`, `performance-*`, `clang-analyzer-*`, `cppcoreguidelines-*`, `google-*`, `llvm-*`, `misc-*`, `modernize-*`, `readability-*`. Each group's narrow exclusion list (raw-buffer pointer math, `reinterpret_cast`, `#pragma once`, JSI multiple-inheritance, opinionated/noisy checks) is documented inline with rationale. Analyzes only this package's own `cpp/` headers; third-party is `-isystem`.
- `scripts/clang-tidy.sh` + the `lint:cpp` package script — run clang-tidy over `cpp/` using `compile_flags.txt` (the same database clangd uses), failing on any finding.
- `.github/workflows/clang-tidy.yml` — CI gate, **dormant** behind the `ENABLE_CLANG_TIDY` repo variable. It provisions headers through the on-demand download flow (`download-libs.js`, #1283) rather than a stub, since clang-tidy needs the ExecuTorch headers to parse the sources.

The fixes each group surfaced are split across the per-group commits (scoped `DType` enum, member-init lists, `explicit` ctor, `const`-correctness cleanup, `use-auto`/`emplace`/`cmp_*` modernizations, `NOLINT`s for the intentional cases).

Depends on #1283 for `download-libs.js`; enable the workflow once that has merged and a release carrying `headers.tar.gz` exists. The provisioning step sets `RNET_HEADERS_ONLY=1` (clang-tidy needs only headers) — see PR thread re: honoring that flag in `download-libs.js`.

Verified locally (Homebrew LLVM clang-tidy): `lint:cpp` is green on all sources and exits non-zero on an injected finding.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

1. Provision `packages/react-native-executorch/third-party/include` and run `yarn install`.
2. From the repo root: `CLANG_TIDY=$(brew --prefix llvm)/bin/clang-tidy yarn workspace react-native-executorch lint:cpp` — expect 0 findings.
3. Confirm the gate has teeth: introduce a bug in a `cpp/` file, e.g. `double r = a / b;` (ints) for `bugprone-integer-division`, and re-run — expect a non-zero exit. Revert afterwards.

### Related issues

#1271

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
