### PR TITLE
[RNE Rewrite] feat: add instance segmentation pipeline

### DIFF
--- a/.cspell-wordlist.txt
+++ b/.cspell-wordlist.txt
@@ -245,3 +245,5 @@ popd
 yolov
 YOLOV
 XLARGE
+thresholding
+binarization

--- a/apps/computer-vision/app/_layout.tsx
+++ b/apps/computer-vision/app/_layout.tsx
@@ -56,6 +56,13 @@ export default function Layout() {
         }}
       />
       <Drawer.Screen
+        name="instanceSegmentation/index"
+        options={{
+          drawerLabel: 'Instance Segmentation',
+          title: 'Instance Segmentation',
+        }}
+      />
+      <Drawer.Screen
         name="inspect/index"
         options={{
           drawerLabel: 'Model Inspector',

--- a/apps/computer-vision/app/index.tsx
+++ b/apps/computer-vision/app/index.tsx
@@ -23,6 +23,12 @@ export default function Home() {
         <TouchableOpacity style={styles.button} onPress={() => router.navigate('segmentation/')}>
           <Text style={styles.buttonText}>Semantic Segmentation</Text>
         </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.button}
+          onPress={() => router.navigate('instanceSegmentation/')}
+        >
+          <Text style={styles.buttonText}>Instance Segmentation</Text>
+        </TouchableOpacity>
         <TouchableOpacity style={styles.button} onPress={() => router.navigate('keypoint/')}>
           <Text style={styles.buttonText}>Keypoint Detection</Text>
         </TouchableOpacity>

--- a/apps/computer-vision/app/instanceSegmentation/index.tsx
+++ b/apps/computer-vision/app/instanceSegmentation/index.tsx
@@ -1,0 +1,309 @@
+import React, { useState, useRef } from 'react';
+import { View, Text, StyleSheet, ScrollView, Dimensions, Platform } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { commonStyles, theme } from '../../theme';
+import {
+  Skia,
+  ColorType,
+  AlphaType,
+  useImage,
+  type SkImage as SkiaImageType,
+} from '@shopify/react-native-skia';
+import {
+  useInstanceSegmenter,
+  models,
+  type InstanceSegmentationResult,
+} from 'react-native-executorch';
+import ScreenWrapper from '../../components/ScreenWrapper';
+import { getImage } from '../../utils';
+import { ModelPicker, type ModelOption } from '../../components/ModelPicker';
+import { ImageViewport } from '../../components/ImageViewport';
+import { ModelStatus } from '../../components/ModelStatus';
+import { LatencyIndicator } from '../../components/LatencyIndicator';
+import { Button } from '../../components/Button';
+import { BoundingBox } from '../../components/BoundingBox';
+
+const MODEL_OPTIONS: ModelOption[] = [
+  {
+    label: 'YOLO26 Nano (XNNPACK FP32)',
+    value: models.instanceSegmentation.YOLO26.NANO.SIZE_384.XNNPACK_FP32,
+  },
+  {
+    label: 'RFDETR (XNNPACK FP32)',
+    value: models.instanceSegmentation.RFDETR_NANO.XNNPACK_FP32,
+  },
+  {
+    label: 'RFDETR (CoreML INT8)',
+    value: models.instanceSegmentation.RFDETR_NANO.COREML_INT8,
+    disabled: Platform.OS !== 'ios',
+  },
+  {
+    label: 'FastSAM Small (XNNPACK FP32)',
+    value: models.instanceSegmentation.FASTSAM.S.XNNPACK_FP32,
+  },
+  {
+    label: 'FastSAM X-Large (XNNPACK FP32)',
+    value: models.instanceSegmentation.FASTSAM.X.XNNPACK_FP32,
+  },
+  {
+    label: 'FastSAM Small (CoreML FP16)',
+    value: models.instanceSegmentation.FASTSAM.S.COREML_FP16,
+    disabled: Platform.OS !== 'ios',
+  },
+  {
+    label: 'FastSAM X-Large (CoreML FP16)',
+    value: models.instanceSegmentation.FASTSAM.X.COREML_FP16,
+    disabled: Platform.OS !== 'ios',
+  },
+];
+
+const MASK_COLORS = [
+  { r: 255, g: 99, b: 132, a: 140 }, // Pink/Red
+  { r: 54, g: 162, b: 235, a: 140 }, // Blue
+  { r: 255, g: 206, b: 86, a: 140 }, // Yellow
+  { r: 75, g: 192, b: 192, a: 140 }, // Teal
+  { r: 153, g: 102, b: 255, a: 140 }, // Purple
+  { r: 255, g: 159, b: 64, a: 140 }, // Orange
+  { r: 46, g: 204, b: 113, a: 140 }, // Green
+  { r: 231, g: 76, b: 60, a: 140 }, // Crimson
+];
+
+const MASK_STROKE_COLORS = [
+  '#FF6384',
+  '#36A2EB',
+  '#FFCE56',
+  '#4BC0C0',
+  '#9966FF',
+  '#FF9F64',
+  '#2ECC71',
+  '#E74C3C',
+];
+
+const VIEW_WIDTH = Dimensions.get('window').width - 32;
+const VIEW_HEIGHT = Math.round((VIEW_WIDTH * 16) / 9);
+
+function InstanceSegmentationContent() {
+  const insets = useSafeAreaInsets();
+  const [selectedModel, setSelectedModel] = useState<any>(MODEL_OPTIONS[0].value);
+  const [imageUri, setImageUri] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [results, setResults] = useState<InstanceSegmentationResult<'xyxy', string>[]>([]);
+  const [latency, setLatency] = useState<number | null>(null);
+  const [masks, setMasks] = useState<{ image: SkiaImageType; color: string }[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const isProcessingRef = useRef(false);
+
+  const skiaImage = useImage(imageUri, (err) => setError(err.message || String(err)));
+
+  const {
+    isReady,
+    downloadProgress,
+    error: loadError,
+    segmentInstances,
+    segmentInstancesWorklet,
+  } = useInstanceSegmenter(selectedModel);
+
+  const handlePickImage = async (useCamera: boolean) => {
+    setError(null);
+    try {
+      const uri = await getImage(useCamera);
+      if (uri) {
+        setImageUri(uri);
+        setResults([]);
+        setLatency(null);
+        setMasks([]);
+      }
+    } catch (e: any) {
+      setError(e.message || String(e));
+    }
+  };
+
+  const runSegmentation = async (sync: boolean) => {
+    if (isProcessingRef.current) return;
+    if (!skiaImage || !segmentInstances || !segmentInstancesWorklet) return;
+
+    isProcessingRef.current = true;
+    if (!sync) setIsProcessing(true);
+    setError(null);
+
+    try {
+      const pixels = skiaImage.readPixels();
+      if (!pixels) {
+        throw new Error('Failed to read pixels from image');
+      }
+      if (!(pixels instanceof Uint8Array)) {
+        throw new Error('Expected Uint8Array from readPixels');
+      }
+      const buffer = {
+        data: pixels,
+        width: skiaImage.width(),
+        height: skiaImage.height(),
+        format: 'rgba' as const,
+        layout: 'hwc' as const,
+      };
+
+      const start = Date.now();
+      const output = (
+        sync ? segmentInstancesWorklet(buffer) : await segmentInstances(buffer)
+      ) as InstanceSegmentationResult<'xyxy', string>[];
+      setLatency(Date.now() - start);
+      setResults(output);
+
+      const nextMasks: { image: SkiaImageType; color: string }[] = [];
+      for (let i = 0; i < output.length; i++) {
+        const inst = output[i]!;
+        const color = MASK_COLORS[i % MASK_COLORS.length]!;
+        const colorStr = `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a / 255})`;
+
+        const maskData = inst.mask.data;
+        const maskW = inst.mask.width;
+        const maskH = inst.mask.height;
+        const outData = Skia.Data.fromBytes(maskData);
+        const info = {
+          width: maskW,
+          height: maskH,
+          colorType: ColorType.Alpha_8,
+          alphaType: AlphaType.Premul,
+        };
+        const maskImage = Skia.Image.MakeImage(info, outData, maskW);
+        if (maskImage) {
+          nextMasks.push({ image: maskImage, color: colorStr });
+        }
+      }
+      setMasks(nextMasks);
+    } catch (e: any) {
+      setError(e.message || String(e));
+    } finally {
+      isProcessingRef.current = false;
+      if (!sync) setIsProcessing(false);
+    }
+  };
+
+  let scaleX = 1;
+  let scaleY = 1;
+  let offsetX = 0;
+  let offsetY = 0;
+
+  if (skiaImage) {
+    const imgW = skiaImage.width();
+    const imgH = skiaImage.height();
+    const scale = Math.min(VIEW_WIDTH / imgW, VIEW_HEIGHT / imgH);
+    const displayedW = imgW * scale;
+    const displayedH = imgH * scale;
+    offsetX = (VIEW_WIDTH - displayedW) / 2;
+    offsetY = (VIEW_HEIGHT - displayedH) / 2;
+    scaleX = scale;
+    scaleY = scale;
+  }
+
+  const activeError = loadError ? String(loadError) : error;
+
+  return (
+    <ScrollView
+      style={commonStyles.container}
+      contentContainerStyle={[
+        commonStyles.contentContainer,
+        { paddingBottom: insets.bottom + theme.spacing.large },
+      ]}
+    >
+      <Text style={commonStyles.description}>
+        Upload or capture an image to run instance segmentation.
+      </Text>
+
+      <ModelPicker
+        label="Model"
+        options={MODEL_OPTIONS}
+        selectedValue={selectedModel}
+        onValueChange={(model) => {
+          setSelectedModel(model);
+          setResults([]);
+          setLatency(null);
+          setError(null);
+          setMasks([]);
+        }}
+      />
+
+      <ModelStatus
+        isReady={isReady}
+        downloadProgress={downloadProgress}
+        error={activeError}
+        modelTypeLabel="segmenter model"
+      />
+
+      <ImageViewport
+        skiaImage={skiaImage}
+        masks={masks}
+        onPressPlaceholder={() => handlePickImage(false)}
+      >
+        {skiaImage && results.length > 0 && (
+          <View style={styles.overlayContainer} pointerEvents="none">
+            {results.map((det, index: number) => {
+              const strokeColor = MASK_STROKE_COLORS[index % MASK_STROKE_COLORS.length]!;
+
+              const left = offsetX + det.box.xmin * scaleX;
+              const top = offsetY + det.box.ymin * scaleY;
+              const width = (det.box.xmax - det.box.xmin) * scaleX;
+              const height = (det.box.ymax - det.box.ymin) * scaleY;
+
+              return (
+                <BoundingBox
+                  key={index}
+                  left={left}
+                  top={top}
+                  width={width}
+                  height={height}
+                  borderColor={strokeColor}
+                  backgroundColor="transparent"
+                  label={`${det.label} ${Math.round(det.confidence * 100)}%`}
+                  labelTextColor="#fff"
+                />
+              );
+            })}
+          </View>
+        )}
+      </ImageViewport>
+
+      <View style={commonStyles.buttonRow}>
+        <Button title="Gallery" onPress={() => handlePickImage(false)} variant="secondary" />
+        <Button title="Camera" onPress={() => handlePickImage(true)} variant="secondary" />
+      </View>
+
+      <View style={commonStyles.buttonRow}>
+        <Button
+          title="Run Async"
+          onPress={() => runSegmentation(false)}
+          disabled={!skiaImage || !isReady || isProcessing}
+          loading={isProcessing}
+        />
+        <Button
+          title="Run Sync"
+          onPress={() => runSegmentation(true)}
+          disabled={!skiaImage || !isReady || isProcessing}
+          variant="accent"
+        />
+      </View>
+
+      <LatencyIndicator latency={latency} />
+    </ScrollView>
+  );
+}
+
+export default function InstanceSegmentationScreen() {
+  return (
+    <ScreenWrapper>
+      <InstanceSegmentationContent />
+    </ScreenWrapper>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlayContainer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+    overflow: 'hidden',
+  },
+});

--- a/apps/computer-vision/components/ImageViewport.tsx
+++ b/apps/computer-vision/components/ImageViewport.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity, Dimensions } from 'react-nati
 import {
   Canvas,
   Image as SkImage,
+  BlendColor,
   type SkImage as SkiaImageType,
 } from '@shopify/react-native-skia';
 
@@ -14,6 +15,7 @@ const VIEW_HEIGHT = Math.round((VIEW_WIDTH * 16) / 9);
 export interface ImageViewportProps {
   skiaImage: SkiaImageType | null;
   overlayImage?: SkiaImageType | null;
+  masks?: { image: SkiaImageType; color: string }[];
   onPressPlaceholder: () => void;
   placeholderText?: string;
   overlayOpacity?: number;
@@ -23,6 +25,7 @@ export interface ImageViewportProps {
 export function ImageViewport({
   skiaImage,
   overlayImage,
+  masks,
   onPressPlaceholder,
   placeholderText = 'Tap to select an image from gallery',
   overlayOpacity = 0.8,
@@ -58,6 +61,21 @@ export function ImageViewport({
             opacity={overlayOpacity}
           />
         )}
+        {masks &&
+          masks.map((item, index) => (
+            <SkImage
+              key={index}
+              image={item.image}
+              fit="contain"
+              x={0}
+              y={0}
+              width={VIEW_WIDTH}
+              height={VIEW_HEIGHT}
+              opacity={overlayOpacity}
+            >
+              <BlendColor color={item.color} mode="srcIn" />
+            </SkImage>
+          ))}
       </Canvas>
       {children}
     </View>

--- a/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
@@ -345,10 +345,8 @@ void install_restrictToBox(jsi::Runtime &rt, jsi::Object &module) {
         ::cv::Mat srcMat(H, W, cvType, src->data_.get());
         ::cv::Mat dstMat(H, W, cvType, dst->data_.get());
 
-        if (isEmpty) {
-            dstMat.setTo(::cv::Scalar::all(0));
-        } else {
-            dstMat.setTo(::cv::Scalar::all(0));
+        dstMat.setTo(::cv::Scalar::all(0));
+        if (!isEmpty) {
             int32_t boxW = x2 - x1 + 1;
             int32_t boxH = y2 - y1 + 1;
             ::cv::Rect roi(x1, y1, boxW, boxH);

--- a/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
@@ -301,16 +301,13 @@ void install_restrictToBox(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "restrictToBox: src and dst must have the same shape");
         }
 
-        if (src->shape_.size() < 2) {
-            throw jsi::JSError(rt, "restrictToBox: src must have at least 2 dimensions [H, W, ...]");
+        if (src->shape_.size() != 3) {
+            throw jsi::JSError(rt, "restrictToBox: src must be a 3D tensor of shape [H, W, C]");
         }
 
         int32_t H = src->shape_[0];
         int32_t W = src->shape_[1];
-        int32_t C = 1;
-        for (size_t i = 2; i < src->shape_.size(); ++i) {
-            C *= src->shape_[i];
-        }
+        int32_t C = src->shape_[2];
 
         int32_t x1 = static_cast<int32_t>(std::ceil(xmin));
         int32_t y1 = static_cast<int32_t>(std::ceil(ymin));
@@ -361,7 +358,7 @@ void install_restrictToBox(jsi::Runtime &rt, jsi::Object &module) {
         return jsi::Value(rt, args[1]);
     };
 
-    module.setProperty(rt, name, jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name), 6, fnBody));
+    module.setProperty(rt, name, jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name), 4, fnBody));
 }
 
 } // namespace rnexecutorch::extensions::cv::box_ops

--- a/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
@@ -9,6 +9,8 @@
 #include <utility>
 #include <vector>
 
+#include <opencv2/core.hpp>
+
 #include "core/dtype.h"
 #include "core/tensor.h"
 
@@ -243,4 +245,136 @@ void install_nms(jsi::Runtime &rt, jsi::Object &module) {
 
     module.setProperty(rt, name, jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name), 3, fnBody));
 }
+
+namespace {
+int dtypeToCvDepth(rnexecutorch::core::types::DType dtype) {
+    switch (dtype) {
+    case rnexecutorch::core::types::DType::uint8:
+        return CV_8U;
+    case rnexecutorch::core::types::DType::int32:
+        return CV_32S;
+    case rnexecutorch::core::types::DType::float32:
+        return CV_32F;
+    }
+    throw std::invalid_argument("unsupported dtype");
+}
+} // namespace
+
+void install_restrictToBox(jsi::Runtime &rt, jsi::Object &module) {
+    auto name = "restrictToBox";
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
+        if (count != 4) {
+            throw jsi::JSError(rt, "Usage: restrictToBox(src, dst, boxTuple, format)");
+        }
+
+        if (!args[0].isObject() || !args[0].asObject(rt).isHostObject<TensorHostObject>(rt)) {
+            throw jsi::JSError(rt, "restrictToBox: src must be a Tensor");
+        }
+
+        if (!args[1].isObject() || !args[1].asObject(rt).isHostObject<TensorHostObject>(rt)) {
+            throw jsi::JSError(rt, "restrictToBox: dst must be a Tensor");
+        }
+
+        if (!args[2].isObject() || !args[2].asObject(rt).isArray(rt)) {
+            throw jsi::JSError(rt, "restrictToBox: boxTuple must be an Array");
+        }
+
+        if (!args[3].isString()) {
+            throw jsi::JSError(rt, "restrictToBox: format must be a String");
+        }
+
+        auto src = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
+        auto dst = args[1].asObject(rt).getHostObject<TensorHostObject>(rt);
+        auto boxTuple = args[2].asObject(rt).asArray(rt);
+        std::string boxFormatStr = args[3].asString(rt).utf8(rt);
+
+        if (boxTuple.size(rt) != 4) {
+            throw jsi::JSError(rt, "restrictToBox: boxTuple must contain exactly 4 coordinates");
+        }
+
+        BoxFormat boxFormat;
+        try {
+            boxFormat = parseBoxFormat(boxFormatStr);
+        } catch (const std::invalid_argument &e) {
+            throw jsi::JSError(rt, "restrictToBox: " + std::string(e.what()));
+        }
+
+        float a = static_cast<float>(boxTuple.getValueAtIndex(rt, 0).asNumber());
+        float b = static_cast<float>(boxTuple.getValueAtIndex(rt, 1).asNumber());
+        float c = static_cast<float>(boxTuple.getValueAtIndex(rt, 2).asNumber());
+        float d = static_cast<float>(boxTuple.getValueAtIndex(rt, 3).asNumber());
+
+        auto [xmin, ymin, xmax, ymax] = decodeToXyxy(a, b, c, d, boxFormat);
+
+        if (src.get() == dst.get()) {
+            throw jsi::JSError(rt, "restrictToBox: In-place operations (src == dst) are not supported.");
+        }
+
+        if (src->shape_ != dst->shape_) {
+            throw jsi::JSError(rt, "restrictToBox: src and dst must have the same shape");
+        }
+
+        if (src->shape_.size() < 2) {
+            throw jsi::JSError(rt, "restrictToBox: src must have at least 2 dimensions [H, W, ...]");
+        }
+
+        int32_t H = src->shape_[0];
+        int32_t W = src->shape_[1];
+        int32_t C = 1;
+        for (size_t i = 2; i < src->shape_.size(); ++i) {
+            C *= src->shape_[i];
+        }
+
+        int32_t x1 = static_cast<int32_t>(std::ceil(xmin));
+        int32_t y1 = static_cast<int32_t>(std::ceil(ymin));
+        int32_t x2 = static_cast<int32_t>(std::floor(xmax));
+        int32_t y2 = static_cast<int32_t>(std::floor(ymax));
+
+        x1 = std::max(0, x1);
+        y1 = std::max(0, y1);
+        x2 = std::min(W - 1, x2);
+        y2 = std::min(H - 1, y2);
+
+        bool isEmpty = (x2 < x1) || (y2 < y1);
+
+        if (src->dtype_ != dst->dtype_) {
+            throw jsi::JSError(rt, "restrictToBox: src and dst must have the same dtype");
+        }
+
+        std::shared_lock<std::shared_mutex> srcLock(src->mutex_, std::try_to_lock);
+        std::unique_lock<std::shared_mutex> dstLock(dst->mutex_, std::try_to_lock);
+        if (!srcLock.owns_lock() || !dstLock.owns_lock()) {
+            throw jsi::JSError(rt, "restrictToBox: tensors in use");
+        }
+
+        if (!src->data_ || !dst->data_) {
+            throw jsi::JSError(rt, "restrictToBox: tensors must not be disposed");
+        }
+
+        int32_t cvType;
+        try {
+            cvType = CV_MAKETYPE(dtypeToCvDepth(src->dtype_), C);
+        } catch (const std::invalid_argument &e) {
+            throw jsi::JSError(rt, "restrictToBox: " + std::string(e.what()));
+        }
+
+        ::cv::Mat srcMat(H, W, cvType, src->data_.get());
+        ::cv::Mat dstMat(H, W, cvType, dst->data_.get());
+
+        if (isEmpty) {
+            dstMat.setTo(::cv::Scalar::all(0));
+        } else {
+            dstMat.setTo(::cv::Scalar::all(0));
+            int32_t boxW = x2 - x1 + 1;
+            int32_t boxH = y2 - y1 + 1;
+            ::cv::Rect roi(x1, y1, boxW, boxH);
+            srcMat(roi).copyTo(dstMat(roi));
+        }
+
+        return jsi::Value(rt, args[1]);
+    };
+
+    module.setProperty(rt, name, jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name), 6, fnBody));
+}
+
 } // namespace rnexecutorch::extensions::cv::box_ops

--- a/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
@@ -13,6 +13,7 @@
 
 #include "core/dtype.h"
 #include "core/tensor.h"
+#include "utils.h"
 
 namespace rnexecutorch::extensions::cv::box_ops {
 namespace jsi = facebook::jsi;
@@ -245,20 +246,6 @@ void install_nms(jsi::Runtime &rt, jsi::Object &module) {
 
     module.setProperty(rt, name, jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name), 3, fnBody));
 }
-
-namespace {
-int dtypeToCvDepth(rnexecutorch::core::types::DType dtype) {
-    switch (dtype) {
-    case rnexecutorch::core::types::DType::uint8:
-        return CV_8U;
-    case rnexecutorch::core::types::DType::int32:
-        return CV_32S;
-    case rnexecutorch::core::types::DType::float32:
-        return CV_32F;
-    }
-    throw std::invalid_argument("unsupported dtype");
-}
-} // namespace
 
 void install_restrictToBox(jsi::Runtime &rt, jsi::Object &module) {
     auto name = "restrictToBox";

--- a/packages/react-native-executorch/cpp/extensions/cv/box_ops.h
+++ b/packages/react-native-executorch/cpp/extensions/cv/box_ops.h
@@ -4,4 +4,5 @@
 
 namespace rnexecutorch::extensions::cv::box_ops {
 void install_nms(facebook::jsi::Runtime &rt, facebook::jsi::Object &module);
+void install_restrictToBox(facebook::jsi::Runtime &rt, facebook::jsi::Object &module);
 } // namespace rnexecutorch::extensions::cv::box_ops

--- a/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
@@ -191,6 +191,9 @@ int codeToColorConversionFlag(const std::string &code) {
     if (code == "RGBA2BGR") {
         return ::cv::COLOR_RGBA2BGR;
     }
+    if (code == "RGBA2BGRA") {
+        return ::cv::COLOR_RGBA2BGRA;
+    }
     if (code == "BGRA2RGBA") {
         return ::cv::COLOR_BGRA2RGBA;
     }
@@ -212,6 +215,12 @@ int codeToColorConversionFlag(const std::string &code) {
     if (code == "BGR2RGBA") {
         return ::cv::COLOR_BGR2RGBA;
     }
+    if (code == "RGB2BGRA") {
+        return ::cv::COLOR_RGB2BGRA;
+    }
+    if (code == "BGR2BGRA") {
+        return ::cv::COLOR_BGR2BGRA;
+    }
     if (code == "RGB2GRAY") {
         return ::cv::COLOR_RGB2GRAY;
     }
@@ -226,6 +235,15 @@ int codeToColorConversionFlag(const std::string &code) {
     }
     if (code == "GRAY2RGBA") {
         return ::cv::COLOR_GRAY2RGBA;
+    }
+    if (code == "GRAY2RGB") {
+        return ::cv::COLOR_GRAY2RGB;
+    }
+    if (code == "GRAY2BGR") {
+        return ::cv::COLOR_GRAY2BGR;
+    }
+    if (code == "GRAY2BGRA") {
+        return ::cv::COLOR_GRAY2BGRA;
     }
     throw std::invalid_argument("cvtColor: unsupported color conversion code '" + code + "'");
 }

--- a/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
@@ -10,6 +10,7 @@
 
 #include "core/dtype.h"
 #include "core/tensor.h"
+#include "utils.h"
 
 namespace rnexecutorch::extensions::cv::image_ops {
 namespace jsi = facebook::jsi;
@@ -33,18 +34,6 @@ int interpToFlag(const std::string &interp) {
         return ::cv::INTER_LANCZOS4;
     }
     throw std::invalid_argument("unsupported interpolation '" + interp + "'");
-}
-
-int dtypeToCvDepth(rnexecutorch::core::types::DType dtype) {
-    switch (dtype) {
-    case rnexecutorch::core::types::DType::uint8:
-        return CV_8U;
-    case rnexecutorch::core::types::DType::int32:
-        return CV_32S;
-    case rnexecutorch::core::types::DType::float32:
-        return CV_32F;
-    }
-    throw std::invalid_argument("unsupported dtype");
 }
 
 struct FitBox {

--- a/packages/react-native-executorch/cpp/extensions/cv/install.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/install.cpp
@@ -16,6 +16,7 @@ void install(facebook::jsi::Runtime &rt, facebook::jsi::Object &module) {
     image_ops::install_applyColormap(rt, cvModule);
 
     box_ops::install_nms(rt, cvModule);
+    box_ops::install_restrictToBox(rt, cvModule);
 
     module.setProperty(rt, "cv", cvModule);
 }

--- a/packages/react-native-executorch/cpp/extensions/cv/utils.h
+++ b/packages/react-native-executorch/cpp/extensions/cv/utils.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "core/dtype.h"
+#include <opencv2/core.hpp>
+#include <stdexcept>
+
+namespace rnexecutorch::extensions::cv {
+
+inline int dtypeToCvDepth(rnexecutorch::core::types::DType dtype) {
+    switch (dtype) {
+    case rnexecutorch::core::types::DType::uint8:
+        return CV_8U;
+    case rnexecutorch::core::types::DType::int32:
+        return CV_32S;
+    case rnexecutorch::core::types::DType::float32:
+        return CV_32F;
+    }
+    throw std::invalid_argument("unsupported dtype");
+}
+
+} // namespace rnexecutorch::extensions::cv

--- a/packages/react-native-executorch/cpp/extensions/math/install.cpp
+++ b/packages/react-native-executorch/cpp/extensions/math/install.cpp
@@ -10,6 +10,7 @@ void install(jsi::Runtime &rt, jsi::Object &module) {
     install_sigmoid(rt, mathModule);
     install_softmax(rt, mathModule);
     install_argmax(rt, mathModule);
+    install_threshold(rt, mathModule);
 
     module.setProperty(rt, "math", mathModule);
 }

--- a/packages/react-native-executorch/cpp/extensions/math/operations.cpp
+++ b/packages/react-native-executorch/cpp/extensions/math/operations.cpp
@@ -301,4 +301,71 @@ void install_argmax(jsi::Runtime &rt, jsi::Object &module) {
     };
     module.setProperty(rt, name, jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name), 3, fnBody));
 }
+
+void install_threshold(jsi::Runtime &rt, jsi::Object &module) {
+    auto name = "threshold";
+    auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
+        if (count != 3) {
+            throw jsi::JSError(rt, "Usage: threshold(src, dst, threshold)");
+        }
+
+        if (!args[0].isObject() || !args[0].asObject(rt).isHostObject<TensorHostObject>(rt)) {
+            throw jsi::JSError(rt, "threshold: src must be a Tensor");
+        }
+
+        if (!args[1].isObject() || !args[1].asObject(rt).isHostObject<TensorHostObject>(rt)) {
+            throw jsi::JSError(rt, "threshold: dst must be a Tensor");
+        }
+
+        if (!args[2].isNumber()) {
+            throw jsi::JSError(rt, "threshold: threshold must be a number");
+        }
+
+        auto src = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
+        auto dst = args[1].asObject(rt).getHostObject<TensorHostObject>(rt);
+        float thresholdVal = static_cast<float>(args[2].asNumber());
+
+        if (src.get() == dst.get()) {
+            throw jsi::JSError(rt, "threshold: In-place operations (src == dst) are not supported.");
+        }
+
+        if (src->shape_ != dst->shape_) {
+            throw jsi::JSError(rt, "threshold: src and dst must have the same shape");
+        }
+
+        if (src->dtype_ != rnexecutorch::core::types::DType::float32) {
+            throw jsi::JSError(rt, "threshold: src must be a float32 tensor");
+        }
+
+        if (dst->dtype_ != rnexecutorch::core::types::DType::float32) {
+            throw jsi::JSError(rt, "threshold: dst must be a float32 tensor");
+        }
+
+        std::shared_lock<std::shared_mutex> srcLock(src->mutex_, std::try_to_lock);
+        std::unique_lock<std::shared_mutex> dstLock(dst->mutex_, std::try_to_lock);
+        if (!srcLock.owns_lock() || !dstLock.owns_lock()) {
+            throw jsi::JSError(rt, "threshold: tensors in use");
+        }
+
+        if (!src->data_) {
+            throw jsi::JSError(rt, "threshold: src tensor has been disposed");
+        }
+
+        if (!dst->data_) {
+            throw jsi::JSError(rt, "threshold: dst tensor has been disposed");
+        }
+
+        const auto *srcData = reinterpret_cast<const float *>(src->data_.get());
+        auto *dstData = reinterpret_cast<float *>(dst->data_.get());
+
+        for (size_t i = 0; i < src->numel_; ++i) {
+            dstData[i] = (srcData[i] >= thresholdVal) ? 1.0f : 0.0f;
+        }
+
+        return jsi::Value(rt, args[1]);
+    };
+
+    module.setProperty(rt, name, jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name), 3, fnBody));
+}
+
 } // namespace rnexecutorch::extensions::math

--- a/packages/react-native-executorch/cpp/extensions/math/operations.h
+++ b/packages/react-native-executorch/cpp/extensions/math/operations.h
@@ -6,4 +6,5 @@ namespace rnexecutorch::extensions::math {
 void install_sigmoid(facebook::jsi::Runtime &rt, facebook::jsi::Object &module);
 void install_softmax(facebook::jsi::Runtime &rt, facebook::jsi::Object &module);
 void install_argmax(facebook::jsi::Runtime &rt, facebook::jsi::Object &module);
+void install_threshold(facebook::jsi::Runtime &rt, facebook::jsi::Object &module);
 } // namespace rnexecutorch::extensions::math

--- a/packages/react-native-executorch/src/extensions/cv/image.ts
+++ b/packages/react-native-executorch/src/extensions/cv/image.ts
@@ -2,7 +2,7 @@
  * Supported pixel format layouts for image buffers.
  * @category Types
  */
-export type ImageFormat = 'rgb' | 'rgba' | 'bgr' | 'bgra';
+export type ImageFormat = 'rgb' | 'rgba' | 'bgr' | 'bgra' | 'gray';
 
 /**
  * Represents a raw CPU image buffer in HWC (Height, Width, Channel) layout.

--- a/packages/react-native-executorch/src/extensions/cv/ops/boxes.ts
+++ b/packages/react-native-executorch/src/extensions/cv/ops/boxes.ts
@@ -165,3 +165,34 @@ export function nms(boxes: Tensor, scores: Tensor, opts: NmsOptions): number[] |
   'worklet';
   return rnexecutorchJsi.cv.nms(boxes, scores, opts);
 }
+
+/**
+ * Masks the source tensor by keeping only the elements inside the specified
+ * bounding box, writing the result to a pre-allocated destination tensor.
+ *
+ * Note: This operation does not change the tensor dimensions (it does not crop
+ * the shape). Instead, it copies the elements within the box coordinates from
+ * `src` to `dst`, and sets all elements outside the box to `0`.
+ * @category Typescript API
+ * @param src The source tensor of shape [H, W, ...] with at least 2 dimensions.
+ * @param dst The pre-allocated destination tensor of the same shape and data
+ * type as `src`.
+ * @param box The bounding box defining the region of interest to copy.
+ * @returns The destination tensor containing the masked output.
+ */
+export function restrictToBox(src: Tensor, dst: Tensor, box: BoundingBox<BoxFormat>): Tensor {
+  'worklet';
+  let [a, b, c, d] = [0, 0, 0, 0];
+  switch (box.format) {
+    case 'xyxy':
+      [a, b, c, d] = [box.xmin, box.ymin, box.xmax, box.ymax];
+      break;
+    case 'xywh':
+      [a, b, c, d] = [box.xmin, box.ymin, box.w, box.h];
+      break;
+    case 'cxcywh':
+      [a, b, c, d] = [box.cx, box.cy, box.w, box.h];
+      break;
+  }
+  return rnexecutorchJsi.cv.restrictToBox(src, dst, [a, b, c, d], box.format);
+}

--- a/packages/react-native-executorch/src/extensions/cv/ops/boxes.ts
+++ b/packages/react-native-executorch/src/extensions/cv/ops/boxes.ts
@@ -174,9 +174,9 @@ export function nms(boxes: Tensor, scores: Tensor, opts: NmsOptions): number[] |
  * the shape). Instead, it copies the elements within the box coordinates from
  * `src` to `dst`, and sets all elements outside the box to `0`.
  * @category Typescript API
- * @param src The source tensor of shape [H, W, ...] with at least 2 dimensions.
- * @param dst The pre-allocated destination tensor of the same shape and data
- * type as `src`.
+ * @param src The source tensor of shape [H, W, C].
+ * @param dst The pre-allocated destination tensor of shape [H, W, C] and the
+ * same data type as `src`.
  * @param box The bounding box defining the region of interest to copy.
  * @returns The destination tensor containing the masked output.
  */

--- a/packages/react-native-executorch/src/extensions/cv/ops/image.ts
+++ b/packages/react-native-executorch/src/extensions/cv/ops/image.ts
@@ -9,6 +9,7 @@ import type { ImageFormat } from '../image';
 export type ColorConversionCode =
   | 'RGBA2RGB'
   | 'RGBA2BGR'
+  | 'RGBA2BGRA'
   | 'BGRA2RGBA'
   | 'BGRA2RGB'
   | 'BGRA2BGR'
@@ -20,7 +21,12 @@ export type ColorConversionCode =
   | 'BGRA2GRAY'
   | 'RGB2RGBA'
   | 'BGR2RGBA'
-  | 'GRAY2RGBA';
+  | 'RGB2BGRA'
+  | 'BGR2BGRA'
+  | 'GRAY2RGBA'
+  | 'GRAY2RGB'
+  | 'GRAY2BGR'
+  | 'GRAY2BGRA';
 
 /**
  * Helper lookup map detailing required color conversion codes to transition
@@ -31,11 +37,11 @@ export const FORMAT_CONVERSION: Record<
   ImageFormat,
   Record<ImageFormat, ColorConversionCode | null>
 > = {
-  rgb: { rgb: null, rgba: 'RGB2RGBA', bgr: 'RGB2BGR', bgra: null, gray: 'RGB2GRAY' },
-  bgr: { rgb: 'BGR2RGB', rgba: 'BGR2RGBA', bgr: null, bgra: null, gray: 'BGR2GRAY' },
-  rgba: { rgb: 'RGBA2RGB', rgba: null, bgr: 'RGBA2BGR', bgra: null, gray: 'RGBA2GRAY' },
+  rgb: { rgb: null, rgba: 'RGB2RGBA', bgr: 'RGB2BGR', bgra: 'RGB2BGRA', gray: 'RGB2GRAY' },
+  bgr: { rgb: 'BGR2RGB', rgba: 'BGR2RGBA', bgr: null, bgra: 'BGR2BGRA', gray: 'BGR2GRAY' },
+  rgba: { rgb: 'RGBA2RGB', rgba: null, bgr: 'RGBA2BGR', bgra: 'RGBA2BGRA', gray: 'RGBA2GRAY' },
   bgra: { rgb: 'BGRA2RGB', rgba: 'BGRA2RGBA', bgr: 'BGRA2BGR', bgra: null, gray: 'BGRA2GRAY' },
-  gray: { rgb: 'GRAY2RGBA', rgba: 'GRAY2RGBA', bgr: null, bgra: null, gray: null },
+  gray: { rgb: 'GRAY2RGB', rgba: 'GRAY2RGBA', bgr: 'GRAY2BGR', bgra: 'GRAY2BGRA', gray: null },
 };
 
 /**

--- a/packages/react-native-executorch/src/extensions/cv/ops/image.ts
+++ b/packages/react-native-executorch/src/extensions/cv/ops/image.ts
@@ -31,10 +31,11 @@ export const FORMAT_CONVERSION: Record<
   ImageFormat,
   Record<ImageFormat, ColorConversionCode | null>
 > = {
-  rgb: { rgb: null, rgba: 'RGB2RGBA', bgr: 'RGB2BGR', bgra: null },
-  bgr: { rgb: 'BGR2RGB', rgba: 'BGR2RGBA', bgr: null, bgra: null },
-  rgba: { rgb: 'RGBA2RGB', rgba: null, bgr: 'RGBA2BGR', bgra: null },
-  bgra: { rgb: 'BGRA2RGB', rgba: 'BGRA2RGBA', bgr: 'BGRA2BGR', bgra: null },
+  rgb: { rgb: null, rgba: 'RGB2RGBA', bgr: 'RGB2BGR', bgra: null, gray: 'RGB2GRAY' },
+  bgr: { rgb: 'BGR2RGB', rgba: 'BGR2RGBA', bgr: null, bgra: null, gray: 'BGR2GRAY' },
+  rgba: { rgb: 'RGBA2RGB', rgba: null, bgr: 'RGBA2BGR', bgra: null, gray: 'RGBA2GRAY' },
+  bgra: { rgb: 'BGRA2RGB', rgba: 'BGRA2RGBA', bgr: 'BGRA2BGR', bgra: null, gray: 'BGRA2GRAY' },
+  gray: { rgb: 'GRAY2RGBA', rgba: 'GRAY2RGBA', bgr: null, bgra: null, gray: null },
 };
 
 /**
@@ -47,6 +48,7 @@ export const FORMAT_CHANNELS: Record<ImageFormat, number> = {
   bgr: 3,
   rgba: 4,
   bgra: 4,
+  gray: 1,
 };
 
 /**

--- a/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
@@ -37,12 +37,14 @@ export type InstanceSegmenterModel<F extends BoxFormat, L> = {
   readonly opts: InstanceSegmenterOptions<F, L>;
 };
 
-export type InstanceSegmentation<F extends BoxFormat, L> = {
+export type InstanceSegmentationResult<F extends BoxFormat, L> = {
   readonly box: BoundingBox<F>;
   readonly mask: ImageBuffer;
   readonly label: L;
   readonly confidence: number;
 };
+
+export type InstanceSegmentation<F extends BoxFormat, L> = InstanceSegmentationResult<F, L>;
 
 export async function createInstanceSegmenter<F extends BoxFormat, L>(
   config: InstanceSegmenterModel<F, L>,
@@ -53,12 +55,12 @@ export async function createInstanceSegmenter<F extends BoxFormat, L>(
   segmentInstances: (
     input: ImageBuffer,
     options?: { confidenceThreshold?: number; iouThreshold?: number; maskThreshold?: number }
-  ) => Promise<InstanceSegmentation<F, L>[]>;
+  ) => Promise<InstanceSegmentationResult<F, L>[]>;
 
   segmentInstancesWorklet: (
     input: ImageBuffer,
     options?: { confidenceThreshold?: number; iouThreshold?: number; maskThreshold?: number }
-  ) => InstanceSegmentation<F, L>[];
+  ) => InstanceSegmentationResult<F, L>[];
 }> {
   const { modelPath, opts } = config;
   const model = await wrapAsync(loadModel, runtime)(modelPath);
@@ -107,7 +109,7 @@ export async function createInstanceSegmenter<F extends BoxFormat, L>(
   const segmentInstancesWorklet = (
     input: ImageBuffer,
     options?: { confidenceThreshold?: number; iouThreshold?: number; maskThreshold?: number }
-  ): InstanceSegmentation<F, L>[] => {
+  ): InstanceSegmentationResult<F, L>[] => {
     'worklet';
     const tInput = preprocessor.process(input);
     model.execute('forward', [tInput], [tBoxes, tScores, tClasses, tAllMasks]);
@@ -140,7 +142,7 @@ export async function createInstanceSegmenter<F extends BoxFormat, L>(
 
     const [tResize, tThreshold, tCrop, tUint8] = auxTensors;
 
-    const results: InstanceSegmentation<F, L>[] = [];
+    const results: InstanceSegmentationResult<F, L>[] = [];
 
     try {
       for (const idx of indices) {
@@ -150,7 +152,7 @@ export async function createInstanceSegmenter<F extends BoxFormat, L>(
 
         if (label === undefined) {
           throw new Error(
-            `InstanceSegmenter: Predicted class index ${classIdx} is` +
+            `InstanceSegmenter: Predicted class index ${classIdx} is ` +
               `out of bounds for labels array of size ${opts.labels.length}.`
           );
         }

--- a/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
@@ -20,6 +20,13 @@ import {
 
 export type { BoxFormat };
 
+/**
+ * Options for configuring an instance segmenter preprocessor, label
+ * vocabulary, and threshold parameters.
+ * @category Types
+ * @typeParam F The format type of the bounding box.
+ * @typeParam L The label type.
+ */
 export type InstanceSegmenterOptions<F extends BoxFormat, L> = Omit<
   ImagePreprocessorOptions,
   'resizeMode'
@@ -32,11 +39,24 @@ export type InstanceSegmenterOptions<F extends BoxFormat, L> = Omit<
   readonly defaultConfidenceThreshold: number;
 };
 
+/**
+ * Model configuration required to instantiate an instance segmenter task runner.
+ * @category Types
+ * @typeParam F The format type of the bounding box.
+ * @typeParam L The label type.
+ */
 export type InstanceSegmenterModel<F extends BoxFormat, L> = {
   readonly modelPath: string;
   readonly opts: InstanceSegmenterOptions<F, L>;
 };
 
+/**
+ * Result structure representing a single detected instance with its bounding box,
+ * segmentation mask, label, and confidence score.
+ * @category Types
+ * @typeParam F The format type of the bounding box.
+ * @typeParam L The label type.
+ */
 export type InstanceSegmentationResult<F extends BoxFormat, L> = {
   readonly box: BoundingBox<F>;
   readonly mask: ImageBuffer;
@@ -44,19 +64,50 @@ export type InstanceSegmentationResult<F extends BoxFormat, L> = {
   readonly confidence: number;
 };
 
-export type InstanceSegmentation<F extends BoxFormat, L> = InstanceSegmentationResult<F, L>;
-
+/**
+ * Creates an instance segmenter runner for executing local Instance
+ * Segmentation models.
+ *
+ * It validates model input/output tensor shapes and types, pre-allocates
+ * execution and auxiliary tensors, sets up an image preprocessor, and returns
+ * execution and resource management controls.
+ * @category Typescript API
+ * @typeParam F The bounding box format type.
+ * @typeParam L The label type.
+ * @param config Model configuration containing path and options.
+ * @param runtime Optional worklet runtime thread on which to run the model
+ * execution.
+ * @returns A promise resolving to an object containing instance segmentation
+ * and disposal controls.
+ */
 export async function createInstanceSegmenter<F extends BoxFormat, L>(
   config: InstanceSegmenterModel<F, L>,
   runtime?: WorkletRuntime
 ): Promise<{
+  /**
+   * Releases all allocated native resources.
+   */
   dispose: () => void;
 
+  /**
+   * Performs asynchronous instance segmentation on the given input image.
+   * @param input The input image buffer.
+   * @param options Execution override options.
+   * @param options.confidenceThreshold Override for the minimum confidence
+   * threshold.
+   * @param options.iouThreshold Override for the IoU threshold in NMS.
+   * @param options.maskThreshold Override for the mask binarization threshold.
+   * @returns A promise resolving to a list of detected instances.
+   */
   segmentInstances: (
     input: ImageBuffer,
     options?: { confidenceThreshold?: number; iouThreshold?: number; maskThreshold?: number }
   ) => Promise<InstanceSegmentationResult<F, L>[]>;
 
+  /**
+   * Synchronous version of {@link segmentInstances} to be executed directly on
+   * the caller or worklet thread.
+   */
   segmentInstancesWorklet: (
     input: ImageBuffer,
     options?: { confidenceThreshold?: number; iouThreshold?: number; maskThreshold?: number }

--- a/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
@@ -1,0 +1,197 @@
+import type { WorkletRuntime } from 'react-native-worklets';
+
+import { tensor } from '../../../core/tensor';
+import { loadModel } from '../../../core/model';
+import { validateModelSchema, SymbolicTensor } from '../../../core/modelSchema';
+import { wrapAsync } from '../../../core/runtime';
+
+import type { ImageBuffer } from '../image';
+import { createImagePreprocessor, type ImagePreprocessorOptions } from './preprocessing';
+import { threshold } from '../../math';
+import { resize, normalize } from '../ops/image';
+import {
+  decodeBox,
+  scaleBox,
+  nms,
+  restrictToBox,
+  type BoundingBox,
+  type BoxFormat,
+} from '../ops/boxes';
+
+export type { BoxFormat };
+
+export type InstanceSegmenterOptions<F extends BoxFormat, L> = Omit<
+  ImagePreprocessorOptions,
+  'resizeMode'
+> & {
+  readonly resizeMode: 'stretch';
+  readonly labels: readonly L[];
+  readonly boxFormat: F;
+  readonly defaultIouThreshold: number;
+  readonly defaultMaskThreshold: number;
+  readonly defaultConfidenceThreshold: number;
+};
+
+export type InstanceSegmenterModel<F extends BoxFormat, L> = {
+  readonly modelPath: string;
+  readonly opts: InstanceSegmenterOptions<F, L>;
+};
+
+export type InstanceSegmentation<F extends BoxFormat, L> = {
+  readonly box: BoundingBox<F>;
+  readonly mask: ImageBuffer;
+  readonly label: L;
+  readonly confidence: number;
+};
+
+export async function createInstanceSegmenter<F extends BoxFormat, L>(
+  config: InstanceSegmenterModel<F, L>,
+  runtime?: WorkletRuntime
+): Promise<{
+  dispose: () => void;
+
+  segmentInstances: (
+    input: ImageBuffer,
+    options?: { confidenceThreshold?: number; iouThreshold?: number; maskThreshold?: number }
+  ) => Promise<InstanceSegmentation<F, L>[]>;
+
+  segmentInstancesWorklet: (
+    input: ImageBuffer,
+    options?: { confidenceThreshold?: number; iouThreshold?: number; maskThreshold?: number }
+  ) => InstanceSegmentation<F, L>[];
+}> {
+  const { modelPath, opts } = config;
+  const model = await wrapAsync(loadModel, runtime)(modelPath);
+  const meta = validateModelSchema(
+    model,
+    'forward',
+    [SymbolicTensor('float32', [1, 3, 'H', 'W'], [3, 'H', 'W'])],
+    [
+      SymbolicTensor('float32', ['N', 4]),
+      SymbolicTensor('float32', ['N']),
+      SymbolicTensor('float32', ['N']),
+      SymbolicTensor('float32', ['N', 'MH', 'MW']),
+    ]
+  );
+
+  const inpShape = meta.inputTensorMeta[0]!.shape;
+
+  const outBoxesShape = meta.outputTensorMeta[0]!.shape;
+  const outScoresShape = meta.outputTensorMeta[1]!.shape;
+  const outClassesShape = meta.outputTensorMeta[2]!.shape;
+  const outMasksShape = meta.outputTensorMeta[3]!.shape;
+
+  const maskH = outMasksShape[1]!;
+  const maskW = outMasksShape[2]!;
+  const targetH = inpShape.at(-2)!;
+  const targetW = inpShape.at(-1)!;
+
+  const tensors = [
+    tensor('float32', outBoxesShape),
+    tensor('float32', outScoresShape),
+    tensor('float32', outClassesShape),
+    tensor('float32', outMasksShape),
+    tensor('float32', [maskH, maskW, 1]),
+  ] as const;
+
+  const [tBoxes, tScores, tClasses, tAllMasks, tMask] = tensors;
+
+  const preprocessor = createImagePreprocessor(opts, inpShape);
+
+  const dispose = () => {
+    preprocessor.dispose();
+    tensors.forEach((t) => t.dispose());
+    model.dispose();
+  };
+
+  const segmentInstancesWorklet = (
+    input: ImageBuffer,
+    options?: { confidenceThreshold?: number; iouThreshold?: number; maskThreshold?: number }
+  ): InstanceSegmentation<F, L>[] => {
+    'worklet';
+    const tInput = preprocessor.process(input);
+    model.execute('forward', [tInput], [tBoxes, tScores, tClasses, tAllMasks]);
+
+    const iouThreshold = options?.iouThreshold ?? opts.defaultIouThreshold;
+    const maskThreshold = options?.maskThreshold ?? opts.defaultMaskThreshold;
+    const confidenceThreshold = options?.confidenceThreshold ?? opts.defaultConfidenceThreshold;
+
+    const eps = 1e-7;
+    const clampedMaskThreshold = Math.max(eps, Math.min(1 - eps, maskThreshold));
+    const logitMaskThreshold = Math.log(clampedMaskThreshold / (1 - clampedMaskThreshold));
+
+    const indices = nms(tBoxes, tScores, {
+      boxFormat: opts.boxFormat,
+      iouThreshold,
+      confidenceThreshold,
+      nmsType: 'standard',
+    });
+
+    const boxes = tBoxes.getData(new Float32Array(tBoxes.numel));
+    const scores = tScores.getData(new Float32Array(tScores.numel));
+    const classes = tClasses.getData(new Float32Array(tClasses.numel));
+
+    const auxTensors = [
+      tensor('float32', [input.height, input.width, 1]),
+      tensor('float32', [input.height, input.width, 1]),
+      tensor('float32', [input.height, input.width, 1]),
+      tensor('uint8', [input.height, input.width, 1]),
+    ] as const;
+
+    const [tResize, tThreshold, tCrop, tUint8] = auxTensors;
+
+    const results: InstanceSegmentation<F, L>[] = [];
+
+    try {
+      for (const idx of indices) {
+        const confidence = scores[idx]!;
+        const classIdx = Math.round(classes[idx]!);
+        const label = opts.labels[classIdx];
+
+        if (label === undefined) {
+          throw new Error(
+            `InstanceSegmenter: Predicted class index ${classIdx} is` +
+              `out of bounds for labels array of size ${opts.labels.length}.`
+          );
+        }
+
+        const a = boxes[idx * 4]!;
+        const b = boxes[idx * 4 + 1]!;
+        const c = boxes[idx * 4 + 2]!;
+        const d = boxes[idx * 4 + 3]!;
+
+        const box = scaleBox(decodeBox([a, b, c, d], opts.boxFormat), {
+          from: { width: targetW, height: targetH },
+          to: { width: input.width, height: input.height },
+          resizeMode: 'stretch',
+        });
+
+        const maskData = tAllMasks
+          .copyTo(tMask, { offset: idx * maskH * maskW, length: maskH * maskW })
+          .through(resize, tResize, { mode: 'stretch', interpolation: 'linear' })
+          .through(threshold, tThreshold, logitMaskThreshold)
+          .through(restrictToBox, tCrop, box)
+          .through(normalize, tUint8, { alpha: 255.0 })
+          .getData(new Uint8Array(tUint8.numel));
+
+        const mask = {
+          data: maskData,
+          width: input.width,
+          height: input.height,
+          format: 'gray' as const,
+          layout: 'hwc' as const,
+        };
+
+        results.push({ box, mask, confidence, label });
+      }
+    } finally {
+      auxTensors.forEach((t) => t.dispose());
+    }
+
+    return results;
+  };
+
+  const segmentInstances = wrapAsync(segmentInstancesWorklet, runtime);
+
+  return { segmentInstances, segmentInstancesWorklet, dispose };
+}

--- a/packages/react-native-executorch/src/extensions/math.ts
+++ b/packages/react-native-executorch/src/extensions/math.ts
@@ -46,3 +46,18 @@ export function argmax(src: Tensor, dst: Tensor, axis: number = -1): Tensor {
   'worklet';
   return rnexecutorchJsi.math.argmax(src, dst, axis);
 }
+
+/**
+ * Applies the element-wise threshold step function on a float32 source tensor and
+ * writes the result to a destination tensor.
+ * @category Typescript API
+ * @param src The input float32 source tensor. Shape [d1,...,dn].
+ * @param dst The pre-allocated destination tensor to write the result to.
+ * `dst` tensor must have the same shape as `src` and have dtype float32.
+ * @param thresholdVal The threshold value above or equal to which elements are mapped to 1.0.
+ * @returns The destination tensor containing the threshold step output.
+ */
+export function threshold(src: Tensor, dst: Tensor, thresholdVal: number): Tensor {
+  'worklet';
+  return rnexecutorchJsi.math.threshold(src, dst, thresholdVal);
+}

--- a/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
+++ b/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
@@ -1,0 +1,49 @@
+import { useModel } from './useModel';
+import { useResourceDownload } from './useResourceDownload';
+import {
+  createInstanceSegmenter,
+  type InstanceSegmenterModel,
+} from '../extensions/cv/tasks/instanceSegmentation';
+import type { BoxFormat } from '../extensions/cv/ops/boxes';
+
+/**
+ * React hook to load and run an instance segmentation model.
+ *
+ * This hook manages downloading (if it's a remote URL) and loading the model
+ * file, compiling it, tracking download progress and compilation errors, and
+ * cleaning up native model memory when the component unmounts or configuration
+ * changes.
+ * @category Hooks
+ * @typeParam F The bounding box format.
+ * @typeParam L The class labels type.
+ * @param config The instance segmentation model configuration.
+ * @param options Hook options.
+ * @param options.preventLoad If true, prevents downloading and compiling the
+ * model.
+ * @returns An object containing the model's loading state, error, download
+ * progress, and segmentation functions.
+ */
+export function useInstanceSegmenter<F extends BoxFormat, L>(
+  config: InstanceSegmenterModel<F, L>,
+  options?: { preventLoad?: boolean }
+) {
+  const { localPath, downloadProgress, downloadError } = useResourceDownload(
+    config.modelPath,
+    options?.preventLoad
+  );
+  const { model, error } = useModel(
+    createInstanceSegmenter<F, L>,
+    localPath ? { ...config, modelPath: localPath } : null,
+    [localPath]
+  );
+
+  return {
+    isReady: !!model,
+    error: downloadError || error,
+    downloadProgress,
+    localPath,
+    segmentInstances: model?.segmentInstances,
+    segmentInstancesWorklet: model?.segmentInstancesWorklet,
+    labels: config.opts.labels,
+  };
+}

--- a/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
+++ b/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
@@ -3,8 +3,8 @@ import { useResourceDownload } from './useResourceDownload';
 import {
   createInstanceSegmenter,
   type InstanceSegmenterModel,
+  type BoxFormat,
 } from '../extensions/cv/tasks/instanceSegmentation';
-import type { BoxFormat } from '../extensions/cv/ops/boxes';
 
 /**
  * React hook to load and run an instance segmentation model.

--- a/packages/react-native-executorch/src/index.ts
+++ b/packages/react-native-executorch/src/index.ts
@@ -2,6 +2,7 @@
 export * from './hooks/useClassifier';
 export * from './hooks/useStyleTransfer';
 export * from './hooks/useSemanticSegmenter';
+export * from './hooks/useInstanceSegmenter';
 export * from './hooks/useKeypointDetector';
 export * from './hooks/useObjectDetector';
 export * from './hooks/useTokenizer';
@@ -16,6 +17,7 @@ export * as constants from './constants';
 export * from './extensions/cv/tasks/classification';
 export * from './extensions/cv/tasks/styleTransfer';
 export * from './extensions/cv/tasks/semanticSegmentation';
+export * from './extensions/cv/tasks/instanceSegmentation';
 export * from './extensions/cv/tasks/keypointDetection';
 export * from './extensions/cv/tasks/objectDetection';
 export * from './extensions/nlp/tasks/tokenization';

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -3,6 +3,7 @@ import type { ObjectDetectorModel } from './extensions/cv/tasks/objectDetection'
 import type { StyleTransferModel } from './extensions/cv/tasks/styleTransfer';
 import type { SemanticSegmentationModel } from './extensions/cv/tasks/semanticSegmentation';
 import type { KeypointDetectorModel } from './extensions/cv/tasks/keypointDetection';
+import type { InstanceSegmenterModel } from './extensions/cv/tasks/instanceSegmentation';
 import {
   IMAGENET_NORM,
   IMAGENET1K_LABELS,
@@ -393,6 +394,141 @@ const RFDETR_KEYPOINT_MLX_FP32: KeypointDetectorModel<'xyxy', CocoLandmark> = {
 };
 
 // =============================================================================
+// Instance Segmentation
+// =============================================================================
+const FASTSAM_OPTS = {
+  labels: ['object'] as const,
+  boxFormat: 'xyxy' as const,
+  resizeMode: 'stretch' as const,
+  interpolation: 'linear' as const,
+  alpha: 1 / 255.0,
+  beta: 0.0,
+  defaultConfidenceThreshold: 0.5,
+  defaultIouThreshold: 0.9,
+  defaultMaskThreshold: 0.5,
+};
+const FASTSAM_S_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', 'object'> = {
+  modelPath: `${BASE_URL}-fast-sam/${NEXT_VERSION_TAG}/s/xnnpack/fast_sam_s_xnnpack_fp32.pte`,
+  opts: FASTSAM_OPTS,
+};
+const FASTSAM_S_COREML_FP32: InstanceSegmenterModel<'xyxy', 'object'> = {
+  modelPath: `${BASE_URL}-fast-sam/${NEXT_VERSION_TAG}/s/coreml/fast_sam_s_coreml_fp32.pte`,
+  opts: FASTSAM_OPTS,
+};
+const FASTSAM_S_COREML_FP16: InstanceSegmenterModel<'xyxy', 'object'> = {
+  modelPath: `${BASE_URL}-fast-sam/${NEXT_VERSION_TAG}/s/coreml/fast_sam_s_coreml_fp16.pte`,
+  opts: FASTSAM_OPTS,
+};
+const FASTSAM_X_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', 'object'> = {
+  modelPath: `${BASE_URL}-fast-sam/${NEXT_VERSION_TAG}/x/xnnpack/fast_sam_x_xnnpack_fp32.pte`,
+  opts: FASTSAM_OPTS,
+};
+const FASTSAM_X_COREML_FP32: InstanceSegmenterModel<'xyxy', 'object'> = {
+  modelPath: `${BASE_URL}-fast-sam/${NEXT_VERSION_TAG}/x/coreml/fast_sam_x_coreml_fp32.pte`,
+  opts: FASTSAM_OPTS,
+};
+const FASTSAM_X_COREML_FP16: InstanceSegmenterModel<'xyxy', 'object'> = {
+  modelPath: `${BASE_URL}-fast-sam/${NEXT_VERSION_TAG}/x/coreml/fast_sam_x_coreml_fp16.pte`,
+  opts: FASTSAM_OPTS,
+};
+
+const RFDETR_NANO_SEG_OPTS = {
+  labels: COCO_CLASSES,
+  boxFormat: 'xyxy' as const,
+  resizeMode: 'stretch' as const,
+  interpolation: 'linear' as const,
+  ...IMAGENET_NORM,
+  defaultConfidenceThreshold: 0.5,
+  defaultIouThreshold: 0.55,
+  defaultMaskThreshold: 0.5,
+};
+const RFDETR_NANO_SEG_COREML_INT8: InstanceSegmenterModel<'xyxy', CocoClass> = {
+  modelPath: `${BASE_URL}-rfdetr-nano-segmentation/${NEXT_VERSION_TAG}/coreml/rfdetr_nano_coreml_int8.pte`,
+  opts: RFDETR_NANO_SEG_OPTS,
+};
+const RFDETR_NANO_SEG_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClass> = {
+  modelPath: `${BASE_URL}-rfdetr-nano-segmentation/${NEXT_VERSION_TAG}/xnnpack/rfdetr_nano_xnnpack_fp32.pte`,
+  opts: RFDETR_NANO_SEG_OPTS,
+};
+
+const YOLO26_SEG_OPTS = {
+  labels: COCO_CLASSES_YOLO,
+  boxFormat: 'xyxy' as const,
+  resizeMode: 'stretch' as const,
+  interpolation: 'linear' as const,
+  alpha: 1 / 255.0,
+  beta: 0.0,
+  defaultConfidenceThreshold: 0.25,
+  defaultIouThreshold: 0.7,
+  defaultMaskThreshold: 0.5,
+};
+
+const YOLO26_NANO_SEG_384_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
+  modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/n/xnnpack/yolo26_seg_n_384_xnnpack_fp32.pte`,
+  opts: YOLO26_SEG_OPTS,
+};
+const YOLO26_NANO_SEG_512_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
+  modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/n/xnnpack/yolo26_seg_n_512_xnnpack_fp32.pte`,
+  opts: YOLO26_SEG_OPTS,
+};
+const YOLO26_NANO_SEG_640_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
+  modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/n/xnnpack/yolo26_seg_n_640_xnnpack_fp32.pte`,
+  opts: YOLO26_SEG_OPTS,
+};
+
+const YOLO26_SMALL_SEG_384_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
+  modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/s/xnnpack/yolo26_seg_s_384_xnnpack_fp32.pte`,
+  opts: YOLO26_SEG_OPTS,
+};
+const YOLO26_SMALL_SEG_512_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
+  modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/s/xnnpack/yolo26_seg_s_512_xnnpack_fp32.pte`,
+  opts: YOLO26_SEG_OPTS,
+};
+const YOLO26_SMALL_SEG_640_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
+  modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/s/xnnpack/yolo26_seg_s_640_xnnpack_fp32.pte`,
+  opts: YOLO26_SEG_OPTS,
+};
+
+const YOLO26_MEDIUM_SEG_384_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
+  modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/m/xnnpack/yolo26_seg_m_384_xnnpack_fp32.pte`,
+  opts: YOLO26_SEG_OPTS,
+};
+const YOLO26_MEDIUM_SEG_512_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
+  modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/m/xnnpack/yolo26_seg_m_512_xnnpack_fp32.pte`,
+  opts: YOLO26_SEG_OPTS,
+};
+const YOLO26_MEDIUM_SEG_640_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
+  modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/m/xnnpack/yolo26_seg_m_640_xnnpack_fp32.pte`,
+  opts: YOLO26_SEG_OPTS,
+};
+
+const YOLO26_LARGE_SEG_384_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
+  modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/l/xnnpack/yolo26_seg_l_384_xnnpack_fp32.pte`,
+  opts: YOLO26_SEG_OPTS,
+};
+const YOLO26_LARGE_SEG_512_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
+  modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/l/xnnpack/yolo26_seg_l_512_xnnpack_fp32.pte`,
+  opts: YOLO26_SEG_OPTS,
+};
+const YOLO26_LARGE_SEG_640_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
+  modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/l/xnnpack/yolo26_seg_l_640_xnnpack_fp32.pte`,
+  opts: YOLO26_SEG_OPTS,
+};
+
+const YOLO26_XLARGE_SEG_384_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
+  modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/x/xnnpack/yolo26_seg_x_384_xnnpack_fp32.pte`,
+  opts: YOLO26_SEG_OPTS,
+};
+const YOLO26_XLARGE_SEG_512_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
+  modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/x/xnnpack/yolo26_seg_x_512_xnnpack_fp32.pte`,
+  opts: YOLO26_SEG_OPTS,
+};
+const YOLO26_XLARGE_SEG_640_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
+  modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/x/xnnpack/yolo26_seg_x_640_xnnpack_fp32.pte`,
+  opts: YOLO26_SEG_OPTS,
+};
+
+// =============================================================================
 // Tokenizers
 // =============================================================================
 const ALL_MINILM_L6_V2_TOKENIZER = `${BASE_URL}-all-MiniLM-L6-v2/${VERSION_TAG}/tokenizer.json`;
@@ -542,6 +678,58 @@ export const models = {
       XNNPACK_FP32: RFDETR_KEYPOINT_XNNPACK_FP32,
       COREML_FP32: RFDETR_KEYPOINT_COREML_FP32,
       MLX_FP32: RFDETR_KEYPOINT_MLX_FP32,
+    },
+  },
+  instanceSegmentation: {
+    FASTSAM: {
+      S: {
+        XNNPACK_FP32: FASTSAM_S_XNNPACK_FP32,
+        COREML_FP32: FASTSAM_S_COREML_FP32,
+        COREML_FP16: FASTSAM_S_COREML_FP16,
+      },
+      X: {
+        XNNPACK_FP32: FASTSAM_X_XNNPACK_FP32,
+        COREML_FP32: FASTSAM_X_COREML_FP32,
+        COREML_FP16: FASTSAM_X_COREML_FP16,
+      },
+    },
+    RFDETR_NANO: {
+      ...RFDETR_NANO_SEG_COREML_INT8,
+      COREML_INT8: RFDETR_NANO_SEG_COREML_INT8,
+      XNNPACK_FP32: RFDETR_NANO_SEG_XNNPACK_FP32,
+    },
+    YOLO26: {
+      ...YOLO26_NANO_SEG_384_XNNPACK_FP32,
+      NANO: {
+        ...YOLO26_NANO_SEG_384_XNNPACK_FP32,
+        SIZE_384: { XNNPACK_FP32: YOLO26_NANO_SEG_384_XNNPACK_FP32 },
+        SIZE_512: { XNNPACK_FP32: YOLO26_NANO_SEG_512_XNNPACK_FP32 },
+        SIZE_640: { XNNPACK_FP32: YOLO26_NANO_SEG_640_XNNPACK_FP32 },
+      },
+      SMALL: {
+        ...YOLO26_SMALL_SEG_384_XNNPACK_FP32,
+        SIZE_384: { XNNPACK_FP32: YOLO26_SMALL_SEG_384_XNNPACK_FP32 },
+        SIZE_512: { XNNPACK_FP32: YOLO26_SMALL_SEG_512_XNNPACK_FP32 },
+        SIZE_640: { XNNPACK_FP32: YOLO26_SMALL_SEG_640_XNNPACK_FP32 },
+      },
+      MEDIUM: {
+        ...YOLO26_MEDIUM_SEG_384_XNNPACK_FP32,
+        SIZE_384: { XNNPACK_FP32: YOLO26_MEDIUM_SEG_384_XNNPACK_FP32 },
+        SIZE_512: { XNNPACK_FP32: YOLO26_MEDIUM_SEG_512_XNNPACK_FP32 },
+        SIZE_640: { XNNPACK_FP32: YOLO26_MEDIUM_SEG_640_XNNPACK_FP32 },
+      },
+      LARGE: {
+        ...YOLO26_LARGE_SEG_384_XNNPACK_FP32,
+        SIZE_384: { XNNPACK_FP32: YOLO26_LARGE_SEG_384_XNNPACK_FP32 },
+        SIZE_512: { XNNPACK_FP32: YOLO26_LARGE_SEG_512_XNNPACK_FP32 },
+        SIZE_640: { XNNPACK_FP32: YOLO26_LARGE_SEG_640_XNNPACK_FP32 },
+      },
+      XLARGE: {
+        ...YOLO26_XLARGE_SEG_384_XNNPACK_FP32,
+        SIZE_384: { XNNPACK_FP32: YOLO26_XLARGE_SEG_384_XNNPACK_FP32 },
+        SIZE_512: { XNNPACK_FP32: YOLO26_XLARGE_SEG_512_XNNPACK_FP32 },
+        SIZE_640: { XNNPACK_FP32: YOLO26_XLARGE_SEG_640_XNNPACK_FP32 },
+      },
     },
   },
   tokenizer: {

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -683,11 +683,13 @@ export const models = {
   instanceSegmentation: {
     FASTSAM: {
       S: {
+        ...FASTSAM_S_XNNPACK_FP32,
         XNNPACK_FP32: FASTSAM_S_XNNPACK_FP32,
         COREML_FP32: FASTSAM_S_COREML_FP32,
         COREML_FP16: FASTSAM_S_COREML_FP16,
       },
       X: {
+        ...FASTSAM_X_XNNPACK_FP32,
         XNNPACK_FP32: FASTSAM_X_XNNPACK_FP32,
         COREML_FP32: FASTSAM_X_COREML_FP32,
         COREML_FP16: FASTSAM_X_COREML_FP16,


### PR DESCRIPTION
## Description

Adds instance segmentation task pipeline and corresponding example screen in computer-vision app.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

- [ ] Build computer vision app on both Android and iOS
- [ ] Test the newly added instance segmentation screen
- [ ] Check the modified HF repos:
          - https://huggingface.co/software-mansion/react-native-executorch-fast-sam
          - https://huggingface.co/software-mansion/react-native-executorch-rfdetr-nano-segmentation
          - https://huggingface.co/software-mansion/react-native-executorch-fast-sam

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

Closes #1238 

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

Can be merged only after #1287 
