### PR TITLE
[RNE Rewrite] feat: add input validation and JSI conversion utilities

### DIFF
--- a/packages/react-native-executorch/cpp/core/conversions.cpp
+++ b/packages/react-native-executorch/cpp/core/conversions.cpp
@@ -44,14 +44,13 @@ uint8_t asType<uint8_t>(jsi::Runtime &rt, const std::string &ctx, const jsi::Val
     return static_cast<uint8_t>(v);
 }
 
-template <>
-size_t asType<size_t>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
-    double v = asType<double>(rt, ctx, val);
-    if (std::isnan(v) || v < 0.0) {
-        throw jsi::JSError(rt, ctx + " must be a non-negative integer");
-    }
-    return static_cast<size_t>(v);
-}
+// Note: size_t is intentionally not specialised here.
+// On Linux x86_64 size_t and uint64_t are both `unsigned long`, so adding a
+// size_t specialisation would produce a duplicate-explicit-specialisation ODR
+// error on that platform. asType<size_t> routes through the uint64_t
+// specialisation on Linux (same type) and is a separate instantiation on
+// macOS (where uint64_t is unsigned long long). Either way the semantics —
+// non-negative double → cast — are identical.
 
 template <>
 bool asType<bool>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {

--- a/packages/react-native-executorch/cpp/core/conversions.cpp
+++ b/packages/react-native-executorch/cpp/core/conversions.cpp
@@ -92,4 +92,28 @@ jsi::ArrayBuffer asType<jsi::ArrayBuffer>(jsi::Runtime &rt, const std::string &c
     return val.asObject(rt).getArrayBuffer(rt);
 }
 
+template <>
+jsi::Object asType<jsi::Object>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
+    if (!val.isObject()) {
+        throw jsi::JSError(rt, ctx + " must be an object");
+    }
+    return val.asObject(rt);
+}
+
+template <>
+jsi::Array asType<jsi::Array>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
+    if (!val.isObject() || !val.asObject(rt).isArray(rt)) {
+        throw jsi::JSError(rt, ctx + " must be an Array");
+    }
+    return val.asObject(rt).asArray(rt);
+}
+
+template <>
+jsi::Function asType<jsi::Function>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
+    if (!val.isObject() || !val.asObject(rt).isFunction(rt)) {
+        throw jsi::JSError(rt, ctx + " must be a function");
+    }
+    return val.asObject(rt).asFunction(rt);
+}
+
 } // namespace rnexecutorch::core::conversions

--- a/packages/react-native-executorch/cpp/core/conversions.cpp
+++ b/packages/react-native-executorch/cpp/core/conversions.cpp
@@ -1,0 +1,71 @@
+#include "conversions.h"
+#include <cmath>
+
+namespace rnexecutorch::core::conversions {
+
+template <>
+double asType<double>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
+    if (!val.isNumber()) {
+        throw jsi::JSError(rt, ctx + " must be a number");
+    }
+    return val.asNumber();
+}
+
+template <>
+float asType<float>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
+    return static_cast<float>(asType<double>(rt, ctx, val));
+}
+
+template <>
+int32_t asType<int32_t>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
+    return static_cast<int32_t>(asType<double>(rt, ctx, val));
+}
+
+template <>
+int64_t asType<int64_t>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
+    return static_cast<int64_t>(asType<double>(rt, ctx, val));
+}
+
+template <>
+uint64_t asType<uint64_t>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
+    double v = asType<double>(rt, ctx, val);
+    if (std::isnan(v) || v < 0.0) {
+        throw jsi::JSError(rt, ctx + " must be a non-negative integer");
+    }
+    return static_cast<uint64_t>(v);
+}
+
+template <>
+uint8_t asType<uint8_t>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
+    double v = asType<double>(rt, ctx, val);
+    if (std::isnan(v) || v < 0.0 || v > 255.0) {
+        throw jsi::JSError(rt, ctx + " must be between 0 and 255");
+    }
+    return static_cast<uint8_t>(v);
+}
+
+template <>
+size_t asType<size_t>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
+    double v = asType<double>(rt, ctx, val);
+    if (std::isnan(v) || v < 0.0) {
+        throw jsi::JSError(rt, ctx + " must be a non-negative integer");
+    }
+    return static_cast<size_t>(v);
+}
+
+template <>
+bool asType<bool>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
+    if (!val.isBool()) {
+        throw jsi::JSError(rt, ctx + " must be a boolean");
+    }
+    return val.asBool();
+}
+
+template <>
+std::string asType<std::string>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
+    if (!val.isString()) {
+        throw jsi::JSError(rt, ctx + " must be a string");
+    }
+    return val.asString(rt).utf8(rt);
+}
+} // namespace rnexecutorch::core::conversions

--- a/packages/react-native-executorch/cpp/core/conversions.cpp
+++ b/packages/react-native-executorch/cpp/core/conversions.cpp
@@ -1,7 +1,18 @@
 #include "conversions.h"
 #include <cmath>
+#include <limits>
 
 namespace rnexecutorch::core::conversions {
+
+constexpr double kMaxInt64Double = static_cast<double>(std::numeric_limits<int64_t>::max());
+constexpr double kMinInt64Double = static_cast<double>(std::numeric_limits<int64_t>::min());
+constexpr double kMaxUint64Double = static_cast<double>(std::numeric_limits<uint64_t>::max());
+
+constexpr double kMinInt32Double = static_cast<double>(std::numeric_limits<int32_t>::min());
+constexpr double kMaxInt32Double = static_cast<double>(std::numeric_limits<int32_t>::max());
+
+constexpr double kMinUint8Double = static_cast<double>(std::numeric_limits<uint8_t>::min());
+constexpr double kMaxUint8Double = static_cast<double>(std::numeric_limits<uint8_t>::max());
 
 template <>
 double asType<double>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
@@ -18,18 +29,26 @@ float asType<float>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &
 
 template <>
 int32_t asType<int32_t>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
-    return static_cast<int32_t>(asType<double>(rt, ctx, val));
+    double v = asType<double>(rt, ctx, val);
+    if (std::isnan(v) || std::isinf(v) || v != std::trunc(v) || v < kMinInt32Double || v > kMaxInt32Double) {
+        throw jsi::JSError(rt, ctx + " must be a 32-bit integer");
+    }
+    return static_cast<int32_t>(v);
 }
 
 template <>
 int64_t asType<int64_t>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
-    return static_cast<int64_t>(asType<double>(rt, ctx, val));
+    double v = asType<double>(rt, ctx, val);
+    if (std::isnan(v) || std::isinf(v) || v != std::trunc(v) || v < kMinInt64Double || v >= kMaxInt64Double) {
+        throw jsi::JSError(rt, ctx + " must be a 64-bit integer");
+    }
+    return static_cast<int64_t>(v);
 }
 
 template <>
 uint64_t asType<uint64_t>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
     double v = asType<double>(rt, ctx, val);
-    if (std::isnan(v) || v < 0.0) {
+    if (std::isnan(v) || std::isinf(v) || v != std::trunc(v) || v < 0.0 || v >= kMaxUint64Double) {
         throw jsi::JSError(rt, ctx + " must be a non-negative integer");
     }
     return static_cast<uint64_t>(v);
@@ -38,19 +57,11 @@ uint64_t asType<uint64_t>(jsi::Runtime &rt, const std::string &ctx, const jsi::V
 template <>
 uint8_t asType<uint8_t>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
     double v = asType<double>(rt, ctx, val);
-    if (std::isnan(v) || v < 0.0 || v > 255.0) {
-        throw jsi::JSError(rt, ctx + " must be between 0 and 255");
+    if (std::isnan(v) || std::isinf(v) || v != std::trunc(v) || v < kMinUint8Double || v > kMaxUint8Double) {
+        throw jsi::JSError(rt, ctx + " must be an integer between 0 and 255");
     }
     return static_cast<uint8_t>(v);
 }
-
-// Note: size_t is intentionally not specialised here.
-// On Linux x86_64 size_t and uint64_t are both `unsigned long`, so adding a
-// size_t specialisation would produce a duplicate-explicit-specialisation ODR
-// error on that platform. asType<size_t> routes through the uint64_t
-// specialisation on Linux (same type) and is a separate instantiation on
-// macOS (where uint64_t is unsigned long long). Either way the semantics —
-// non-negative double → cast — are identical.
 
 template <>
 bool asType<bool>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
@@ -67,4 +78,18 @@ std::string asType<std::string>(jsi::Runtime &rt, const std::string &ctx, const 
     }
     return val.asString(rt).utf8(rt);
 }
+
+template <>
+jsi::Value asType<jsi::Value>(jsi::Runtime &rt, const std::string & /*ctx*/, const jsi::Value &val) {
+    return jsi::Value(rt, val);
+}
+
+template <>
+jsi::ArrayBuffer asType<jsi::ArrayBuffer>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
+    if (!val.isObject() || !val.asObject(rt).isArrayBuffer(rt)) {
+        throw jsi::JSError(rt, ctx + " must be an ArrayBuffer");
+    }
+    return val.asObject(rt).getArrayBuffer(rt);
+}
+
 } // namespace rnexecutorch::core::conversions

--- a/packages/react-native-executorch/cpp/core/conversions.cpp
+++ b/packages/react-native-executorch/cpp/core/conversions.cpp
@@ -4,15 +4,15 @@
 
 namespace rnexecutorch::core::conversions {
 
-constexpr double kMaxInt64Double = static_cast<double>(std::numeric_limits<int64_t>::max());
-constexpr double kMinInt64Double = static_cast<double>(std::numeric_limits<int64_t>::min());
-constexpr double kMaxUint64Double = static_cast<double>(std::numeric_limits<uint64_t>::max());
+constexpr auto kMaxInt64Double = static_cast<double>(std::numeric_limits<int64_t>::max());
+constexpr auto kMinInt64Double = static_cast<double>(std::numeric_limits<int64_t>::min());
+constexpr auto kMaxUint64Double = static_cast<double>(std::numeric_limits<uint64_t>::max());
 
-constexpr double kMinInt32Double = static_cast<double>(std::numeric_limits<int32_t>::min());
-constexpr double kMaxInt32Double = static_cast<double>(std::numeric_limits<int32_t>::max());
+constexpr auto kMinInt32Double = static_cast<double>(std::numeric_limits<int32_t>::min());
+constexpr auto kMaxInt32Double = static_cast<double>(std::numeric_limits<int32_t>::max());
 
-constexpr double kMinUint8Double = static_cast<double>(std::numeric_limits<uint8_t>::min());
-constexpr double kMaxUint8Double = static_cast<double>(std::numeric_limits<uint8_t>::max());
+constexpr auto kMinUint8Double = static_cast<double>(std::numeric_limits<uint8_t>::min());
+constexpr auto kMaxUint8Double = static_cast<double>(std::numeric_limits<uint8_t>::max());
 
 template <>
 double asType<double>(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {

--- a/packages/react-native-executorch/cpp/core/conversions.h
+++ b/packages/react-native-executorch/cpp/core/conversions.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include <jsi/jsi.h>
+
+namespace rnexecutorch::core::conversions {
+namespace jsi = facebook::jsi;
+
+template <typename T>
+T asType(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val);
+
+template <>
+inline jsi::Value asType<jsi::Value>(jsi::Runtime &rt, const std::string & /*ctx*/, const jsi::Value &val) {
+    return jsi::Value(rt, val);
+}
+
+template <typename T>
+T getRequiredProperty(jsi::Runtime &rt, const std::string &ctx, const jsi::Object &obj, const std::string &propName) {
+    if (!obj.hasProperty(rt, propName.c_str())) {
+        throw jsi::JSError(rt, std::format("{}: option '{}' is required", ctx, propName));
+    }
+    return asType<T>(rt, std::format("{}: option '{}'", ctx, propName), obj.getProperty(rt, propName.c_str()));
+}
+
+template <typename T>
+std::optional<T> getOptionalProperty(jsi::Runtime &rt, const std::string &ctx, const jsi::Object &obj, const std::string &propName) {
+    if (!obj.hasProperty(rt, propName.c_str())) {
+        return std::nullopt;
+    }
+    auto val = obj.getProperty(rt, propName.c_str());
+    if (val.isUndefined() || val.isNull()) {
+        return std::nullopt;
+    }
+    return asType<T>(rt, std::format("{}: option '{}'", ctx, propName), val);
+}
+
+template <typename T>
+std::vector<T> asVector(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
+    if (!val.isObject() || !val.asObject(rt).isArray(rt)) {
+        throw jsi::JSError(rt, std::format("{} must be an Array", ctx));
+    }
+    auto arr = val.asObject(rt).asArray(rt);
+    std::vector<T> vec;
+    const size_t len = arr.size(rt);
+    vec.reserve(len);
+    for (size_t i = 0; i < len; ++i) {
+        vec.push_back(asType<T>(rt, std::format("{}[{}]", ctx, i), arr.getValueAtIndex(rt, i)));
+    }
+    return vec;
+}
+
+template <typename T>
+jsi::Array toJsiArray(jsi::Runtime &rt, const std::vector<T> &vec) {
+    jsi::Array arr(rt, vec.size());
+    for (size_t i = 0; i < vec.size(); ++i) {
+        if constexpr (std::is_same_v<T, std::string>) {
+            arr.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, vec[i]));
+        } else if constexpr (std::is_same_v<T, bool>) {
+            arr.setValueAtIndex(rt, i, jsi::Value(vec[i]));
+        } else {
+            arr.setValueAtIndex(rt, i, jsi::Value(static_cast<double>(vec[i])));
+        }
+    }
+    return arr;
+}
+
+} // namespace rnexecutorch::core::conversions

--- a/packages/react-native-executorch/cpp/core/conversions.h
+++ b/packages/react-native-executorch/cpp/core/conversions.h
@@ -16,17 +16,12 @@ namespace jsi = facebook::jsi;
 template <typename T>
 T asType(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val);
 
-template <>
-inline jsi::Value asType<jsi::Value>(jsi::Runtime &rt, const std::string & /*ctx*/, const jsi::Value &val) {
-    return jsi::Value(rt, val);
-}
-
 template <typename T>
 T getRequiredProperty(jsi::Runtime &rt, const std::string &ctx, const jsi::Object &obj, const std::string &propName) {
     if (!obj.hasProperty(rt, propName.c_str())) {
-        throw jsi::JSError(rt, std::format("{}: option '{}' is required", ctx, propName));
+        throw jsi::JSError(rt, ctx + ": option '" + propName + "' is required");
     }
-    return asType<T>(rt, std::format("{}: option '{}'", ctx, propName), obj.getProperty(rt, propName.c_str()));
+    return asType<T>(rt, ctx + ": option '" + propName + "'", obj.getProperty(rt, propName.c_str()));
 }
 
 template <typename T>
@@ -38,20 +33,20 @@ std::optional<T> getOptionalProperty(jsi::Runtime &rt, const std::string &ctx, c
     if (val.isUndefined() || val.isNull()) {
         return std::nullopt;
     }
-    return asType<T>(rt, std::format("{}: option '{}'", ctx, propName), val);
+    return asType<T>(rt, ctx + ": option '" + propName + "'", val);
 }
 
 template <typename T>
 std::vector<T> asVector(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
     if (!val.isObject() || !val.asObject(rt).isArray(rt)) {
-        throw jsi::JSError(rt, std::format("{} must be an Array", ctx));
+        throw jsi::JSError(rt, ctx + " must be an Array");
     }
     auto arr = val.asObject(rt).asArray(rt);
     std::vector<T> vec;
     const size_t len = arr.size(rt);
     vec.reserve(len);
     for (size_t i = 0; i < len; ++i) {
-        vec.push_back(asType<T>(rt, std::format("{}[{}]", ctx, i), arr.getValueAtIndex(rt, i)));
+        vec.push_back(asType<T>(rt, ctx + "[" + std::to_string(i) + "]", arr.getValueAtIndex(rt, i)));
     }
     return vec;
 }

--- a/packages/react-native-executorch/cpp/core/conversions.h
+++ b/packages/react-native-executorch/cpp/core/conversions.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <format>
 #include <optional>
 #include <string>
 #include <type_traits>
@@ -59,9 +60,9 @@ DECLARE_ASTYPE_SPECIALIZATION(jsi::ArrayBuffer);
 template <typename T>
 T getRequiredProperty(jsi::Runtime &rt, const std::string &ctx, const jsi::Object &obj, const std::string &propName) {
     if (!obj.hasProperty(rt, propName.c_str())) {
-        throw jsi::JSError(rt, ctx + ": option '" + propName + "' is required");
+        throw jsi::JSError(rt, std::format("{}: option '{}' is required", ctx, propName));
     }
-    return asType<T>(rt, ctx + ": option '" + propName + "'", obj.getProperty(rt, propName.c_str()));
+    return asType<T>(rt, std::format("{}: option '{}'", ctx, propName), obj.getProperty(rt, propName.c_str()));
 }
 
 /**
@@ -85,7 +86,7 @@ std::optional<T> getOptionalProperty(jsi::Runtime &rt, const std::string &ctx, c
     if (val.isUndefined() || val.isNull()) {
         return std::nullopt;
     }
-    return asType<T>(rt, ctx + ": option '" + propName + "'", val);
+    return asType<T>(rt, std::format("{}: option '{}'", ctx, propName), val);
 }
 
 /**
@@ -106,7 +107,7 @@ std::vector<T> asVector(jsi::Runtime &rt, const std::string &ctx, const jsi::Val
     const size_t len = arr.size(rt);
     vec.reserve(len);
     for (size_t i = 0; i < len; ++i) {
-        vec.push_back(asType<T>(rt, ctx + "[" + std::to_string(i) + "]", arr.getValueAtIndex(rt, i)));
+        vec.push_back(asType<T>(rt, std::format("{}[{}]", ctx, i), arr.getValueAtIndex(rt, i)));
     }
     return vec;
 }

--- a/packages/react-native-executorch/cpp/core/conversions.h
+++ b/packages/react-native-executorch/cpp/core/conversions.h
@@ -2,7 +2,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <format>
 #include <optional>
 #include <string>
 #include <type_traits>
@@ -13,9 +12,50 @@
 namespace rnexecutorch::core::conversions {
 namespace jsi = facebook::jsi;
 
+/**
+ * Converts a facebook::jsi::Value to a specified target C++ or JSI type. Throws
+ * a facebook::jsi::JSError with contextual error info if the conversion fails.
+ *
+ * @tparam T The target type to convert to.
+ * @param rt The JSI runtime instance.
+ * @param ctx Context description used to generate helpful error messages.
+ * @param val The JSI value to convert.
+ * @return The converted value of type T.
+ */
 template <typename T>
-T asType(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val);
+T asType(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) = delete;
 
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage): macro is used for succinct template specialization declarations
+#define DECLARE_ASTYPE_SPECIALIZATION(Type) \
+    template <>                             \
+    Type asType<Type>(jsi::Runtime & rt, const std::string &ctx, const jsi::Value &val)
+DECLARE_ASTYPE_SPECIALIZATION(double);
+DECLARE_ASTYPE_SPECIALIZATION(float);
+DECLARE_ASTYPE_SPECIALIZATION(int32_t);
+DECLARE_ASTYPE_SPECIALIZATION(int64_t);
+DECLARE_ASTYPE_SPECIALIZATION(uint64_t);
+DECLARE_ASTYPE_SPECIALIZATION(uint8_t);
+DECLARE_ASTYPE_SPECIALIZATION(bool);
+DECLARE_ASTYPE_SPECIALIZATION(std::string);
+DECLARE_ASTYPE_SPECIALIZATION(jsi::Value);
+DECLARE_ASTYPE_SPECIALIZATION(jsi::Object);
+DECLARE_ASTYPE_SPECIALIZATION(jsi::Array);
+DECLARE_ASTYPE_SPECIALIZATION(jsi::Function);
+DECLARE_ASTYPE_SPECIALIZATION(jsi::ArrayBuffer);
+#undef DECLARE_ASTYPE_SPECIALIZATION
+
+/**
+ * Retrieves a required property from a JSI object, converting it to the
+ * specified type. Throws a facebook::jsi::JSError if the property is missing or
+ * of an incorrect type.
+ *
+ * @tparam T The target type to convert the property to.
+ * @param rt The JSI runtime instance.
+ * @param ctx Context description used for error messages.
+ * @param obj The JSI object containing the property.
+ * @param propName The name of the property to retrieve.
+ * @return The converted property value.
+ */
 template <typename T>
 T getRequiredProperty(jsi::Runtime &rt, const std::string &ctx, const jsi::Object &obj, const std::string &propName) {
     if (!obj.hasProperty(rt, propName.c_str())) {
@@ -24,6 +64,18 @@ T getRequiredProperty(jsi::Runtime &rt, const std::string &ctx, const jsi::Objec
     return asType<T>(rt, ctx + ": option '" + propName + "'", obj.getProperty(rt, propName.c_str()));
 }
 
+/**
+ * Retrieves an optional property from a JSI object, returning std::nullopt if
+ * the property is missing, null, or undefined. Throws a facebook::jsi::JSError
+ * if the property exists but cannot be converted to the target type.
+ *
+ * @tparam T The target type to convert the property to if present.
+ * @param rt The JSI runtime instance.
+ * @param ctx Context description used for error messages.
+ * @param obj The JSI object containing the property.
+ * @param propName The name of the property to retrieve.
+ * @return An optional containing the converted property value, or std::nullopt.
+ */
 template <typename T>
 std::optional<T> getOptionalProperty(jsi::Runtime &rt, const std::string &ctx, const jsi::Object &obj, const std::string &propName) {
     if (!obj.hasProperty(rt, propName.c_str())) {
@@ -36,12 +88,20 @@ std::optional<T> getOptionalProperty(jsi::Runtime &rt, const std::string &ctx, c
     return asType<T>(rt, ctx + ": option '" + propName + "'", val);
 }
 
+/**
+ * Converts a JSI Array to a std::vector of the specified type. Converts each
+ * element of the array individually and propagates index details in the error
+ * context.
+ *
+ * @tparam T The target element type.
+ * @param rt The JSI runtime instance.
+ * @param ctx Context description used for error messages.
+ * @param val The JSI value (must be an Array).
+ * @return A std::vector containing the converted elements.
+ */
 template <typename T>
 std::vector<T> asVector(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
-    if (!val.isObject() || !val.asObject(rt).isArray(rt)) {
-        throw jsi::JSError(rt, ctx + " must be an Array");
-    }
-    auto arr = val.asObject(rt).asArray(rt);
+    auto arr = asType<jsi::Array>(rt, ctx, val);
     std::vector<T> vec;
     const size_t len = arr.size(rt);
     vec.reserve(len);
@@ -51,6 +111,15 @@ std::vector<T> asVector(jsi::Runtime &rt, const std::string &ctx, const jsi::Val
     return vec;
 }
 
+/**
+ * Converts a std::vector of values to a new facebook::jsi::Array.
+ * Handles strings, booleans, and numeric types appropriately.
+ *
+ * @tparam T The element type in the vector.
+ * @param rt The JSI runtime instance.
+ * @param vec The source vector to convert.
+ * @return A new facebook::jsi::Array containing the elements from the vector.
+ */
 template <typename T>
 jsi::Array toJsiArray(jsi::Runtime &rt, const std::vector<T> &vec) {
     jsi::Array arr(rt, vec.size());

--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -291,30 +291,25 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                                 output.toTensor().const_data_ptr(),
                                 output.toTensor().nbytes());
 
-                    jsOutputArray.setValueAtIndex(rt, index, jsi::Object::createFromHostObject(rt, tensorHostObject));
+                    jsOutputArray.setValueAtIndex(rt, index, val);
                     ++tensorOutputIdx;
                     break;
                 }
-                case executorch::runtime::Tag::Double: {
+                case executorch::runtime::Tag::Double:
                     jsOutputArray.setValueAtIndex(rt, index, output.toDouble());
                     break;
-                }
-                case executorch::runtime::Tag::Int: {
+                case executorch::runtime::Tag::Int:
                     jsOutputArray.setValueAtIndex(rt, index, static_cast<double>(output.toInt()));
                     break;
-                }
-                case executorch::runtime::Tag::Bool: {
+                case executorch::runtime::Tag::Bool:
                     jsOutputArray.setValueAtIndex(rt, index, output.toBool());
                     break;
-                }
-                case executorch::runtime::Tag::None: {
+                case executorch::runtime::Tag::None:
                     jsOutputArray.setValueAtIndex(rt, index, jsi::Value::null());
                     break;
-                }
-                default: {
+                default:
                     throw jsi::JSError(rt, std::format("execute: Unsupported return type: {}",
                                                        executorch::runtime::tag_to_string(output.tag)));
-                }
                 }
 
                 ++index;

--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -119,10 +119,6 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 throw jsi::JSError(rt, "getMethodMeta: Usage: getMethodMeta(methodName)");
             }
 
-            if (!args[0].isString()) {
-                throw jsi::JSError(rt, "getMethodMeta: Expected methodName to be a string");
-            }
-
             std::unique_lock<std::mutex> lock(self->mutex_, std::try_to_lock);
             if (!lock.owns_lock()) {
                 throw jsi::JSError(rt, "getMethodMeta: Model is currently in use");
@@ -203,6 +199,13 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
 
             auto methodName = conversions::asType<std::string>(rt, "execute: methodName", args[0]);
             auto methodMeta = getOrThrow(rt, "execute", self->etModule_->method_meta(methodName));
+
+            if (!args[1].isObject() || !args[1].asObject(rt).isArray(rt)) {
+                throw jsi::JSError(rt, "execute: Expected inputs to be an Array");
+            }
+            if (!args[2].isObject() || !args[2].asObject(rt).isArray(rt)) {
+                throw jsi::JSError(rt, "execute: Expected outputTensors to be an Array");
+            }
 
             auto inputsArray = args[1].asObject(rt).asArray(rt);
             auto outputTensorsArray = args[2].asObject(rt).asArray(rt);

--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -1,8 +1,9 @@
 #include "model.h"
 #include "dtype.h"
-#include "tensor.h"
+#include "tensor_helpers.h"
 
 #include <chrono>
+#include <format>
 #include <unordered_set>
 
 #include <executorch/runtime/backend/interface.h>
@@ -11,11 +12,19 @@
 
 namespace rnexecutorch::core::model {
 namespace jsi = facebook::jsi;
+namespace types = rnexecutorch::core::types;
+namespace conversions = rnexecutorch::core::conversions;
+
 using TensorHostObject = rnexecutorch::core::tensor::TensorHostObject;
 
 ModelHostObject::ModelHostObject(const std::string &modelPath)
     : modelPath_(modelPath),
       etModule_(std::make_unique<executorch::extension::Module>(modelPath)) {
+    auto error = etModule_->load();
+    if (!etModule_->is_loaded()) {
+        const std::string errorMsg = executorch::runtime::to_string(error);
+        throw std::runtime_error(std::format("Failed to load model: {}", errorMsg));
+    }
 }
 
 jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
@@ -79,11 +88,11 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 throw jsi::JSError(rt, "getMethodMeta: Model has been disposed");
             }
 
-            auto methodName = args[0].asString(rt).utf8(rt);
+            auto methodName = conversions::asType<std::string>(rt, "getMethodMeta: methodName", args[0]);
             auto methodMeta = self->etModule_->method_meta(methodName);
             if (!methodMeta.ok()) {
                 const std::string errorMsg = executorch::runtime::to_string(methodMeta.error());
-                throw jsi::JSError(rt, "getMethodMeta: Failed to get method meta: " + errorMsg);
+                throw jsi::JSError(rt, std::format("getMethodMeta: Failed to get method meta: {}", errorMsg));
             }
 
             auto inputTagsArray = jsi::Array(rt, methodMeta->num_inputs());
@@ -91,7 +100,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 auto tag = methodMeta->input_tag(i);
                 if (!tag.ok()) {
                     const std::string errorMsg = executorch::runtime::to_string(tag.error());
-                    throw jsi::JSError(rt, "getMethodMeta: Failed to get input tag for input " + std::to_string(i) + ": " + errorMsg);
+                    throw jsi::JSError(rt, std::format("getMethodMeta: Failed to get input tag for input {}: {}", i, errorMsg));
                 }
                 inputTagsArray.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, executorch::runtime::tag_to_string(tag.get())));
             }
@@ -101,7 +110,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 auto tag = methodMeta->output_tag(i);
                 if (!tag.ok()) {
                     const std::string errorMsg = executorch::runtime::to_string(tag.error());
-                    throw jsi::JSError(rt, "getMethodMeta: Failed to get output tag for output " + std::to_string(i) + ": " + errorMsg);
+                    throw jsi::JSError(rt, std::format("getMethodMeta: Failed to get output tag for output {}: {}", i, errorMsg));
                 }
                 outputTagsArray.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, executorch::runtime::tag_to_string(tag.get())));
             }
@@ -111,7 +120,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 auto backendName = methodMeta->get_backend_name(i);
                 if (!backendName.ok()) {
                     const std::string errorMsg = executorch::runtime::to_string(backendName.error());
-                    throw jsi::JSError(rt, "getMethodMeta: Failed to get backend name for backend " + std::to_string(i) + ": " + errorMsg);
+                    throw jsi::JSError(rt, std::format("getMethodMeta: Failed to get backend name for backend {}: {}", i, errorMsg));
                 }
                 usesBackendMap.setProperty(rt, backendName.get(), methodMeta->uses_backend(backendName.get()));
             }
@@ -123,7 +132,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 jsTensorMeta.setProperty(rt, "nbytes", static_cast<double>(tensorMeta.nbytes()));
 
                 try {
-                    const std::string dtypeStr = rnexecutorch::core::types::toString(rnexecutorch::core::types::fromScalarType(tensorMeta.scalar_type()));
+                    const std::string dtypeStr = types::toString(types::fromScalarType(tensorMeta.scalar_type()));
                     jsTensorMeta.setProperty(rt, "dtype", jsi::String::createFromUtf8(rt, dtypeStr));
                 } catch (const std::exception &) {
                     jsTensorMeta.setProperty(rt, "dtype", jsi::String::createFromUtf8(rt, "not supported"));
@@ -143,7 +152,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 auto tensorMeta = methodMeta->input_tensor_meta(i);
                 if (!tensorMeta.ok()) {
                     const std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
-                    throw jsi::JSError(rt, "getMethodMeta: Failed to get tensor meta for input " + std::to_string(i) + ": " + errorMsg);
+                    throw jsi::JSError(rt, std::format("getMethodMeta: Failed to get tensor meta for input {}: {}", i, errorMsg));
                 }
                 inputTensorMetaArray.setValueAtIndex(rt, i, tensorMetaToJS(rt, tensorMeta.get()));
             }
@@ -153,13 +162,12 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 auto tensorMeta = methodMeta->output_tensor_meta(i);
                 if (!tensorMeta.ok()) {
                     const std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
-                    throw jsi::JSError(rt, "getMethodMeta: Failed to get tensor meta for output " + std::to_string(i) + ": " + errorMsg);
+                    throw jsi::JSError(rt, std::format("getMethodMeta: Failed to get tensor meta for output {}: {}", i, errorMsg));
                 }
                 outputTensorMetaArray.setValueAtIndex(rt, i, tensorMetaToJS(rt, tensorMeta.get()));
             }
 
             auto jsMeta = jsi::Object(rt);
-
             jsMeta.setProperty(rt, "name", jsi::String::createFromUtf8(rt, methodMeta->name()));
             jsMeta.setProperty(rt, "numInputs", static_cast<double>(methodMeta->num_inputs()));
             jsMeta.setProperty(rt, "numOutputs", static_cast<double>(methodMeta->num_outputs()));
@@ -181,18 +189,6 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 throw jsi::JSError(rt, "execute: Usage: execute(methodName, inputs, outputTensors)");
             }
 
-            if (!args[0].isString()) {
-                throw jsi::JSError(rt, "execute: Expected arg0 to be a string");
-            }
-
-            if (!args[1].isObject() || !args[1].asObject(rt).isArray(rt)) {
-                throw jsi::JSError(rt, "execute: Expected arg1 to be an array");
-            }
-
-            if (!args[2].isObject() || !args[2].asObject(rt).isArray(rt)) {
-                throw jsi::JSError(rt, "execute: Expected arg2 to be an array");
-            }
-
             std::unique_lock<std::mutex> lock(self->mutex_, std::try_to_lock);
             if (!lock.owns_lock()) {
                 throw jsi::JSError(rt, "execute: Model is currently in use");
@@ -202,20 +198,20 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 throw jsi::JSError(rt, "execute: Model has been disposed");
             }
 
-            auto methodName = args[0].asString(rt).utf8(rt);
+            auto methodName = conversions::asType<std::string>(rt, "execute: methodName", args[0]);
             auto methodMeta = self->etModule_->method_meta(methodName);
             auto inputsArray = args[1].asObject(rt).asArray(rt);
+            auto outputTensorsArray = args[2].asObject(rt).asArray(rt);
 
             if (!methodMeta.ok()) {
                 const std::string errorMsg = executorch::runtime::to_string(methodMeta.error());
-                throw jsi::JSError(rt, "execute: Failed to get method meta for '" + methodName + "': " + errorMsg);
+                throw jsi::JSError(rt, std::format("execute: Failed to get method meta for '{}': {}",
+                                                   methodName, errorMsg));
             }
 
             if (inputsArray.size(rt) != methodMeta->num_inputs()) {
-                const std::string errorMsg = "execute: Incorrect size for inputs: got " +
-                                             std::to_string(inputsArray.size(rt)) +
-                                             ", expected " + std::to_string(methodMeta->num_inputs());
-                throw jsi::JSError(rt, errorMsg);
+                throw jsi::JSError(rt, std::format("execute: Incorrect size for inputs: got {}, expected {}",
+                                                   inputsArray.size(rt), methodMeta->num_inputs()));
             }
 
             auto validateTensor = [](jsi::Runtime &rt,
@@ -223,22 +219,19 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                                      const executorch::runtime::Result<executorch::runtime::TensorInfo> &tensorMeta,
                                      const std::string &identifier) {
                 if (tensorMeta->scalar_type() != tensorHostObject->tensor_->dtype()) {
-                    throw jsi::JSError(rt, "execute: Tensor dtype mismatch for " + identifier);
+                    throw jsi::JSError(rt, std::format("execute: Tensor dtype mismatch for {}", identifier));
                 }
 
                 if (tensorMeta->sizes().size() != tensorHostObject->shape_.size()) {
-                    throw jsi::JSError(rt, "execute: Tensor rank mismatch for " + identifier +
-                                               ": expected rank " + std::to_string(tensorMeta->sizes().size()) +
-                                               " but got " + std::to_string(tensorHostObject->shape_.size()));
+                    throw jsi::JSError(rt, std::format("execute: Tensor rank mismatch for {}: expected rank {} but got {}",
+                                                       identifier, tensorMeta->sizes().size(), tensorHostObject->shape_.size()));
                 }
 
                 auto ndim = tensorHostObject->tensor_->sizes().size();
                 for (size_t j = 0; j < ndim; ++j) {
                     if (tensorMeta->sizes()[j] != tensorHostObject->shape_[j]) {
-                        throw jsi::JSError(rt, "execute: Tensor shape mismatch for " + identifier +
-                                                   ": expected dimension " + std::to_string(j) + " to be " +
-                                                   std::to_string(tensorMeta->sizes()[j]) + " but got " +
-                                                   std::to_string(tensorHostObject->shape_[j]));
+                        throw jsi::JSError(rt, std::format("execute: Tensor shape mismatch for {}: expected dimension {} to be {} but got {}",
+                                                           identifier, j, tensorMeta->sizes()[j], tensorHostObject->shape_[j]));
                     }
                 }
             };
@@ -250,32 +243,17 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             for (size_t i = 0; i < methodMeta->num_inputs(); ++i) {
                 auto tag = methodMeta->input_tag(i);
                 auto val = inputsArray.getValueAtIndex(rt, i);
+                const auto ident = std::format("inputs[{}]", i);
+                const auto ctx = std::format("execute: {}", ident);
 
                 if (!tag.ok()) {
                     const std::string errorMsg = executorch::runtime::to_string(tag.error());
-                    throw jsi::JSError(rt, "execute: Failed to get input tag for inputs[" +
-                                               std::to_string(i) + "]: " + errorMsg);
+                    throw jsi::JSError(rt, std::format("{}: Failed to get input tag: {}", ctx, errorMsg));
                 }
 
                 switch (tag.get()) {
-                case executorch::runtime::Tag::None: {
-                    if (!val.isNull()) {
-                        throw jsi::JSError(rt, "execute: Expected inputs[" +
-                                                   std::to_string(i) + "] to be null");
-                    }
-                    inputs[i] = executorch::runtime::EValue();
-                    break;
-                }
                 case executorch::runtime::Tag::Tensor: {
-                    if (!val.isObject() || !val.asObject(rt).isHostObject<TensorHostObject>(rt)) {
-                        throw jsi::JSError(rt, "execute: Expected inputs[" +
-                                                   std::to_string(i) + "] to be a TensorHostObject");
-                    }
-
-                    auto tensorHostObject = val.asObject(rt).getHostObject<TensorHostObject>(rt);
-                    if (!tensorHostObject->data_) {
-                        throw jsi::JSError(rt, "execute: inputs[" + std::to_string(i) + "] has been disposed");
-                    }
+                    auto tensorHostObject = tensor::fromJs(rt, ctx, val, std::nullopt, std::nullopt);
 
                     if (!lockedTensors.insert(tensorHostObject.get()).second) {
                         throw jsi::JSError(rt, "execute: Tensor aliasing detected. The same tensor was passed multiple times.");
@@ -283,50 +261,36 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
 
                     tensorLocks.emplace_back(tensorHostObject->mutex_, std::try_to_lock);
                     if (!tensorLocks.back().owns_lock()) {
-                        throw jsi::JSError(rt, "execute: inputs[" + std::to_string(i) +
-                                                   "] is currently in use");
+                        throw jsi::JSError(rt, std::format("{} is currently in use", ctx));
+                    }
+
+                    if (!tensorHostObject->data_) {
+                        throw jsi::JSError(rt, std::format("{} has been disposed", ctx));
                     }
 
                     auto tensorMeta = methodMeta->input_tensor_meta(i);
 
                     if (!tensorMeta.ok()) {
                         const std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
-                        throw jsi::JSError(rt, "execute: Failed to get tensor meta for inputs[" +
-                                                   std::to_string(i) + "]: " + errorMsg);
+                        throw jsi::JSError(rt, std::format("{}: Failed to get tensor meta: {}", ctx, errorMsg));
                     }
 
-                    validateTensor(rt, tensorHostObject.get(), tensorMeta, "inputs[" + std::to_string(i) + "]");
+                    validateTensor(rt, tensorHostObject.get(), tensorMeta, ident);
 
                     inputs[i] = tensorHostObject->tensor_;
                     break;
                 }
-                case executorch::runtime::Tag::Double: {
-                    if (!val.isNumber()) {
-                        throw jsi::JSError(rt, "execute: Expected inputs[" +
-                                                   std::to_string(i) + "] to be a number");
-                    }
-                    inputs[i] = executorch::runtime::EValue(val.asNumber());
+                case executorch::runtime::Tag::Double:
+                    inputs[i] = executorch::runtime::EValue(conversions::asType<double>(rt, ctx, val));
                     break;
-                }
-                case executorch::runtime::Tag::Int: {
-                    if (!val.isNumber()) {
-                        throw jsi::JSError(rt, "execute: Expected inputs[" +
-                                                   std::to_string(i) + "] to be a number");
-                    }
-                    inputs[i] = executorch::runtime::EValue(static_cast<int64_t>(val.asNumber()));
+                case executorch::runtime::Tag::Int:
+                    inputs[i] = executorch::runtime::EValue(conversions::asType<int64_t>(rt, ctx, val));
                     break;
-                }
-                case executorch::runtime::Tag::Bool: {
-                    if (!val.isBool()) {
-                        throw jsi::JSError(rt, "execute: Expected inputs[" +
-                                                   std::to_string(i) + "] to be a boolean");
-                    }
-                    inputs[i] = executorch::runtime::EValue(val.asBool());
+                case executorch::runtime::Tag::Bool:
+                    inputs[i] = executorch::runtime::EValue(conversions::asType<bool>(rt, ctx, val));
                     break;
-                }
-                default: {
-                    throw jsi::JSError(rt, "execute: Unsupported input type for inputs[" + std::to_string(i) + "]");
-                }
+                default:
+                    throw jsi::JSError(rt, std::format("{}: Unsupported input type", ctx));
                 }
             }
 
@@ -338,19 +302,20 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(finishTime - startTime).count();
             auto consoleObj = rt.global().getProperty(rt, "console").asObject(rt);
             auto logFn = consoleObj.getProperty(rt, "log").asObject(rt).asFunction(rt);
-            auto info = "Execution of method '" + methodName + "' took " + std::to_string(durationMs) + " ms";
+            auto info = std::format("Execution of method '{}' took {} ms", methodName, durationMs);
             logFn.callWithThis(rt, consoleObj, {jsi::String::createFromUtf8(rt, info)});
 #endif
 
             if (!result.ok()) {
                 const std::string errorMsg = executorch::runtime::to_string(result.error());
-                throw jsi::JSError(rt, "execute: Method '" + methodName + "' execution failed: " + errorMsg +
-                                           ". This may be due to missing required backends - use getMethodMeta()" +
-                                           " to check required backends and getExecuTorchRegisteredBackends()" +
-                                           " to check which backends are registered in the runtime.");
+                throw jsi::JSError(rt, std::format("execute: Method '{}' execution failed: {}. "
+                                                   "This may be due to missing required backends - "
+                                                   "use getMethodMeta() to check required backends and "
+                                                   "getExecuTorchRegisteredBackends() to check "
+                                                   "which backends are registered in the runtime.",
+                                                   methodName, errorMsg));
             }
 
-            auto outputTensorsArray = args[2].asObject(rt).asArray(rt);
             auto jsOutputArray = jsi::Array(rt, result->size());
 
             size_t index = 0;
@@ -367,37 +332,33 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                         throw jsi::JSError(rt, "execute: Not enough tensor output placeholders in outputTensors");
                     }
 
-                    auto val = outputTensorsArray.getValueAtIndex(rt, tensorOutputIdx);
-                    if (!val.isObject() || !val.asObject(rt).isHostObject<TensorHostObject>(rt)) {
-                        throw jsi::JSError(rt, "execute: Expected outputTensors[" +
-                                                   std::to_string(tensorOutputIdx) + "] to be a TensorHostObject");
-                    }
+                    const auto val = outputTensorsArray.getValueAtIndex(rt, tensorOutputIdx);
+                    const auto ident = std::format("outputTensors[{}]", tensorOutputIdx);
+                    const auto ctx = std::format("execute: {}", ident);
 
-                    auto tensorHostObject = val.asObject(rt).getHostObject<TensorHostObject>(rt);
-                    if (!tensorHostObject->data_) {
-                        throw jsi::JSError(rt, "execute: outputTensors[" + std::to_string(tensorOutputIdx) + "] has been disposed");
-                    }
-
+                    auto tensorHostObject = tensor::fromJs(rt, ctx, val, std::nullopt, std::nullopt);
                     if (!lockedTensors.insert(tensorHostObject.get()).second) {
                         throw jsi::JSError(rt, "execute: Tensor aliasing detected. The same tensor was passed multiple times.");
                     }
 
                     tensorLocks.emplace_back(tensorHostObject->mutex_, std::try_to_lock);
                     if (!tensorLocks.back().owns_lock()) {
-                        throw jsi::JSError(rt, "execute: outputTensors[" +
-                                                   std::to_string(tensorOutputIdx) +
-                                                   "] is currently in use");
+                        throw jsi::JSError(rt, std::format("{} is currently in use", ctx));
+                    }
+
+                    if (!tensorHostObject->data_) {
+                        throw jsi::JSError(rt, std::format("{} has been disposed", ctx));
                     }
 
                     auto tensorMeta = methodMeta->output_tensor_meta(index);
 
                     if (!tensorMeta.ok()) {
                         const std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
-                        throw jsi::JSError(rt, "execute: Failed to get tensor meta for output at index " +
-                                                   std::to_string(index) + ": " + errorMsg);
+                        throw jsi::JSError(rt, std::format("execute: Failed to get tensor meta for output at index {}: {}",
+                                                           index, errorMsg));
                     }
 
-                    validateTensor(rt, tensorHostObject.get(), tensorMeta, "outputTensors[" + std::to_string(tensorOutputIdx) + "]");
+                    validateTensor(rt, tensorHostObject.get(), tensorMeta, ident);
 
                     std::memcpy(tensorHostObject->data_.get(),
                                 output.toTensor().const_data_ptr(),
@@ -470,23 +431,15 @@ void install_loadModel(jsi::Runtime &rt, jsi::Object &module) {
     const auto *name = "loadModel";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 1) {
-            throw jsi::JSError(rt, "loadModel: Usage: loadModel(arg0)");
+            throw jsi::JSError(rt, "loadModel: Usage: loadModel(path)");
         }
 
-        if (!args[0].isString()) {
-            throw jsi::JSError(rt, "loadModel: Expected arg0 to be a string");
+        auto modelPath = conversions::asType<std::string>(rt, "loadModel: path", args[0]);
+        try {
+            return jsi::Object::createFromHostObject(rt, std::make_shared<ModelHostObject>(modelPath));
+        } catch (const std::exception &e) {
+            throw jsi::JSError(rt, std::format("loadModel: {}", e.what()));
         }
-
-        auto modelPath = args[0].asString(rt).utf8(rt);
-        auto modelInstance = std::make_shared<ModelHostObject>(modelPath);
-
-        auto error = modelInstance->etModule_->load();
-        if (!modelInstance->etModule_->is_loaded()) {
-            const std::string errorMsg = executorch::runtime::to_string(error);
-            throw jsi::JSError(rt, "loadModel: Failed to load model: " + errorMsg);
-        }
-
-        return jsi::Object::createFromHostObject(rt, modelInstance);
     };
     auto fn = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name), 1, fnBody);
 

--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -200,15 +200,8 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             auto methodName = conversions::asType<std::string>(rt, "execute: methodName", args[0]);
             auto methodMeta = unwrap(rt, "execute", self->etModule_->method_meta(methodName));
 
-            if (!args[1].isObject() || !args[1].asObject(rt).isArray(rt)) {
-                throw jsi::JSError(rt, "execute: Expected inputs to be an Array");
-            }
-            if (!args[2].isObject() || !args[2].asObject(rt).isArray(rt)) {
-                throw jsi::JSError(rt, "execute: Expected outputTensors to be an Array");
-            }
-
-            auto inputsArray = args[1].asObject(rt).asArray(rt);
-            auto outputTensorsArray = args[2].asObject(rt).asArray(rt);
+            auto inputsArray = conversions::asType<jsi::Array>(rt, "execute: inputs", args[1]);
+            auto outputTensorsArray = conversions::asType<jsi::Array>(rt, "execute: outputTensors", args[2]);
 
             if (inputsArray.size(rt) != methodMeta.num_inputs()) {
                 throw jsi::JSError(rt, std::format("execute: Incorrect size for inputs: got {}, expected {}",

--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -18,19 +18,19 @@ namespace jsi = facebook::jsi;
 namespace types = rnexecutorch::core::types;
 
 template <typename T>
-T getOrThrow(jsi::Runtime &rt, const std::string &ctx, executorch::runtime::Result<T> result) {
+T unwrap(jsi::Runtime &rt, const std::string &ctx, executorch::runtime::Result<T> result) {
     if (!result.ok()) {
-        throw jsi::JSError(rt, std::format("{}: {}", ctx, executorch::runtime::to_string(result.error())));
+        throw jsi::JSError(rt, ctx + ": " + executorch::runtime::to_string(result.error()));
     }
     return std::move(result.get());
 }
 
 types::DType
-getDTypeOrThrow(jsi::Runtime &rt, const std::string &ctx, executorch::aten::ScalarType scalarType) {
+fromScalarType(jsi::Runtime &rt, const std::string &ctx, executorch::aten::ScalarType scalarType) {
     try {
         return types::fromScalarType(scalarType);
     } catch (const std::exception &e) {
-        throw jsi::JSError(rt, std::format("{}: Unsupported tensor dtype: {}", ctx, e.what()));
+        throw jsi::JSError(rt, ctx + ": Unsupported tensor dtype: " + e.what());
     }
 }
 
@@ -96,7 +96,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 throw jsi::JSError(rt, "getMethodNames: Model has been disposed");
             }
 
-            auto methodNames = getOrThrow(rt, "getMethodNames", self->etModule_->method_names());
+            auto methodNames = unwrap(rt, "getMethodNames", self->etModule_->method_names());
 
             auto jsArray = jsi::Array(rt, methodNames.size());
             size_t index = 0;
@@ -129,40 +129,40 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             }
 
             auto methodName = conversions::asType<std::string>(rt, "getMethodMeta: methodName", args[0]);
-            auto methodMeta = getOrThrow(rt, "getMethodMeta", self->etModule_->method_meta(methodName));
+            auto methodMeta = unwrap(rt, "getMethodMeta", self->etModule_->method_meta(methodName));
 
             auto inputTagsArray = jsi::Array(rt, methodMeta.num_inputs());
             for (size_t i = 0; i < methodMeta.num_inputs(); ++i) {
                 auto ctx = std::format("getMethodMeta: input tag [{}]", i);
-                auto tag = getOrThrow(rt, ctx, methodMeta.input_tag(i));
+                auto tag = unwrap(rt, ctx, methodMeta.input_tag(i));
                 inputTagsArray.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, tag_to_string(tag)));
             }
 
             auto outputTagsArray = jsi::Array(rt, methodMeta.num_outputs());
             for (size_t i = 0; i < methodMeta.num_outputs(); ++i) {
                 auto ctx = std::format("getMethodMeta: output tag [{}]", i);
-                auto tag = getOrThrow(rt, ctx, methodMeta.output_tag(i));
+                auto tag = unwrap(rt, ctx, methodMeta.output_tag(i));
                 outputTagsArray.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, tag_to_string(tag)));
             }
 
             auto usesBackendMap = jsi::Object(rt);
             for (size_t i = 0; i < methodMeta.num_backends(); ++i) {
                 auto ctx = std::format("getMethodMeta: backend name [{}]", i);
-                const auto *backendName = getOrThrow(rt, ctx, methodMeta.get_backend_name(i));
+                const auto *backendName = unwrap(rt, ctx, methodMeta.get_backend_name(i));
                 usesBackendMap.setProperty(rt, backendName, methodMeta.uses_backend(backendName));
             }
 
             auto inputTensorMetaArray = jsi::Array(rt, methodMeta.num_inputs());
             for (size_t i = 0; i < methodMeta.num_inputs(); ++i) {
                 auto ctx = std::format("getMethodMeta: input tensor meta [{}]", i);
-                auto tensorMeta = getOrThrow(rt, ctx, methodMeta.input_tensor_meta(i));
+                auto tensorMeta = unwrap(rt, ctx, methodMeta.input_tensor_meta(i));
                 inputTensorMetaArray.setValueAtIndex(rt, i, tensorMetaToJs(rt, tensorMeta));
             }
 
             auto outputTensorMetaArray = jsi::Array(rt, methodMeta.num_outputs());
             for (size_t i = 0; i < methodMeta.num_outputs(); ++i) {
                 auto ctx = std::format("getMethodMeta: output tensor meta [{}]", i);
-                auto tensorMeta = getOrThrow(rt, ctx, methodMeta.output_tensor_meta(i));
+                auto tensorMeta = unwrap(rt, ctx, methodMeta.output_tensor_meta(i));
                 outputTensorMetaArray.setValueAtIndex(rt, i, tensorMetaToJs(rt, tensorMeta));
             }
 
@@ -198,7 +198,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             }
 
             auto methodName = conversions::asType<std::string>(rt, "execute: methodName", args[0]);
-            auto methodMeta = getOrThrow(rt, "execute", self->etModule_->method_meta(methodName));
+            auto methodMeta = unwrap(rt, "execute", self->etModule_->method_meta(methodName));
 
             if (!args[1].isObject() || !args[1].asObject(rt).isArray(rt)) {
                 throw jsi::JSError(rt, "execute: Expected inputs to be an Array");
@@ -221,13 +221,13 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
 
             for (size_t i = 0; i < methodMeta.num_inputs(); ++i) {
                 auto ctx = std::format("execute: inputs[{}]", i);
-                auto tag = getOrThrow(rt, ctx, methodMeta.input_tag(i));
+                auto tag = unwrap(rt, ctx, methodMeta.input_tag(i));
                 auto val = inputsArray.getValueAtIndex(rt, i);
 
                 switch (tag) {
                 case executorch::runtime::Tag::Tensor: {
-                    auto tensorMeta = getOrThrow(rt, std::format("{}: tensor meta", ctx), methodMeta.input_tensor_meta(i));
-                    auto expectedDtype = getDTypeOrThrow(rt, ctx, tensorMeta.scalar_type());
+                    auto tensorMeta = unwrap(rt, ctx + ": tensor meta", methodMeta.input_tensor_meta(i));
+                    auto expectedDtype = fromScalarType(rt, ctx, tensorMeta.scalar_type());
                     auto tensorHostObject = tensor::fromJs(rt, ctx, val, expectedDtype, tensorMeta.sizes());
 
                     if (!lockedTensors.insert(tensorHostObject.get()).second) {
@@ -256,11 +256,13 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 }
             }
 
-            auto result = getOrThrow(rt, std::format("execute: Method '{}' failed (check getMethodMeta() "
-                                                     "for required backends and getRegisteredBackends() "
-                                                     "for registered ones)",
-                                                     methodName),
-                                     self->etModule_->execute(methodName, inputs));
+            auto result = unwrap(rt, std::format("execute: Method '{}' execution failed. "
+                                                 "This may be due to missing required backends - "
+                                                 "use getMethodMeta() to check required backends and "
+                                                 "getExecuTorchRegisteredBackends() to check "
+                                                 "which backends are registered in the runtime. Error:",
+                                                 methodName),
+                                 self->etModule_->execute(methodName, inputs));
 
             auto jsOutputArray = jsi::Array(rt, result.size());
             size_t index = 0;
@@ -276,8 +278,8 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                     auto ctx = std::format("execute: outputTensors[{}]", tensorOutputIdx);
                     auto val = outputTensorsArray.getValueAtIndex(rt, tensorOutputIdx);
 
-                    auto tensorMeta = getOrThrow(rt, std::format("{}: tensor meta", ctx), methodMeta.output_tensor_meta(index));
-                    auto expectedDtype = getDTypeOrThrow(rt, ctx, tensorMeta.scalar_type());
+                    auto tensorMeta = unwrap(rt, ctx + ": tensor meta", methodMeta.output_tensor_meta(index));
+                    auto expectedDtype = fromScalarType(rt, ctx, tensorMeta.scalar_type());
                     auto tensorHostObject = tensor::fromJs(rt, ctx, val, expectedDtype, tensorMeta.sizes());
 
                     if (!lockedTensors.insert(tensorHostObject.get()).second) {

--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -14,29 +14,51 @@
 #include <executorch/runtime/core/tag.h>
 
 namespace {
+namespace jsi = facebook::jsi;
+namespace types = rnexecutorch::core::types;
+
 template <typename T>
-T getOrThrow(facebook::jsi::Runtime &rt, const std::string &ctx,
-             executorch::runtime::Result<T> result) {
+T getOrThrow(jsi::Runtime &rt, const std::string &ctx, executorch::runtime::Result<T> result) {
     if (!result.ok()) {
-        throw facebook::jsi::JSError(rt, std::format("{}: {}", ctx, executorch::runtime::to_string(result.error())));
+        throw jsi::JSError(rt, std::format("{}: {}", ctx, executorch::runtime::to_string(result.error())));
     }
     return std::move(result.get());
 }
 
-rnexecutorch::core::types::DType
-getDTypeOrThrow(facebook::jsi::Runtime &rt, const std::string &ctx,
-                executorch::aten::ScalarType scalarType) {
+types::DType
+getDTypeOrThrow(jsi::Runtime &rt, const std::string &ctx, executorch::aten::ScalarType scalarType) {
     try {
-        return rnexecutorch::core::types::fromScalarType(scalarType);
+        return types::fromScalarType(scalarType);
     } catch (const std::exception &e) {
-        throw facebook::jsi::JSError(rt, std::format("{}: Unsupported tensor dtype: {}", ctx, e.what()));
+        throw jsi::JSError(rt, std::format("{}: Unsupported tensor dtype: {}", ctx, e.what()));
     }
+}
+
+jsi::Object tensorMetaToJs(jsi::Runtime &rt, const executorch::runtime::TensorInfo &tensorMeta) {
+    auto jsTensorMeta = jsi::Object(rt);
+    jsTensorMeta.setProperty(rt, "name", jsi::String::createFromUtf8(rt, std::string(tensorMeta.name())));
+    jsTensorMeta.setProperty(rt, "ndim", static_cast<double>(tensorMeta.sizes().size()));
+    jsTensorMeta.setProperty(rt, "nbytes", static_cast<double>(tensorMeta.nbytes()));
+
+    try {
+        auto dtypeStr = types::toString(types::fromScalarType(tensorMeta.scalar_type()));
+        jsTensorMeta.setProperty(rt, "dtype", jsi::String::createFromUtf8(rt, dtypeStr));
+    } catch (const std::exception &) {
+        jsTensorMeta.setProperty(rt, "dtype", jsi::String::createFromUtf8(rt, "not supported"));
+    }
+
+    auto jsShapeArray = jsi::Array(rt, tensorMeta.sizes().size());
+    for (size_t i = 0; i < tensorMeta.sizes().size(); ++i) {
+        jsShapeArray.setValueAtIndex(rt, i, static_cast<double>(tensorMeta.sizes()[i]));
+    }
+    jsTensorMeta.setProperty(rt, "shape", jsShapeArray);
+
+    return jsTensorMeta;
 }
 } // namespace
 
 namespace rnexecutorch::core::model {
 namespace jsi = facebook::jsi;
-namespace types = rnexecutorch::core::types;
 namespace conversions = rnexecutorch::core::conversions;
 
 using TensorHostObject = rnexecutorch::core::tensor::TensorHostObject;
@@ -91,6 +113,8 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
     if (nameStr == "getMethodMeta") {
         auto self = shared_from_this();
         auto fnBody = [self](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
+            using executorch::runtime::tag_to_string;
+
             if (count != 1) {
                 throw jsi::JSError(rt, "getMethodMeta: Usage: getMethodMeta(methodName)");
             }
@@ -113,54 +137,37 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
 
             auto inputTagsArray = jsi::Array(rt, methodMeta.num_inputs());
             for (size_t i = 0; i < methodMeta.num_inputs(); ++i) {
-                auto tag = getOrThrow(rt, std::format("getMethodMeta: input tag [{}]", i), methodMeta.input_tag(i));
-                inputTagsArray.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, executorch::runtime::tag_to_string(tag)));
+                auto ctx = std::format("getMethodMeta: input tag [{}]", i);
+                auto tag = getOrThrow(rt, ctx, methodMeta.input_tag(i));
+                inputTagsArray.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, tag_to_string(tag)));
             }
 
             auto outputTagsArray = jsi::Array(rt, methodMeta.num_outputs());
             for (size_t i = 0; i < methodMeta.num_outputs(); ++i) {
-                auto tag = getOrThrow(rt, std::format("getMethodMeta: output tag [{}]", i), methodMeta.output_tag(i));
-                outputTagsArray.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, executorch::runtime::tag_to_string(tag)));
+                auto ctx = std::format("getMethodMeta: output tag [{}]", i);
+                auto tag = getOrThrow(rt, ctx, methodMeta.output_tag(i));
+                outputTagsArray.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, tag_to_string(tag)));
             }
 
             auto usesBackendMap = jsi::Object(rt);
             for (size_t i = 0; i < methodMeta.num_backends(); ++i) {
-                const auto *backendName = getOrThrow(rt, std::format("getMethodMeta: backend name [{}]", i), methodMeta.get_backend_name(i));
+                auto ctx = std::format("getMethodMeta: backend name [{}]", i);
+                const auto *backendName = getOrThrow(rt, ctx, methodMeta.get_backend_name(i));
                 usesBackendMap.setProperty(rt, backendName, methodMeta.uses_backend(backendName));
             }
 
-            auto tensorMetaToJS = [](jsi::Runtime &rt, const executorch::runtime::TensorInfo &tensorMeta) -> jsi::Object {
-                auto jsTensorMeta = jsi::Object(rt);
-                jsTensorMeta.setProperty(rt, "name", jsi::String::createFromUtf8(rt, std::string(tensorMeta.name())));
-                jsTensorMeta.setProperty(rt, "ndim", static_cast<double>(tensorMeta.sizes().size()));
-                jsTensorMeta.setProperty(rt, "nbytes", static_cast<double>(tensorMeta.nbytes()));
-
-                try {
-                    auto dtypeStr = types::toString(types::fromScalarType(tensorMeta.scalar_type()));
-                    jsTensorMeta.setProperty(rt, "dtype", jsi::String::createFromUtf8(rt, dtypeStr));
-                } catch (const std::exception &) {
-                    jsTensorMeta.setProperty(rt, "dtype", jsi::String::createFromUtf8(rt, "not supported"));
-                }
-
-                auto jsShapeArray = jsi::Array(rt, tensorMeta.sizes().size());
-                for (size_t i = 0; i < tensorMeta.sizes().size(); ++i) {
-                    jsShapeArray.setValueAtIndex(rt, i, static_cast<double>(tensorMeta.sizes()[i]));
-                }
-                jsTensorMeta.setProperty(rt, "shape", jsShapeArray);
-
-                return jsTensorMeta;
-            };
-
             auto inputTensorMetaArray = jsi::Array(rt, methodMeta.num_inputs());
             for (size_t i = 0; i < methodMeta.num_inputs(); ++i) {
-                auto tensorMeta = getOrThrow(rt, std::format("getMethodMeta: input tensor meta [{}]", i), methodMeta.input_tensor_meta(i));
-                inputTensorMetaArray.setValueAtIndex(rt, i, tensorMetaToJS(rt, tensorMeta));
+                auto ctx = std::format("getMethodMeta: input tensor meta [{}]", i);
+                auto tensorMeta = getOrThrow(rt, ctx, methodMeta.input_tensor_meta(i));
+                inputTensorMetaArray.setValueAtIndex(rt, i, tensorMetaToJs(rt, tensorMeta));
             }
 
             auto outputTensorMetaArray = jsi::Array(rt, methodMeta.num_outputs());
             for (size_t i = 0; i < methodMeta.num_outputs(); ++i) {
-                auto tensorMeta = getOrThrow(rt, std::format("getMethodMeta: output tensor meta [{}]", i), methodMeta.output_tensor_meta(i));
-                outputTensorMetaArray.setValueAtIndex(rt, i, tensorMetaToJS(rt, tensorMeta));
+                auto ctx = std::format("getMethodMeta: output tensor meta [{}]", i);
+                auto tensorMeta = getOrThrow(rt, ctx, methodMeta.output_tensor_meta(i));
+                outputTensorMetaArray.setValueAtIndex(rt, i, tensorMetaToJs(rt, tensorMeta));
             }
 
             auto jsMeta = jsi::Object(rt);
@@ -195,8 +202,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             }
 
             auto methodName = conversions::asType<std::string>(rt, "execute: methodName", args[0]);
-            auto methodMeta = getOrThrow(rt, std::format("execute: method meta for '{}'", methodName),
-                                         self->etModule_->method_meta(methodName));
+            auto methodMeta = getOrThrow(rt, "execute", self->etModule_->method_meta(methodName));
 
             auto inputsArray = args[1].asObject(rt).asArray(rt);
             auto outputTensorsArray = args[2].asObject(rt).asArray(rt);
@@ -211,9 +217,9 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             std::unordered_set<TensorHostObject *> lockedTensors;
 
             for (size_t i = 0; i < methodMeta.num_inputs(); ++i) {
-                auto tag = getOrThrow(rt, std::format("execute: inputs[{}] tag", i), methodMeta.input_tag(i));
-                auto val = inputsArray.getValueAtIndex(rt, i);
                 auto ctx = std::format("execute: inputs[{}]", i);
+                auto tag = getOrThrow(rt, ctx, methodMeta.input_tag(i));
+                auto val = inputsArray.getValueAtIndex(rt, i);
 
                 switch (tag) {
                 case executorch::runtime::Tag::Tensor: {
@@ -226,63 +232,62 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                                                "The same tensor was passed multiple times.");
                     }
                     tensorLocks.emplace_back(tensor::tryLockUnique(rt, ctx, tensorHostObject));
-
                     inputs[i] = tensorHostObject->tensor_;
                     break;
                 }
                 case executorch::runtime::Tag::Double:
-                    inputs[i] = executorch::runtime::EValue(conversions::asType<double>(rt, ctx, val));
+                    inputs[i] = conversions::asType<double>(rt, ctx, val);
                     break;
                 case executorch::runtime::Tag::Int:
-                    inputs[i] = executorch::runtime::EValue(conversions::asType<int64_t>(rt, ctx, val));
+                    inputs[i] = conversions::asType<int64_t>(rt, ctx, val);
                     break;
                 case executorch::runtime::Tag::Bool:
-                    inputs[i] = executorch::runtime::EValue(conversions::asType<bool>(rt, ctx, val));
+                    inputs[i] = conversions::asType<bool>(rt, ctx, val);
+                    break;
+                case executorch::runtime::Tag::None:
+                    inputs[i] = executorch::runtime::EValue();
                     break;
                 default:
-                    throw jsi::JSError(rt, std::format("{}: Unsupported input type", ctx));
+                    throw jsi::JSError(rt, std::format("{}: Unsupported input type: {}",
+                                                       ctx, executorch::runtime::tag_to_string(tag)));
                 }
             }
 
-            const auto result = getOrThrow(rt, std::format("execute: Method '{}' failed (check getMethodMeta() "
-                                                           "for required backends and getRegisteredBackends() "
-                                                           "for registered ones)",
-                                                           methodName),
-                                           self->etModule_->execute(methodName, inputs));
+            auto result = getOrThrow(rt, std::format("execute: Method '{}' failed (check getMethodMeta() "
+                                                     "for required backends and getRegisteredBackends() "
+                                                     "for registered ones)",
+                                                     methodName),
+                                     self->etModule_->execute(methodName, inputs));
 
             auto jsOutputArray = jsi::Array(rt, result.size());
-
             size_t index = 0;
             size_t tensorOutputIdx = 0;
 
             for (const auto &output : result) {
                 switch (output.tag) {
-                case executorch::runtime::Tag::None: {
-                    jsOutputArray.setValueAtIndex(rt, index, jsi::Value::null());
-                    break;
-                }
                 case executorch::runtime::Tag::Tensor: {
                     if (tensorOutputIdx >= outputTensorsArray.size(rt)) {
                         throw jsi::JSError(rt, "execute: Not enough tensor output placeholders in outputTensors");
                     }
 
-                    auto val = outputTensorsArray.getValueAtIndex(rt, tensorOutputIdx);
                     auto ctx = std::format("execute: outputTensors[{}]", tensorOutputIdx);
+                    auto val = outputTensorsArray.getValueAtIndex(rt, tensorOutputIdx);
 
                     auto tensorMeta = getOrThrow(rt, std::format("{}: tensor meta", ctx), methodMeta.output_tensor_meta(index));
                     auto expectedDtype = getDTypeOrThrow(rt, ctx, tensorMeta.scalar_type());
                     auto tensorHostObject = tensor::fromJs(rt, ctx, val, expectedDtype, tensorMeta.sizes());
 
                     if (!lockedTensors.insert(tensorHostObject.get()).second) {
-                        throw jsi::JSError(rt, "execute: Tensor aliasing detected. The same tensor was passed multiple times.");
+                        throw jsi::JSError(rt, "execute: Tensor aliasing detected. "
+                                               "The same tensor was passed multiple times.");
                     }
                     tensorLocks.emplace_back(tensor::tryLockUnique(rt, ctx, tensorHostObject));
-
-                    std::memcpy(tensorHostObject->data_.get(), output.toTensor().const_data_ptr(), output.toTensor().nbytes());
+                    std::memcpy(tensorHostObject->data_.get(),
+                                output.toTensor().const_data_ptr(),
+                                output.toTensor().nbytes());
 
                     jsOutputArray.setValueAtIndex(rt, index, jsi::Object::createFromHostObject(rt, tensorHostObject));
                     ++tensorOutputIdx;
-
                     break;
                 }
                 case executorch::runtime::Tag::Double: {
@@ -297,8 +302,13 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                     jsOutputArray.setValueAtIndex(rt, index, output.toBool());
                     break;
                 }
+                case executorch::runtime::Tag::None: {
+                    jsOutputArray.setValueAtIndex(rt, index, jsi::Value::null());
+                    break;
+                }
                 default: {
-                    throw jsi::JSError(rt, "execute: Unsupported return type");
+                    throw jsi::JSError(rt, std::format("execute: Unsupported return type: {}",
+                                                       executorch::runtime::tag_to_string(output.tag)));
                 }
                 }
 

--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -61,7 +61,7 @@ namespace rnexecutorch::core::model {
 namespace jsi = facebook::jsi;
 namespace conversions = rnexecutorch::core::conversions;
 
-using TensorHostObject = rnexecutorch::core::tensor::TensorHostObject;
+using rnexecutorch::core::tensor::TensorHostObject;
 
 ModelHostObject::ModelHostObject(const std::string &modelPath)
     : modelPath_(modelPath),

--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -256,13 +256,23 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 }
             }
 
-            auto result = unwrap(rt, std::format("execute: Method '{}' execution failed. "
-                                                 "This may be due to missing required backends - "
-                                                 "use getMethodMeta() to check required backends and "
-                                                 "getExecuTorchRegisteredBackends() to check "
-                                                 "which backends are registered in the runtime. Error:",
+            auto startTime = std::chrono::high_resolution_clock::now();
+            auto executeResult = self->etModule_->execute(methodName, inputs);
+            auto finishTime = std::chrono::high_resolution_clock::now();
+
+#ifdef EXECUTORCH_ENABLE_EXECUTION_PROFILING
+            auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(finishTime - startTime).count();
+            auto consoleObj = rt.global().getProperty(rt, "console").asObject(rt);
+            auto logFn = consoleObj.getProperty(rt, "log").asObject(rt).asFunction(rt);
+            auto info = std::format("Execution of method '{}' took {} ms", methodName, durationMs);
+            logFn.callWithThis(rt, consoleObj, {jsi::String::createFromUtf8(rt, info)});
+#endif
+
+            auto result = unwrap(rt, std::format("execute: Method '{}' failed (check getMethodMeta() "
+                                                 "for required backends and getRegisteredBackends() "
+                                                 "for registered ones)",
                                                  methodName),
-                                 self->etModule_->execute(methodName, inputs));
+                                 std::move(executeResult));
 
             auto jsOutputArray = jsi::Array(rt, result.size());
             size_t index = 0;

--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -3,12 +3,36 @@
 #include "tensor_helpers.h"
 
 #include <chrono>
+#include <exception>
 #include <format>
+#include <jsi/jsi.h>
 #include <unordered_set>
+#include <utility>
 
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/tag.h>
+
+namespace {
+template <typename T>
+T getOrThrow(facebook::jsi::Runtime &rt, const std::string &ctx,
+             executorch::runtime::Result<T> result) {
+    if (!result.ok()) {
+        throw facebook::jsi::JSError(rt, std::format("{}: {}", ctx, executorch::runtime::to_string(result.error())));
+    }
+    return std::move(result.get());
+}
+
+rnexecutorch::core::types::DType
+getDTypeOrThrow(facebook::jsi::Runtime &rt, const std::string &ctx,
+                executorch::aten::ScalarType scalarType) {
+    try {
+        return rnexecutorch::core::types::fromScalarType(scalarType);
+    } catch (const std::exception &e) {
+        throw facebook::jsi::JSError(rt, std::format("{}: Unsupported tensor dtype: {}", ctx, e.what()));
+    }
+}
+} // namespace
 
 namespace rnexecutorch::core::model {
 namespace jsi = facebook::jsi;
@@ -50,15 +74,11 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 throw jsi::JSError(rt, "getMethodNames: Model has been disposed");
             }
 
-            auto methodNames = self->etModule_->method_names();
-            if (!methodNames.ok()) {
-                const std::string errorMsg = executorch::runtime::to_string(methodNames.error());
-                throw jsi::JSError(rt, "getMethodNames: Failed to get method names: " + errorMsg);
-            }
+            auto methodNames = getOrThrow(rt, "getMethodNames", self->etModule_->method_names());
 
-            auto jsArray = jsi::Array(rt, methodNames->size());
+            auto jsArray = jsi::Array(rt, methodNames.size());
             size_t index = 0;
-            for (const auto &methodName : methodNames.get()) {
+            for (const auto &methodName : methodNames) {
                 jsArray.setValueAtIndex(rt, index, jsi::String::createFromUtf8(rt, methodName));
                 ++index;
             }
@@ -76,7 +96,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             }
 
             if (!args[0].isString()) {
-                throw jsi::JSError(rt, "getMethodMeta: Expected arg0 to be a string");
+                throw jsi::JSError(rt, "getMethodMeta: Expected methodName to be a string");
             }
 
             std::unique_lock<std::mutex> lock(self->mutex_, std::try_to_lock);
@@ -89,40 +109,24 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             }
 
             auto methodName = conversions::asType<std::string>(rt, "getMethodMeta: methodName", args[0]);
-            auto methodMeta = self->etModule_->method_meta(methodName);
-            if (!methodMeta.ok()) {
-                const std::string errorMsg = executorch::runtime::to_string(methodMeta.error());
-                throw jsi::JSError(rt, std::format("getMethodMeta: Failed to get method meta: {}", errorMsg));
+            auto methodMeta = getOrThrow(rt, "getMethodMeta", self->etModule_->method_meta(methodName));
+
+            auto inputTagsArray = jsi::Array(rt, methodMeta.num_inputs());
+            for (size_t i = 0; i < methodMeta.num_inputs(); ++i) {
+                auto tag = getOrThrow(rt, std::format("getMethodMeta: input tag [{}]", i), methodMeta.input_tag(i));
+                inputTagsArray.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, executorch::runtime::tag_to_string(tag)));
             }
 
-            auto inputTagsArray = jsi::Array(rt, methodMeta->num_inputs());
-            for (size_t i = 0; i < methodMeta->num_inputs(); ++i) {
-                auto tag = methodMeta->input_tag(i);
-                if (!tag.ok()) {
-                    const std::string errorMsg = executorch::runtime::to_string(tag.error());
-                    throw jsi::JSError(rt, std::format("getMethodMeta: Failed to get input tag for input {}: {}", i, errorMsg));
-                }
-                inputTagsArray.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, executorch::runtime::tag_to_string(tag.get())));
-            }
-
-            auto outputTagsArray = jsi::Array(rt, methodMeta->num_outputs());
-            for (size_t i = 0; i < methodMeta->num_outputs(); ++i) {
-                auto tag = methodMeta->output_tag(i);
-                if (!tag.ok()) {
-                    const std::string errorMsg = executorch::runtime::to_string(tag.error());
-                    throw jsi::JSError(rt, std::format("getMethodMeta: Failed to get output tag for output {}: {}", i, errorMsg));
-                }
-                outputTagsArray.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, executorch::runtime::tag_to_string(tag.get())));
+            auto outputTagsArray = jsi::Array(rt, methodMeta.num_outputs());
+            for (size_t i = 0; i < methodMeta.num_outputs(); ++i) {
+                auto tag = getOrThrow(rt, std::format("getMethodMeta: output tag [{}]", i), methodMeta.output_tag(i));
+                outputTagsArray.setValueAtIndex(rt, i, jsi::String::createFromUtf8(rt, executorch::runtime::tag_to_string(tag)));
             }
 
             auto usesBackendMap = jsi::Object(rt);
-            for (size_t i = 0; i < methodMeta->num_backends(); ++i) {
-                auto backendName = methodMeta->get_backend_name(i);
-                if (!backendName.ok()) {
-                    const std::string errorMsg = executorch::runtime::to_string(backendName.error());
-                    throw jsi::JSError(rt, std::format("getMethodMeta: Failed to get backend name for backend {}: {}", i, errorMsg));
-                }
-                usesBackendMap.setProperty(rt, backendName.get(), methodMeta->uses_backend(backendName.get()));
+            for (size_t i = 0; i < methodMeta.num_backends(); ++i) {
+                const auto *backendName = getOrThrow(rt, std::format("getMethodMeta: backend name [{}]", i), methodMeta.get_backend_name(i));
+                usesBackendMap.setProperty(rt, backendName, methodMeta.uses_backend(backendName));
             }
 
             auto tensorMetaToJS = [](jsi::Runtime &rt, const executorch::runtime::TensorInfo &tensorMeta) -> jsi::Object {
@@ -132,7 +136,7 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 jsTensorMeta.setProperty(rt, "nbytes", static_cast<double>(tensorMeta.nbytes()));
 
                 try {
-                    const std::string dtypeStr = types::toString(types::fromScalarType(tensorMeta.scalar_type()));
+                    auto dtypeStr = types::toString(types::fromScalarType(tensorMeta.scalar_type()));
                     jsTensorMeta.setProperty(rt, "dtype", jsi::String::createFromUtf8(rt, dtypeStr));
                 } catch (const std::exception &) {
                     jsTensorMeta.setProperty(rt, "dtype", jsi::String::createFromUtf8(rt, "not supported"));
@@ -147,30 +151,22 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 return jsTensorMeta;
             };
 
-            auto inputTensorMetaArray = jsi::Array(rt, methodMeta->num_inputs());
-            for (size_t i = 0; i < methodMeta->num_inputs(); ++i) {
-                auto tensorMeta = methodMeta->input_tensor_meta(i);
-                if (!tensorMeta.ok()) {
-                    const std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
-                    throw jsi::JSError(rt, std::format("getMethodMeta: Failed to get tensor meta for input {}: {}", i, errorMsg));
-                }
-                inputTensorMetaArray.setValueAtIndex(rt, i, tensorMetaToJS(rt, tensorMeta.get()));
+            auto inputTensorMetaArray = jsi::Array(rt, methodMeta.num_inputs());
+            for (size_t i = 0; i < methodMeta.num_inputs(); ++i) {
+                auto tensorMeta = getOrThrow(rt, std::format("getMethodMeta: input tensor meta [{}]", i), methodMeta.input_tensor_meta(i));
+                inputTensorMetaArray.setValueAtIndex(rt, i, tensorMetaToJS(rt, tensorMeta));
             }
 
-            auto outputTensorMetaArray = jsi::Array(rt, methodMeta->num_outputs());
-            for (size_t i = 0; i < methodMeta->num_outputs(); ++i) {
-                auto tensorMeta = methodMeta->output_tensor_meta(i);
-                if (!tensorMeta.ok()) {
-                    const std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
-                    throw jsi::JSError(rt, std::format("getMethodMeta: Failed to get tensor meta for output {}: {}", i, errorMsg));
-                }
-                outputTensorMetaArray.setValueAtIndex(rt, i, tensorMetaToJS(rt, tensorMeta.get()));
+            auto outputTensorMetaArray = jsi::Array(rt, methodMeta.num_outputs());
+            for (size_t i = 0; i < methodMeta.num_outputs(); ++i) {
+                auto tensorMeta = getOrThrow(rt, std::format("getMethodMeta: output tensor meta [{}]", i), methodMeta.output_tensor_meta(i));
+                outputTensorMetaArray.setValueAtIndex(rt, i, tensorMetaToJS(rt, tensorMeta));
             }
 
             auto jsMeta = jsi::Object(rt);
-            jsMeta.setProperty(rt, "name", jsi::String::createFromUtf8(rt, methodMeta->name()));
-            jsMeta.setProperty(rt, "numInputs", static_cast<double>(methodMeta->num_inputs()));
-            jsMeta.setProperty(rt, "numOutputs", static_cast<double>(methodMeta->num_outputs()));
+            jsMeta.setProperty(rt, "name", jsi::String::createFromUtf8(rt, methodMeta.name()));
+            jsMeta.setProperty(rt, "numInputs", static_cast<double>(methodMeta.num_inputs()));
+            jsMeta.setProperty(rt, "numOutputs", static_cast<double>(methodMeta.num_outputs()));
             jsMeta.setProperty(rt, "inputTags", inputTagsArray);
             jsMeta.setProperty(rt, "outputTags", outputTagsArray);
             jsMeta.setProperty(rt, "usesBackend", usesBackendMap);
@@ -199,83 +195,37 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
             }
 
             auto methodName = conversions::asType<std::string>(rt, "execute: methodName", args[0]);
-            auto methodMeta = self->etModule_->method_meta(methodName);
+            auto methodMeta = getOrThrow(rt, std::format("execute: method meta for '{}'", methodName),
+                                         self->etModule_->method_meta(methodName));
+
             auto inputsArray = args[1].asObject(rt).asArray(rt);
             auto outputTensorsArray = args[2].asObject(rt).asArray(rt);
 
-            if (!methodMeta.ok()) {
-                const std::string errorMsg = executorch::runtime::to_string(methodMeta.error());
-                throw jsi::JSError(rt, std::format("execute: Failed to get method meta for '{}': {}",
-                                                   methodName, errorMsg));
-            }
-
-            if (inputsArray.size(rt) != methodMeta->num_inputs()) {
+            if (inputsArray.size(rt) != methodMeta.num_inputs()) {
                 throw jsi::JSError(rt, std::format("execute: Incorrect size for inputs: got {}, expected {}",
-                                                   inputsArray.size(rt), methodMeta->num_inputs()));
+                                                   inputsArray.size(rt), methodMeta.num_inputs()));
             }
 
-            auto validateTensor = [](jsi::Runtime &rt,
-                                     const TensorHostObject *tensorHostObject,
-                                     const executorch::runtime::Result<executorch::runtime::TensorInfo> &tensorMeta,
-                                     const std::string &identifier) {
-                if (tensorMeta->scalar_type() != tensorHostObject->tensor_->dtype()) {
-                    throw jsi::JSError(rt, std::format("execute: Tensor dtype mismatch for {}", identifier));
-                }
-
-                if (tensorMeta->sizes().size() != tensorHostObject->shape_.size()) {
-                    throw jsi::JSError(rt, std::format("execute: Tensor rank mismatch for {}: expected rank {} but got {}",
-                                                       identifier, tensorMeta->sizes().size(), tensorHostObject->shape_.size()));
-                }
-
-                auto ndim = tensorHostObject->tensor_->sizes().size();
-                for (size_t j = 0; j < ndim; ++j) {
-                    if (tensorMeta->sizes()[j] != tensorHostObject->shape_[j]) {
-                        throw jsi::JSError(rt, std::format("execute: Tensor shape mismatch for {}: expected dimension {} to be {} but got {}",
-                                                           identifier, j, tensorMeta->sizes()[j], tensorHostObject->shape_[j]));
-                    }
-                }
-            };
-
-            auto inputs = std::vector<executorch::runtime::EValue>(methodMeta->num_inputs());
+            std::vector<executorch::runtime::EValue> inputs(methodMeta.num_inputs());
             std::vector<std::unique_lock<std::shared_mutex>> tensorLocks;
             std::unordered_set<TensorHostObject *> lockedTensors;
 
-            for (size_t i = 0; i < methodMeta->num_inputs(); ++i) {
-                auto tag = methodMeta->input_tag(i);
+            for (size_t i = 0; i < methodMeta.num_inputs(); ++i) {
+                auto tag = getOrThrow(rt, std::format("execute: inputs[{}] tag", i), methodMeta.input_tag(i));
                 auto val = inputsArray.getValueAtIndex(rt, i);
-                const auto ident = std::format("inputs[{}]", i);
-                const auto ctx = std::format("execute: {}", ident);
+                auto ctx = std::format("execute: inputs[{}]", i);
 
-                if (!tag.ok()) {
-                    const std::string errorMsg = executorch::runtime::to_string(tag.error());
-                    throw jsi::JSError(rt, std::format("{}: Failed to get input tag: {}", ctx, errorMsg));
-                }
-
-                switch (tag.get()) {
+                switch (tag) {
                 case executorch::runtime::Tag::Tensor: {
-                    auto tensorHostObject = tensor::fromJs(rt, ctx, val, std::nullopt, std::nullopt);
+                    auto tensorMeta = getOrThrow(rt, std::format("{}: tensor meta", ctx), methodMeta.input_tensor_meta(i));
+                    auto expectedDtype = getDTypeOrThrow(rt, ctx, tensorMeta.scalar_type());
+                    auto tensorHostObject = tensor::fromJs(rt, ctx, val, expectedDtype, tensorMeta.sizes());
 
                     if (!lockedTensors.insert(tensorHostObject.get()).second) {
-                        throw jsi::JSError(rt, "execute: Tensor aliasing detected. The same tensor was passed multiple times.");
+                        throw jsi::JSError(rt, "execute: Tensor aliasing detected. "
+                                               "The same tensor was passed multiple times.");
                     }
-
-                    tensorLocks.emplace_back(tensorHostObject->mutex_, std::try_to_lock);
-                    if (!tensorLocks.back().owns_lock()) {
-                        throw jsi::JSError(rt, std::format("{} is currently in use", ctx));
-                    }
-
-                    if (!tensorHostObject->data_) {
-                        throw jsi::JSError(rt, std::format("{} has been disposed", ctx));
-                    }
-
-                    auto tensorMeta = methodMeta->input_tensor_meta(i);
-
-                    if (!tensorMeta.ok()) {
-                        const std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
-                        throw jsi::JSError(rt, std::format("{}: Failed to get tensor meta: {}", ctx, errorMsg));
-                    }
-
-                    validateTensor(rt, tensorHostObject.get(), tensorMeta, ident);
+                    tensorLocks.emplace_back(tensor::tryLockUnique(rt, ctx, tensorHostObject));
 
                     inputs[i] = tensorHostObject->tensor_;
                     break;
@@ -294,34 +244,18 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                 }
             }
 
-            auto startTime = std::chrono::high_resolution_clock::now();
-            auto result = self->etModule_->execute(methodName, inputs);
-            auto finishTime = std::chrono::high_resolution_clock::now();
+            const auto result = getOrThrow(rt, std::format("execute: Method '{}' failed (check getMethodMeta() "
+                                                           "for required backends and getRegisteredBackends() "
+                                                           "for registered ones)",
+                                                           methodName),
+                                           self->etModule_->execute(methodName, inputs));
 
-#ifdef EXECUTORCH_ENABLE_EXECUTION_PROFILING
-            auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(finishTime - startTime).count();
-            auto consoleObj = rt.global().getProperty(rt, "console").asObject(rt);
-            auto logFn = consoleObj.getProperty(rt, "log").asObject(rt).asFunction(rt);
-            auto info = std::format("Execution of method '{}' took {} ms", methodName, durationMs);
-            logFn.callWithThis(rt, consoleObj, {jsi::String::createFromUtf8(rt, info)});
-#endif
-
-            if (!result.ok()) {
-                const std::string errorMsg = executorch::runtime::to_string(result.error());
-                throw jsi::JSError(rt, std::format("execute: Method '{}' execution failed: {}. "
-                                                   "This may be due to missing required backends - "
-                                                   "use getMethodMeta() to check required backends and "
-                                                   "getExecuTorchRegisteredBackends() to check "
-                                                   "which backends are registered in the runtime.",
-                                                   methodName, errorMsg));
-            }
-
-            auto jsOutputArray = jsi::Array(rt, result->size());
+            auto jsOutputArray = jsi::Array(rt, result.size());
 
             size_t index = 0;
             size_t tensorOutputIdx = 0;
 
-            for (const auto &output : result.get()) {
+            for (const auto &output : result) {
                 switch (output.tag) {
                 case executorch::runtime::Tag::None: {
                     jsOutputArray.setValueAtIndex(rt, index, jsi::Value::null());
@@ -332,37 +266,19 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                         throw jsi::JSError(rt, "execute: Not enough tensor output placeholders in outputTensors");
                     }
 
-                    const auto val = outputTensorsArray.getValueAtIndex(rt, tensorOutputIdx);
-                    const auto ident = std::format("outputTensors[{}]", tensorOutputIdx);
-                    const auto ctx = std::format("execute: {}", ident);
+                    auto val = outputTensorsArray.getValueAtIndex(rt, tensorOutputIdx);
+                    auto ctx = std::format("execute: outputTensors[{}]", tensorOutputIdx);
 
-                    auto tensorHostObject = tensor::fromJs(rt, ctx, val, std::nullopt, std::nullopt);
+                    auto tensorMeta = getOrThrow(rt, std::format("{}: tensor meta", ctx), methodMeta.output_tensor_meta(index));
+                    auto expectedDtype = getDTypeOrThrow(rt, ctx, tensorMeta.scalar_type());
+                    auto tensorHostObject = tensor::fromJs(rt, ctx, val, expectedDtype, tensorMeta.sizes());
+
                     if (!lockedTensors.insert(tensorHostObject.get()).second) {
                         throw jsi::JSError(rt, "execute: Tensor aliasing detected. The same tensor was passed multiple times.");
                     }
+                    tensorLocks.emplace_back(tensor::tryLockUnique(rt, ctx, tensorHostObject));
 
-                    tensorLocks.emplace_back(tensorHostObject->mutex_, std::try_to_lock);
-                    if (!tensorLocks.back().owns_lock()) {
-                        throw jsi::JSError(rt, std::format("{} is currently in use", ctx));
-                    }
-
-                    if (!tensorHostObject->data_) {
-                        throw jsi::JSError(rt, std::format("{} has been disposed", ctx));
-                    }
-
-                    auto tensorMeta = methodMeta->output_tensor_meta(index);
-
-                    if (!tensorMeta.ok()) {
-                        const std::string errorMsg = executorch::runtime::to_string(tensorMeta.error());
-                        throw jsi::JSError(rt, std::format("execute: Failed to get tensor meta for output at index {}: {}",
-                                                           index, errorMsg));
-                    }
-
-                    validateTensor(rt, tensorHostObject.get(), tensorMeta, ident);
-
-                    std::memcpy(tensorHostObject->data_.get(),
-                                output.toTensor().const_data_ptr(),
-                                output.toTensor().nbytes());
+                    std::memcpy(tensorHostObject->data_.get(), output.toTensor().const_data_ptr(), output.toTensor().nbytes());
 
                     jsOutputArray.setValueAtIndex(rt, index, jsi::Object::createFromHostObject(rt, tensorHostObject));
                     ++tensorOutputIdx;

--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -22,7 +22,7 @@ namespace types = rnexecutorch::core::types;
 template <typename T>
 T unwrap(jsi::Runtime &rt, const std::string &ctx, executorch::runtime::Result<T> result) {
     if (!result.ok()) {
-        throw jsi::JSError(rt, ctx + ": " + executorch::runtime::to_string(result.error()));
+        throw jsi::JSError(rt, std::format("{}: {}", ctx, executorch::runtime::to_string(result.error())));
     }
     return std::move(result.get());
 }

--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -1,13 +1,15 @@
 #include "model.h"
-#include "dtype.h"
-#include "tensor_helpers.h"
 
 #include <chrono>
 #include <exception>
 #include <format>
-#include <jsi/jsi.h>
 #include <unordered_set>
 #include <utility>
+
+#include "dtype.h"
+#include "tensor_helpers.h"
+
+#include <jsi/jsi.h>
 
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/core/error.h>
@@ -255,8 +257,8 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
 
 #ifdef EXECUTORCH_ENABLE_EXECUTION_PROFILING
             auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(finishTime - startTime).count();
-            auto consoleObj = rt.global().getProperty(rt, "console").asObject(rt);
-            auto logFn = consoleObj.getProperty(rt, "log").asObject(rt).asFunction(rt);
+            auto consoleObj = conversions::asType<jsi::Object>(rt, "console", rt.global().getProperty(rt, "console"));
+            auto logFn = conversions::asType<jsi::Function>(rt, "console.log", consoleObj.getProperty(rt, "log"));
             auto info = std::format("Execution of method '{}' took {} ms", methodName, durationMs);
             logFn.callWithThis(rt, consoleObj, {jsi::String::createFromUtf8(rt, info)});
 #endif

--- a/packages/react-native-executorch/cpp/core/model.h
+++ b/packages/react-native-executorch/cpp/core/model.h
@@ -10,6 +10,7 @@
 #include <executorch/extension/module/module.h>
 
 namespace rnexecutorch::core::model {
+namespace jsi = facebook::jsi;
 /**
  * JSI HostObject wrapping an ExecuTorch Model instance
  * (`executorch::extension::Module`).
@@ -18,17 +19,19 @@ namespace rnexecutorch::core::model {
  * retrieving method names, executing inference runs, and disposing of native
  * resources.
  */
-class ModelHostObject : public facebook::jsi::HostObject, public std::enable_shared_from_this<ModelHostObject> {
+class ModelHostObject : public jsi::HostObject,
+                        public std::enable_shared_from_this<ModelHostObject> {
 public:
+    explicit ModelHostObject(const std::string &modelPath);
+
+    jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &name) override;
+    std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
+
+private:
     std::string modelPath_;
     std::unique_ptr<executorch::extension::Module> etModule_;
     std::mutex mutex_;
-
-    explicit ModelHostObject(const std::string &modelPath);
-
-    facebook::jsi::Value get(facebook::jsi::Runtime &rt, const facebook::jsi::PropNameID &name) override;
-    std::vector<facebook::jsi::PropNameID> getPropertyNames(facebook::jsi::Runtime &rt) override;
 };
 
-void install_loadModel(facebook::jsi::Runtime &rt, facebook::jsi::Object &module);
+void install_loadModel(jsi::Runtime &rt, jsi::Object &module);
 } // namespace rnexecutorch::core::model

--- a/packages/react-native-executorch/cpp/core/model.h
+++ b/packages/react-native-executorch/cpp/core/model.h
@@ -28,7 +28,7 @@ public:
     std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
 
 private:
-    std::string modelPath_;
+    const std::string modelPath_;
     std::unique_ptr<executorch::extension::Module> etModule_;
     std::mutex mutex_;
 };

--- a/packages/react-native-executorch/cpp/core/model.h
+++ b/packages/react-native-executorch/cpp/core/model.h
@@ -28,7 +28,7 @@ public:
     std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
 
 private:
-    const std::string modelPath_;
+    std::string modelPath_;
     std::unique_ptr<executorch::extension::Module> etModule_;
     std::mutex mutex_;
 };

--- a/packages/react-native-executorch/cpp/core/tensor.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor.cpp
@@ -57,24 +57,24 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
             auto srcLock = tryLockShared(rt, "copyTo: self", self);
             auto dstLock = tryLockUnique(rt, "copyTo: dst", dst);
 
-            if (count == 2 && !args[1].isObject()) {
-                throw jsi::JSError(rt, "copyTo: Expected options to be an object");
+            jsi::Object optsObj(rt);
+            if (count == 2) {
+                optsObj = conversions::asType<jsi::Object>(rt, "copyTo: options", args[1]);
             }
-            const jsi::Object optsObj = (count == 2) ? args[1].asObject(rt) : jsi::Object(rt);
-            const size_t srcOffset = conversions::getOptionalProperty<uint64_t>(rt, "copyTo", optsObj, "offset").value_or(0);
-            const size_t copyLen = conversions::getOptionalProperty<uint64_t>(rt, "copyTo", optsObj, "length").value_or(self->numel_ - srcOffset);
+            size_t offset = conversions::getOptionalProperty<uint64_t>(rt, "copyTo", optsObj, "offset").value_or(0);
+            size_t length = conversions::getOptionalProperty<uint64_t>(rt, "copyTo", optsObj, "length").value_or(self->numel_ - offset);
 
-            if (srcOffset + copyLen > self->numel_) {
+            if (offset + length > self->numel_) {
                 throw jsi::JSError(rt, "copyTo: out of bounds offset and length for src tensor");
             }
 
             const auto elemSize = types::elementSize(self->dtype_);
 
-            if (copyLen * elemSize != dst->size_) {
+            if (length * elemSize != dst->size_) {
                 throw jsi::JSError(rt, "copyTo: size mismatch between copy byte size and dst tensor size");
             }
 
-            std::memcpy(dst->data_.get(), self->data_.get() + (srcOffset * elemSize), copyLen * elemSize);
+            std::memcpy(dst->data_.get(), self->data_.get() + (offset * elemSize), length * elemSize);
 
             return jsi::Value(rt, args[0].asObject(rt));
         };
@@ -88,10 +88,7 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "setData: Usage: setData(array)");
             }
 
-            if (!args[0].isObject()) {
-                throw jsi::JSError(rt, "setData: Expected array to be an object (TypedArray)");
-            }
-            auto dataObj = args[0].asObject(rt);
+            auto dataObj = conversions::asType<jsi::Object>(rt, "setData: array", args[0]);
             auto buffer = conversions::getRequiredProperty<jsi::ArrayBuffer>(rt, "setData", dataObj, "buffer");
             size_t byteOffset = conversions::getOptionalProperty<uint64_t>(rt, "setData", dataObj, "byteOffset").value_or(0);
             size_t byteLength = conversions::getOptionalProperty<uint64_t>(rt, "setData", dataObj, "byteLength").value_or(buffer.size(rt));
@@ -117,10 +114,7 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "getData: Usage: getData(array)");
             }
 
-            if (!args[0].isObject()) {
-                throw jsi::JSError(rt, "getData: Expected array to be an object (TypedArray)");
-            }
-            auto dataObj = args[0].asObject(rt);
+            auto dataObj = conversions::asType<jsi::Object>(rt, "getData: array", args[0]);
             auto buffer = conversions::getRequiredProperty<jsi::ArrayBuffer>(rt, "getData", dataObj, "buffer");
             size_t byteOffset = conversions::getOptionalProperty<uint64_t>(rt, "getData", dataObj, "byteOffset").value_or(0);
             size_t byteLength = conversions::getOptionalProperty<uint64_t>(rt, "getData", dataObj, "byteLength").value_or(buffer.size(rt));
@@ -146,10 +140,7 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "through: Usage: through(fn, ...args)");
             }
 
-            if (!args[0].isObject() || !args[0].asObject(rt).isFunction(rt)) {
-                throw jsi::JSError(rt, "through: First argument must be a function");
-            }
-            auto fn = args[0].asObject(rt).asFunction(rt);
+            auto fn = conversions::asType<jsi::Function>(rt, "through: fn", args[0]);
 
             std::vector<jsi::Value> fnArgs;
             fnArgs.reserve(count);
@@ -176,10 +167,7 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 return jsi::Value(rt, thisVal);
             }
 
-            if (!args[1].isObject() || !args[1].asObject(rt).isFunction(rt)) {
-                throw jsi::JSError(rt, "throughIf: Second argument must be a function");
-            }
-            auto fn = args[1].asObject(rt).asFunction(rt);
+            auto fn = conversions::asType<jsi::Function>(rt, "throughIf: fn", args[1]);
 
             std::vector<jsi::Value> fnArgs;
             fnArgs.reserve(count - 1);

--- a/packages/react-native-executorch/cpp/core/tensor.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor.cpp
@@ -57,9 +57,9 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
             auto srcLock = tryLockShared(rt, "copyTo: self", self);
             auto dstLock = tryLockUnique(rt, "copyTo: dst", dst);
 
-            const jsi::Object optsObj = (count == 2 && args[1].isObject()) ? args[1].asObject(rt) : jsi::Object(rt);
-            const size_t srcOffset = conversions::getOptionalProperty<size_t>(rt, "copyTo", optsObj, "offset").value_or(0);
-            const size_t copyLen = conversions::getOptionalProperty<size_t>(rt, "copyTo", optsObj, "length").value_or(self->numel_ - srcOffset);
+            const jsi::Object optsObj = (count == 2) ? args[1].asObject(rt) : jsi::Object(rt);
+            const size_t srcOffset = conversions::getOptionalProperty<uint64_t>(rt, "copyTo", optsObj, "offset").value_or(0);
+            const size_t copyLen = conversions::getOptionalProperty<uint64_t>(rt, "copyTo", optsObj, "length").value_or(self->numel_ - srcOffset);
 
             if (srcOffset + copyLen > self->numel_) {
                 throw jsi::JSError(rt, "copyTo: out of bounds offset and length for src tensor");
@@ -87,8 +87,8 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
 
             const auto dataObj = args[0].asObject(rt);
             const auto buffer = dataObj.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt);
-            size_t byteOffset = conversions::getOptionalProperty<size_t>(rt, "setData", dataObj, "byteOffset").value_or(0);
-            size_t byteLength = conversions::getOptionalProperty<size_t>(rt, "setData", dataObj, "byteLength").value_or(buffer.size(rt));
+            size_t byteOffset = conversions::getOptionalProperty<uint64_t>(rt, "setData", dataObj, "byteOffset").value_or(0);
+            size_t byteLength = conversions::getOptionalProperty<uint64_t>(rt, "setData", dataObj, "byteLength").value_or(buffer.size(rt));
 
             auto lock = tryLockUnique(rt, "setData: self", self);
 
@@ -113,8 +113,8 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
 
             const jsi::Object dataObj = args[0].asObject(rt);
             const jsi::ArrayBuffer buffer = dataObj.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt);
-            size_t byteOffset = conversions::getOptionalProperty<size_t>(rt, "getData", dataObj, "byteOffset").value_or(0);
-            size_t byteLength = conversions::getOptionalProperty<size_t>(rt, "getData", dataObj, "byteLength").value_or(buffer.size(rt));
+            size_t byteOffset = conversions::getOptionalProperty<uint64_t>(rt, "getData", dataObj, "byteOffset").value_or(0);
+            size_t byteLength = conversions::getOptionalProperty<uint64_t>(rt, "getData", dataObj, "byteLength").value_or(buffer.size(rt));
 
             auto lock = tryLockShared(rt, "getData: self", self);
 

--- a/packages/react-native-executorch/cpp/core/tensor.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor.cpp
@@ -57,6 +57,9 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
             auto srcLock = tryLockShared(rt, "copyTo: self", self);
             auto dstLock = tryLockUnique(rt, "copyTo: dst", dst);
 
+            if (count == 2 && !args[1].isObject()) {
+                throw jsi::JSError(rt, "copyTo: Expected options to be an object");
+            }
             const jsi::Object optsObj = (count == 2) ? args[1].asObject(rt) : jsi::Object(rt);
             const size_t srcOffset = conversions::getOptionalProperty<uint64_t>(rt, "copyTo", optsObj, "offset").value_or(0);
             const size_t copyLen = conversions::getOptionalProperty<uint64_t>(rt, "copyTo", optsObj, "length").value_or(self->numel_ - srcOffset);
@@ -85,8 +88,15 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "setData: Usage: setData(array)");
             }
 
-            const auto dataObj = args[0].asObject(rt);
-            const auto buffer = dataObj.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt);
+            if (!args[0].isObject()) {
+                throw jsi::JSError(rt, "setData: Expected array to be an object (TypedArray)");
+            }
+            auto dataObj = args[0].asObject(rt);
+            auto bufferVal = conversions::getRequiredProperty<jsi::Value>(rt, "setData", dataObj, "buffer");
+            if (!bufferVal.isObject() || !bufferVal.asObject(rt).isArrayBuffer(rt)) {
+                throw jsi::JSError(rt, "setData: option 'buffer' must be an ArrayBuffer");
+            }
+            auto buffer = bufferVal.asObject(rt).getArrayBuffer(rt);
             size_t byteOffset = conversions::getOptionalProperty<uint64_t>(rt, "setData", dataObj, "byteOffset").value_or(0);
             size_t byteLength = conversions::getOptionalProperty<uint64_t>(rt, "setData", dataObj, "byteLength").value_or(buffer.size(rt));
 
@@ -111,8 +121,15 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "getData: Usage: getData(array)");
             }
 
-            const jsi::Object dataObj = args[0].asObject(rt);
-            const jsi::ArrayBuffer buffer = dataObj.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt);
+            if (!args[0].isObject()) {
+                throw jsi::JSError(rt, "getData: Expected array to be an object (TypedArray)");
+            }
+            auto dataObj = args[0].asObject(rt);
+            auto bufferVal = conversions::getRequiredProperty<jsi::Value>(rt, "getData", dataObj, "buffer");
+            if (!bufferVal.isObject() || !bufferVal.asObject(rt).isArrayBuffer(rt)) {
+                throw jsi::JSError(rt, "getData: option 'buffer' must be an ArrayBuffer");
+            }
+            auto buffer = bufferVal.asObject(rt).getArrayBuffer(rt);
             size_t byteOffset = conversions::getOptionalProperty<uint64_t>(rt, "getData", dataObj, "byteOffset").value_or(0);
             size_t byteLength = conversions::getOptionalProperty<uint64_t>(rt, "getData", dataObj, "byteLength").value_or(buffer.size(rt));
 
@@ -137,6 +154,9 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "through: Usage: through(fn, ...args)");
             }
 
+            if (!args[0].isObject() || !args[0].asObject(rt).isFunction(rt)) {
+                throw jsi::JSError(rt, "through: First argument must be a function");
+            }
             auto fn = args[0].asObject(rt).asFunction(rt);
 
             std::vector<jsi::Value> fnArgs;
@@ -164,6 +184,9 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 return jsi::Value(rt, thisVal);
             }
 
+            if (!args[1].isObject() || !args[1].asObject(rt).isFunction(rt)) {
+                throw jsi::JSError(rt, "throughIf: Second argument must be a function");
+            }
             auto fn = args[1].asObject(rt).asFunction(rt);
 
             std::vector<jsi::Value> fnArgs;

--- a/packages/react-native-executorch/cpp/core/tensor.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor.cpp
@@ -51,7 +51,7 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "copyTo: Usage: copyTo(dst, options?)");
             }
 
-            auto dst = fromJs(rt, "copyTo: dst", args[0], std::nullopt, std::nullopt);
+            auto dst = tensor::fromJs(rt, "copyTo: dst", args[0], std::nullopt, std::nullopt);
 
             checkNotSameTensor(rt, "copyTo: self", self, "copyTo: dst", dst);
             auto srcLock = tryLockShared(rt, "copyTo: self", self);

--- a/packages/react-native-executorch/cpp/core/tensor.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor.cpp
@@ -92,11 +92,7 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "setData: Expected array to be an object (TypedArray)");
             }
             auto dataObj = args[0].asObject(rt);
-            auto bufferVal = conversions::getRequiredProperty<jsi::Value>(rt, "setData", dataObj, "buffer");
-            if (!bufferVal.isObject() || !bufferVal.asObject(rt).isArrayBuffer(rt)) {
-                throw jsi::JSError(rt, "setData: option 'buffer' must be an ArrayBuffer");
-            }
-            auto buffer = bufferVal.asObject(rt).getArrayBuffer(rt);
+            auto buffer = conversions::getRequiredProperty<jsi::ArrayBuffer>(rt, "setData", dataObj, "buffer");
             size_t byteOffset = conversions::getOptionalProperty<uint64_t>(rt, "setData", dataObj, "byteOffset").value_or(0);
             size_t byteLength = conversions::getOptionalProperty<uint64_t>(rt, "setData", dataObj, "byteLength").value_or(buffer.size(rt));
 
@@ -125,11 +121,7 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "getData: Expected array to be an object (TypedArray)");
             }
             auto dataObj = args[0].asObject(rt);
-            auto bufferVal = conversions::getRequiredProperty<jsi::Value>(rt, "getData", dataObj, "buffer");
-            if (!bufferVal.isObject() || !bufferVal.asObject(rt).isArrayBuffer(rt)) {
-                throw jsi::JSError(rt, "getData: option 'buffer' must be an ArrayBuffer");
-            }
-            auto buffer = bufferVal.asObject(rt).getArrayBuffer(rt);
+            auto buffer = conversions::getRequiredProperty<jsi::ArrayBuffer>(rt, "getData", dataObj, "buffer");
             size_t byteOffset = conversions::getOptionalProperty<uint64_t>(rt, "getData", dataObj, "byteOffset").value_or(0);
             size_t byteLength = conversions::getOptionalProperty<uint64_t>(rt, "getData", dataObj, "byteLength").value_or(buffer.size(rt));
 

--- a/packages/react-native-executorch/cpp/core/tensor.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor.cpp
@@ -1,35 +1,43 @@
 #include "tensor.h"
+#include "dtype.h"
+#include "tensor_helpers.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
+#include <format>
 #include <numeric>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <variant>
+
+#include <executorch/extension/tensor/tensor_ptr_maker.h>
 
 namespace rnexecutorch::core::tensor {
-namespace jsi = facebook::jsi;
+namespace types = rnexecutorch::core::types;
+namespace conversions = rnexecutorch::core::conversions;
 
-TensorHostObject::TensorHostObject(const std::vector<std::int32_t> &shape, rnexecutorch::core::types::DType dtype)
+TensorHostObject::TensorHostObject(const std::vector<std::int32_t> &shape, DType dtype)
     : dtype_(dtype),
       shape_(shape),
-      numel_(std::accumulate(shape.begin(), shape.end(), static_cast<size_t>(1), std::multiplies<>())) {
-    const auto elemSize = rnexecutorch::core::types::elementSize(dtype);
-
-    size_ = numel_ * elemSize;
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays): owning runtime-sized byte buffer
-    data_ = std::make_unique<std::uint8_t[]>(size_);
-    tensor_ = executorch::extension::from_blob(data_.get(), shape_, rnexecutorch::core::types::toScalarType(dtype));
+      numel_(std::accumulate(shape.begin(), shape.end(), static_cast<size_t>(1), std::multiplies<>())),
+      size_(numel_ * types::elementSize(dtype)) {
+    data_ = std::make_unique<std::uint8_t[]>(size_); // NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays):
+                                                     // owning runtime-sized byte buffer
+    tensor_ = executorch::extension::from_blob(data_.get(), shape_, types::toScalarType(dtype));
 }
 
 jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
     auto nameStr = name.utf8(rt);
 
     if (nameStr == "shape") {
-        auto jsArray = jsi::Array(rt, shape_.size());
-        for (size_t i = 0; i < shape_.size(); ++i) {
-            jsArray.setValueAtIndex(rt, i, static_cast<double>(shape_[i]));
-        }
-        return jsArray;
+        return conversions::toJsiArray(rt, shape_);
     }
 
     if (nameStr == "dtype") {
-        return jsi::String::createFromUtf8(rt, rnexecutorch::core::types::toString(dtype_));
+        return jsi::String::createFromUtf8(rt, types::toString(dtype_));
     }
 
     if (nameStr == "numel") {
@@ -43,54 +51,22 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "copyTo: Usage: copyTo(dst, options?)");
             }
 
-            if (!args[0].isObject() || !args[0].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-                throw jsi::JSError(rt, "copyTo: Expected dst to be a Tensor");
-            }
+            auto dst = fromJs(rt, "copyTo: dst", args[0], std::nullopt, std::nullopt);
 
-            auto dst = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
+            checkNotSameTensor(rt, "copyTo: self", self, "copyTo: dst", dst);
+            auto srcLock = tryLockShared(rt, "copyTo: self", self);
+            auto dstLock = tryLockUnique(rt, "copyTo: dst", dst);
 
-            if (self.get() == dst.get()) {
-                throw jsi::JSError(rt, "copyTo: In-place operations (src == dst) are not supported.");
-            }
-
-            std::shared_lock<std::shared_mutex> srcLock(self->mutex_, std::try_to_lock);
-            if (!srcLock.owns_lock()) {
-                throw jsi::JSError(rt, "copyTo: src tensor is currently in use");
-            }
-
-            std::unique_lock<std::shared_mutex> dstLock(dst->mutex_, std::try_to_lock);
-            if (!dstLock.owns_lock()) {
-                throw jsi::JSError(rt, "copyTo: dst tensor is currently in use");
-            }
-
-            if (!self->data_) {
-                throw jsi::JSError(rt, "copyTo: src tensor has been disposed");
-            }
-
-            if (!dst->data_) {
-                throw jsi::JSError(rt, "copyTo: dst tensor has been disposed");
-            }
-
-            size_t srcOffset = 0;
-            size_t copyLen = self->numel_;
-            if (count == 2 && args[1].isObject()) {
-                auto optsObj = args[1].asObject(rt);
-                if (optsObj.hasProperty(rt, "offset")) {
-                    srcOffset = static_cast<size_t>(optsObj.getProperty(rt, "offset").asNumber());
-                }
-
-                copyLen -= srcOffset;
-
-                if (optsObj.hasProperty(rt, "length")) {
-                    copyLen = static_cast<size_t>(optsObj.getProperty(rt, "length").asNumber());
-                }
-            }
+            const jsi::Object optsObj = (count == 2 && args[1].isObject()) ? args[1].asObject(rt) : jsi::Object(rt);
+            const size_t srcOffset = conversions::getOptionalProperty<size_t>(rt, "copyTo", optsObj, "offset").value_or(0);
+            const size_t copyLen = conversions::getOptionalProperty<size_t>(rt, "copyTo", optsObj, "length").value_or(self->numel_ - srcOffset);
 
             if (srcOffset + copyLen > self->numel_) {
                 throw jsi::JSError(rt, "copyTo: out of bounds offset and length for src tensor");
             }
 
-            const auto elemSize = rnexecutorch::core::types::elementSize(self->dtype_);
+            const auto elemSize = types::elementSize(self->dtype_);
+
             if (copyLen * elemSize != dst->size_) {
                 throw jsi::JSError(rt, "copyTo: size mismatch between copy byte size and dst tensor size");
             }
@@ -109,49 +85,16 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "setData: Usage: setData(array)");
             }
 
-            if (!args[0].isObject()) {
-                throw jsi::JSError(rt, "setData: Expected array to be an object (TypedArray)");
-            }
+            const auto dataObj = args[0].asObject(rt);
+            const auto buffer = dataObj.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt);
+            size_t byteOffset = conversions::getOptionalProperty<size_t>(rt, "setData", dataObj, "byteOffset").value_or(0);
+            size_t byteLength = conversions::getOptionalProperty<size_t>(rt, "setData", dataObj, "byteLength").value_or(buffer.size(rt));
 
-            const jsi::Object dataObj = args[0].asObject(rt);
-            if (!dataObj.hasProperty(rt, "buffer")) {
-                throw jsi::JSError(rt, "setData: Expected a TypedArray with a 'buffer' property");
-            }
-
-            const jsi::ArrayBuffer buffer = dataObj.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt);
-            size_t byteOffset = 0;
-            size_t byteLength = buffer.size(rt);
-
-            if (dataObj.hasProperty(rt, "byteOffset")) {
-                auto byteOffsetValue = dataObj.getProperty(rt, "byteOffset");
-                if (!byteOffsetValue.isNumber()) {
-                    throw jsi::JSError(rt, "setData: Expected 'byteOffset' to be a number");
-                }
-                byteOffset = static_cast<size_t>(byteOffsetValue.asNumber());
-            }
-
-            if (dataObj.hasProperty(rt, "byteLength")) {
-                auto byteLengthValue = dataObj.getProperty(rt, "byteLength");
-                if (!byteLengthValue.isNumber()) {
-                    throw jsi::JSError(rt, "setData: Expected 'byteLength' to be a number");
-                }
-                byteLength = static_cast<size_t>(byteLengthValue.asNumber());
-            }
-
-            std::unique_lock<std::shared_mutex> lock(self->mutex_, std::try_to_lock);
-            if (!lock.owns_lock()) {
-                throw jsi::JSError(rt, "setData: Tensor is currently in use and cannot be written to");
-            }
-
-            if (!self->data_) {
-                throw jsi::JSError(rt, "setData: Tensor has been disposed");
-            }
+            auto lock = tryLockUnique(rt, "setData: self", self);
 
             if (byteLength != self->size_) {
-                const std::string errorMsg = "setData: Data size mismatch: TypedArray is " + std::to_string(byteLength) +
-                                             " bytes, but Tensor requires " + std::to_string(self->size_) +
-                                             " bytes.";
-                throw jsi::JSError(rt, errorMsg);
+                throw jsi::JSError(rt, std::format("setData: Data size mismatch: TypedArray is {} bytes, but Tensor requires {} bytes.",
+                                                   byteLength, self->size_));
             }
 
             std::memcpy(self->data_.get(), buffer.data(rt) + byteOffset, byteLength);
@@ -168,49 +111,16 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "getData: Usage: getData(array)");
             }
 
-            if (!args[0].isObject()) {
-                throw jsi::JSError(rt, "getData: Expected array to be an object (TypedArray)");
-            }
-
             const jsi::Object dataObj = args[0].asObject(rt);
-            if (!dataObj.hasProperty(rt, "buffer")) {
-                throw jsi::JSError(rt, "getData: Expected a TypedArray with a 'buffer' property");
-            }
-
             const jsi::ArrayBuffer buffer = dataObj.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt);
-            size_t byteOffset = 0;
-            size_t byteLength = buffer.size(rt);
+            size_t byteOffset = conversions::getOptionalProperty<size_t>(rt, "getData", dataObj, "byteOffset").value_or(0);
+            size_t byteLength = conversions::getOptionalProperty<size_t>(rt, "getData", dataObj, "byteLength").value_or(buffer.size(rt));
 
-            if (dataObj.hasProperty(rt, "byteOffset")) {
-                auto byteOffsetValue = dataObj.getProperty(rt, "byteOffset");
-                if (!byteOffsetValue.isNumber()) {
-                    throw jsi::JSError(rt, "getData: Expected 'byteOffset' to be a number");
-                }
-                byteOffset = static_cast<size_t>(byteOffsetValue.asNumber());
-            }
-
-            if (dataObj.hasProperty(rt, "byteLength")) {
-                auto byteLengthValue = dataObj.getProperty(rt, "byteLength");
-                if (!byteLengthValue.isNumber()) {
-                    throw jsi::JSError(rt, "getData: Expected 'byteLength' to be a number");
-                }
-                byteLength = static_cast<size_t>(byteLengthValue.asNumber());
-            }
-
-            std::shared_lock<std::shared_mutex> lock(self->mutex_, std::try_to_lock);
-            if (!lock.owns_lock()) {
-                throw jsi::JSError(rt, "getData: Tensor is currently in use and cannot be read");
-            }
-
-            if (!self->data_) {
-                throw jsi::JSError(rt, "getData: Tensor has been disposed");
-            }
+            auto lock = tryLockShared(rt, "getData: self", self);
 
             if (byteLength != self->size_) {
-                const std::string errorMsg = "getData: Data size mismatch: TypedArray is " + std::to_string(byteLength) +
-                                             " bytes, but Tensor requires " + std::to_string(self->size_) +
-                                             " bytes.";
-                throw jsi::JSError(rt, errorMsg);
+                throw jsi::JSError(rt, std::format("getData: Data size mismatch: TypedArray is {} bytes, but Tensor requires {} bytes.",
+                                                   byteLength, self->size_));
             }
 
             std::memcpy(buffer.data(rt) + byteOffset, self->data_.get(), byteLength);
@@ -225,10 +135,6 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
         auto fnBody = [self](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
             if (count < 1) {
                 throw jsi::JSError(rt, "through: Usage: through(fn, ...args)");
-            }
-
-            if (!args[0].isObject() || !args[0].asObject(rt).isFunction(rt)) {
-                throw jsi::JSError(rt, "through: First argument must be a function");
             }
 
             auto fn = args[0].asObject(rt).asFunction(rt);
@@ -253,13 +159,9 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 throw jsi::JSError(rt, "throughIf: Usage: throughIf(pred, fn, ...args)");
             }
 
-            const bool pred = args[0].asBool();
+            const bool pred = conversions::asType<bool>(rt, "throughIf: pred", args[0]);
             if (!pred) {
                 return jsi::Value(rt, thisVal);
-            }
-
-            if (!args[1].isObject() || !args[1].asObject(rt).isFunction(rt)) {
-                throw jsi::JSError(rt, "throughIf: Second argument must be a function");
             }
 
             auto fn = args[1].asObject(rt).asFunction(rt);
@@ -301,8 +203,8 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
     return jsi::Value::undefined();
 }
 
-std::vector<facebook::jsi::PropNameID> TensorHostObject::getPropertyNames(jsi::Runtime &rt) {
-    std::vector<facebook::jsi::PropNameID> properties;
+std::vector<jsi::PropNameID> TensorHostObject::getPropertyNames(jsi::Runtime &rt) {
+    std::vector<jsi::PropNameID> properties;
     properties.push_back(jsi::PropNameID::forAscii(rt, "shape"));
     properties.push_back(jsi::PropNameID::forAscii(rt, "dtype"));
     properties.push_back(jsi::PropNameID::forAscii(rt, "numel"));
@@ -322,35 +224,16 @@ void install_createTensor(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "createTensor: Usage: createTensor(shape, dtype)");
         }
 
-        if (!args[0].isObject() || !args[0].asObject(rt).isArray(rt)) {
-            throw jsi::JSError(rt, "createTensor: Expected shape as an array of integers");
-        }
-
-        if (!args[1].isString()) {
-            throw jsi::JSError(rt, "createTensor: Expected dtype as a string");
-        }
-
-        auto shapeArray = args[0].asObject(rt).asArray(rt);
-        std::vector<std::int32_t> shape;
-        for (size_t i = 0; i < shapeArray.length(rt); ++i) {
-            auto dimValue = shapeArray.getValueAtIndex(rt, i);
-            if (!dimValue.isNumber()) {
-                throw jsi::JSError(rt, "createTensor: Shape array must contain only numbers");
-            }
-
-            if (dimValue.asNumber() <= 0) {
-                throw jsi::JSError(rt, "createTensor: Shape dimensions must be positive integers");
-            }
-
-            shape.push_back(static_cast<std::int32_t>(dimValue.asNumber()));
+        auto shape = conversions::asVector<int32_t>(rt, "createTensor: shape", args[0]);
+        if (std::ranges::any_of(shape, [](auto dim) { return dim <= 0; })) {
+            throw jsi::JSError(rt, "createTensor: Shape dimensions must be positive integers");
         }
 
         try {
-            const auto dtype = rnexecutorch::core::types::parseDType(args[1].asString(rt).utf8(rt));
-            auto tensorHostObject = std::make_shared<TensorHostObject>(shape, dtype);
-            return jsi::Object::createFromHostObject(rt, tensorHostObject);
+            const auto dtype = types::parseDType(conversions::asType<std::string>(rt, "createTensor: dtype", args[1]));
+            return jsi::Object::createFromHostObject(rt, std::make_shared<TensorHostObject>(shape, dtype));
         } catch (const std::exception &e) {
-            throw jsi::JSError(rt, "createTensor: Error creating tensor: " + std::string(e.what()));
+            throw jsi::JSError(rt, std::format("createTensor: Error creating tensor: {}", e.what()));
         }
     };
     auto fn = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name), 2, fnBody);

--- a/packages/react-native-executorch/cpp/core/tensor.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor.cpp
@@ -65,10 +65,13 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
                 optsObj = conversions::asType<jsi::Object>(rt, "copyTo: options", args[1]);
             }
             size_t offset = getOptionalProperty<uint64_t>(rt, "copyTo: options", optsObj, "offset").value_or(0);
-            size_t length = getOptionalProperty<uint64_t>(rt, "copyTo: options", optsObj, "length").value_or(self->numel_ - offset);
+            if (offset > self->numel_) {
+                throw jsi::JSError(rt, "copyTo: offset is out of bounds for src tensor");
+            }
 
-            if (offset + length > self->numel_) {
-                throw jsi::JSError(rt, "copyTo: out of bounds offset and length for src tensor");
+            size_t length = getOptionalProperty<uint64_t>(rt, "copyTo: options", optsObj, "length").value_or(self->numel_ - offset);
+            if (length > self->numel_ - offset) {
+                throw jsi::JSError(rt, "copyTo: length is out of bounds for the given offset of the src tensor");
             }
 
             const auto elemSize = types::elementSize(self->dtype_);
@@ -98,6 +101,10 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
 
             auto lock = tryLockUnique(rt, "setData: self", self);
 
+            if (byteOffset > buffer.size(rt) || byteLength > buffer.size(rt) - byteOffset) {
+                throw jsi::JSError(rt, "setData: Out of bounds offset/length for buffer");
+            }
+
             if (byteLength != self->size_) {
                 throw jsi::JSError(rt, std::format("setData: Data size mismatch: TypedArray is {} bytes, but Tensor requires {} bytes.",
                                                    byteLength, self->size_));
@@ -123,6 +130,10 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
             size_t byteLength = getOptionalProperty<uint64_t>(rt, "getData: array", dataObj, "byteLength").value_or(buffer.size(rt));
 
             auto lock = tryLockShared(rt, "getData: self", self);
+
+            if (byteOffset > buffer.size(rt) || byteLength > buffer.size(rt) - byteOffset) {
+                throw jsi::JSError(rt, "getData: Out of bounds offset/length for buffer");
+            }
 
             if (byteLength != self->size_) {
                 throw jsi::JSError(rt, std::format("getData: Data size mismatch: TypedArray is {} bytes, but Tensor requires {} bytes.",

--- a/packages/react-native-executorch/cpp/core/tensor.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor.cpp
@@ -1,6 +1,4 @@
 #include "tensor.h"
-#include "dtype.h"
-#include "tensor_helpers.h"
 
 #include <algorithm>
 #include <cstddef>
@@ -10,8 +8,10 @@
 #include <numeric>
 #include <optional>
 #include <string>
-#include <unordered_map>
-#include <variant>
+
+#include "core/conversions.h"
+#include "dtype.h"
+#include "tensor_helpers.h"
 
 #include <executorch/extension/tensor/tensor_ptr_maker.h>
 
@@ -19,13 +19,16 @@ namespace rnexecutorch::core::tensor {
 namespace types = rnexecutorch::core::types;
 namespace conversions = rnexecutorch::core::conversions;
 
+using rnexecutorch::core::conversions::getOptionalProperty;
+using rnexecutorch::core::conversions::getRequiredProperty;
+
 TensorHostObject::TensorHostObject(const std::vector<std::int32_t> &shape, DType dtype)
     : dtype_(dtype),
       shape_(shape),
       numel_(std::accumulate(shape.begin(), shape.end(), static_cast<size_t>(1), std::multiplies<>())),
       size_(numel_ * types::elementSize(dtype)) {
-    data_ = std::make_unique<std::uint8_t[]>(size_); // NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays):
-                                                     // owning runtime-sized byte buffer
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays): owning runtime-sized byte buffer
+    data_ = std::make_unique<std::uint8_t[]>(size_);
     tensor_ = executorch::extension::from_blob(data_.get(), shape_, types::toScalarType(dtype));
 }
 
@@ -61,8 +64,8 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
             if (count == 2) {
                 optsObj = conversions::asType<jsi::Object>(rt, "copyTo: options", args[1]);
             }
-            size_t offset = conversions::getOptionalProperty<uint64_t>(rt, "copyTo", optsObj, "offset").value_or(0);
-            size_t length = conversions::getOptionalProperty<uint64_t>(rt, "copyTo", optsObj, "length").value_or(self->numel_ - offset);
+            size_t offset = getOptionalProperty<uint64_t>(rt, "copyTo: options", optsObj, "offset").value_or(0);
+            size_t length = getOptionalProperty<uint64_t>(rt, "copyTo: options", optsObj, "length").value_or(self->numel_ - offset);
 
             if (offset + length > self->numel_) {
                 throw jsi::JSError(rt, "copyTo: out of bounds offset and length for src tensor");
@@ -76,7 +79,7 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
 
             std::memcpy(dst->data_.get(), self->data_.get() + (offset * elemSize), length * elemSize);
 
-            return jsi::Value(rt, args[0].asObject(rt));
+            return jsi::Value(rt, args[0]);
         };
         return jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "copyTo"), 1, fnBody);
     }
@@ -89,9 +92,9 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
             }
 
             auto dataObj = conversions::asType<jsi::Object>(rt, "setData: array", args[0]);
-            auto buffer = conversions::getRequiredProperty<jsi::ArrayBuffer>(rt, "setData", dataObj, "buffer");
-            size_t byteOffset = conversions::getOptionalProperty<uint64_t>(rt, "setData", dataObj, "byteOffset").value_or(0);
-            size_t byteLength = conversions::getOptionalProperty<uint64_t>(rt, "setData", dataObj, "byteLength").value_or(buffer.size(rt));
+            auto buffer = getRequiredProperty<jsi::ArrayBuffer>(rt, "setData: array", dataObj, "buffer");
+            size_t byteOffset = getOptionalProperty<uint64_t>(rt, "setData: array", dataObj, "byteOffset").value_or(0);
+            size_t byteLength = getOptionalProperty<uint64_t>(rt, "setData: array", dataObj, "byteLength").value_or(buffer.size(rt));
 
             auto lock = tryLockUnique(rt, "setData: self", self);
 
@@ -102,7 +105,7 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
 
             std::memcpy(self->data_.get(), buffer.data(rt) + byteOffset, byteLength);
 
-            return jsi::Value(rt, thisVal.asObject(rt));
+            return jsi::Value(rt, thisVal);
         };
         return jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "setData"), 1, fnBody);
     }
@@ -115,9 +118,9 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
             }
 
             auto dataObj = conversions::asType<jsi::Object>(rt, "getData: array", args[0]);
-            auto buffer = conversions::getRequiredProperty<jsi::ArrayBuffer>(rt, "getData", dataObj, "buffer");
-            size_t byteOffset = conversions::getOptionalProperty<uint64_t>(rt, "getData", dataObj, "byteOffset").value_or(0);
-            size_t byteLength = conversions::getOptionalProperty<uint64_t>(rt, "getData", dataObj, "byteLength").value_or(buffer.size(rt));
+            auto buffer = getRequiredProperty<jsi::ArrayBuffer>(rt, "getData: array", dataObj, "buffer");
+            size_t byteOffset = getOptionalProperty<uint64_t>(rt, "getData: array", dataObj, "byteOffset").value_or(0);
+            size_t byteLength = getOptionalProperty<uint64_t>(rt, "getData: array", dataObj, "byteLength").value_or(buffer.size(rt));
 
             auto lock = tryLockShared(rt, "getData: self", self);
 
@@ -128,7 +131,7 @@ jsi::Value TensorHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) 
 
             std::memcpy(buffer.data(rt) + byteOffset, self->data_.get(), byteLength);
 
-            return jsi::Value(rt, args[0].asObject(rt));
+            return jsi::Value(rt, args[0]);
         };
         return jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "getData"), 1, fnBody);
     }

--- a/packages/react-native-executorch/cpp/core/tensor.h
+++ b/packages/react-native-executorch/cpp/core/tensor.h
@@ -4,16 +4,18 @@
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <string>
 #include <vector>
 
+#include <executorch/extension/tensor/tensor_ptr.h>
 #include <jsi/jsi.h>
-
-#include <executorch/extension/tensor/tensor.h>
-#include <executorch/runtime/core/exec_aten/exec_aten.h>
 
 #include "dtype.h"
 
 namespace rnexecutorch::core::tensor {
+namespace jsi = facebook::jsi;
+namespace types = rnexecutorch::core::types;
+
 /**
  * JSI HostObject wrapping an ExecuTorch TensorPtr instance.
  *
@@ -21,23 +23,25 @@ namespace rnexecutorch::core::tensor {
  * dtype, numel), writing data from array buffers, reading data to array
  * buffers, and disposing of underlying memory.
  */
-class TensorHostObject : public facebook::jsi::HostObject, public std::enable_shared_from_this<TensorHostObject> {
+class TensorHostObject : public jsi::HostObject,
+                         public std::enable_shared_from_this<TensorHostObject> {
 public:
-    rnexecutorch::core::types::DType dtype_;
+    types::DType dtype_;
     std::vector<std::int32_t> shape_;
     size_t numel_;
-
     size_t size_;
-    std::unique_ptr<std::uint8_t[]> data_; // NOLINT(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays): owning runtime-sized byte buffer
+
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays): owning runtime-sized byte buffer
+    std::unique_ptr<std::uint8_t[]> data_;
     executorch::extension::TensorPtr tensor_;
 
     std::shared_mutex mutex_;
 
-    TensorHostObject(const std::vector<std::int32_t> &shape, rnexecutorch::core::types::DType dtype);
+    TensorHostObject(const std::vector<std::int32_t> &shape, types::DType dtype);
 
-    facebook::jsi::Value get(facebook::jsi::Runtime &rt, const facebook::jsi::PropNameID &name) override;
-    std::vector<facebook::jsi::PropNameID> getPropertyNames(facebook::jsi::Runtime &rt) override;
+    jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &name) override;
+    std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
 };
 
-void install_createTensor(facebook::jsi::Runtime &rt, facebook::jsi::Object &module);
+void install_createTensor(jsi::Runtime &rt, jsi::Object &module);
 } // namespace rnexecutorch::core::tensor

--- a/packages/react-native-executorch/cpp/core/tensor.h
+++ b/packages/react-native-executorch/cpp/core/tensor.h
@@ -1,16 +1,16 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <mutex>
 #include <shared_mutex>
-#include <string>
 #include <vector>
 
-#include <executorch/extension/tensor/tensor_ptr.h>
+#include "dtype.h"
+
 #include <jsi/jsi.h>
 
-#include "dtype.h"
+#include <executorch/extension/tensor/tensor_ptr.h>
 
 namespace rnexecutorch::core::tensor {
 namespace jsi = facebook::jsi;
@@ -26,10 +26,10 @@ namespace types = rnexecutorch::core::types;
 class TensorHostObject : public jsi::HostObject,
                          public std::enable_shared_from_this<TensorHostObject> {
 public:
-    types::DType dtype_;
-    std::vector<std::int32_t> shape_;
-    size_t numel_;
-    size_t size_;
+    const types::DType dtype_;
+    const std::vector<std::int32_t> shape_;
+    const size_t numel_;
+    const size_t size_;
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays): owning runtime-sized byte buffer
     std::unique_ptr<std::uint8_t[]> data_;

--- a/packages/react-native-executorch/cpp/core/tensor_helpers.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor_helpers.cpp
@@ -103,7 +103,7 @@ fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
         } else if (std::holds_alternative<std::string>(dim)) {
             const auto &symbol = std::get<std::string>(dim);
             if (symbolToConcrete.contains(symbol) && shape[i] != symbolToConcrete[symbol]) {
-                throw jsi::JSError(rt, std::format("{} must have shape {} (dim '{}' mismatch: expected {}, got {})",
+                throw jsi::JSError(rt, std::format("{} must have shape {} (dim {} mismatch: expected {}, got {})",
                                                    name, shapeToString(*expectedShape), i, symbolToConcrete[symbol], shape[i]));
             }
             symbolToConcrete[symbol] = shape[i];

--- a/packages/react-native-executorch/cpp/core/tensor_helpers.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor_helpers.cpp
@@ -39,6 +39,32 @@ void checkNotSameTensor(jsi::Runtime &rt,
     }
 }
 
+namespace {
+
+std::string shapeToString(const SymbolicShape &expectedShape) {
+    std::string s;
+    for (size_t i = 0; i < expectedShape.size(); ++i) {
+        if (i > 0) {
+            s += ", ";
+        }
+        const auto &dim = expectedShape.at(i);
+        if (std::holds_alternative<int32_t>(dim)) {
+            s += std::format("{}", std::get<int32_t>(dim));
+        } else if (std::holds_alternative<std::string>(dim)) {
+            s += std::get<std::string>(dim);
+        } else {
+            const auto &rangeDim = std::get<RangeDim>(dim);
+            s += std::format("[{}..{}{}]",
+                             rangeDim.min,
+                             rangeDim.max,
+                             rangeDim.step ? std::format(" step {}", *rangeDim.step) : "");
+        }
+    }
+    return std::format("[{}]", s);
+}
+
+} // namespace
+
 std::shared_ptr<TensorHostObject>
 fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
        std::optional<DType> expectedDtype, const std::optional<SymbolicShape> &expectedShape) {
@@ -48,52 +74,56 @@ fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
     }
 
     auto tensor = value.asObject(rt).getHostObject<TensorHostObject>(rt);
-    auto dtype = tensor->dtype_;
-    auto shape = tensor->shape_;
+    const auto &dtype = tensor->dtype_;
+    const auto &shape = tensor->shape_;
 
     if (expectedDtype && dtype != *expectedDtype) {
         throw jsi::JSError(rt, std::format("{} must be of type {}",
                                            name, types::toString(*expectedDtype)));
     }
 
-    if (expectedShape) {
-        std::string shapeStr = "[";
-        for (size_t i = 0; i < expectedShape->size(); ++i) {
-            if (i > 0) {
-                shapeStr += ", ";
-            }
-            const auto &dim = expectedShape->at(i);
-            if (std::holds_alternative<int32_t>(dim)) {
-                shapeStr += std::to_string(std::get<int32_t>(dim));
-            } else {
-                shapeStr += std::get<std::string>(dim);
-            }
-        }
-        shapeStr += "]";
+    if (!expectedShape) {
+        return tensor;
+    }
 
-        if (shape.size() != expectedShape->size()) {
-            throw jsi::JSError(rt, std::format("{} must have shape {} (expected {} dimensions, got {})",
-                                               name, shapeStr, expectedShape->size(), shape.size()));
-        }
+    if (shape.size() != expectedShape->size()) {
+        throw jsi::JSError(rt, std::format("{} must have shape {} (expected {} dimensions, got {})",
+                                           name, shapeToString(*expectedShape), expectedShape->size(), shape.size()));
+    }
 
-        std::unordered_map<std::string, int32_t> symbolMap;
-        for (size_t i = 0; i < expectedShape->size(); ++i) {
-            const auto &dim = expectedShape->at(i);
-            if (std::holds_alternative<int32_t>(dim)) {
-                if (shape[i] != std::get<int32_t>(dim)) {
-                    throw jsi::JSError(rt, std::format("{} must have shape {} (dim {} mismatch: expected {}, got {})",
-                                                       name, shapeStr, i, std::get<int32_t>(dim), shape[i]));
-                }
-            } else {
-                const auto &symbol = std::get<std::string>(dim);
-                if (symbolMap.contains(symbol) && shape[i] != symbolMap[symbol]) {
-                    throw jsi::JSError(rt, std::format("{} must have shape {} (dim '{}' mismatch: expected {}, got {})",
-                                                       name, shapeStr, i, symbolMap[symbol], shape[i]));
-                }
-                symbolMap[symbol] = shape[i];
+    std::unordered_map<std::string, int32_t> symbolToConcrete;
+    for (size_t i = 0; i < expectedShape->size(); ++i) {
+        const auto &dim = expectedShape->at(i);
+        if (std::holds_alternative<int32_t>(dim)) {
+            const auto expected = std::get<int32_t>(dim);
+            if (shape[i] != expected) {
+                throw jsi::JSError(rt, std::format("{} must have shape {} (dim {} mismatch: expected {}, got {})",
+                                                   name, shapeToString(*expectedShape), i, expected, shape[i]));
+            }
+        } else if (std::holds_alternative<std::string>(dim)) {
+            const auto &symbol = std::get<std::string>(dim);
+            if (symbolToConcrete.contains(symbol) && shape[i] != symbolToConcrete[symbol]) {
+                throw jsi::JSError(rt, std::format("{} must have shape {} (dim '{}' mismatch: expected {}, got {})",
+                                                   name, shapeToString(*expectedShape), i, symbolToConcrete[symbol], shape[i]));
+            }
+            symbolToConcrete[symbol] = shape[i];
+        } else {
+            const auto &rangeDim = std::get<RangeDim>(dim);
+            if (shape[i] < rangeDim.min) {
+                throw jsi::JSError(rt, std::format("{} must have shape {} (dim {} out of range: {} < min {})",
+                                                   name, shapeToString(*expectedShape), i, shape[i], rangeDim.min));
+            }
+            if (shape[i] > rangeDim.max) {
+                throw jsi::JSError(rt, std::format("{} must have shape {} (dim {} out of range: {} > max {})",
+                                                   name, shapeToString(*expectedShape), i, shape[i], rangeDim.max));
+            }
+            if (rangeDim.step && (shape[i] - rangeDim.min) % *rangeDim.step != 0) {
+                throw jsi::JSError(rt, std::format("{} must have shape {} (dim {} must be min({}) + k*step({}), got {})",
+                                                   name, shapeToString(*expectedShape), i, rangeDim.min, *rangeDim.step, shape[i]));
             }
         }
     }
+
     return tensor;
 }
 } // namespace rnexecutorch::core::tensor

--- a/packages/react-native-executorch/cpp/core/tensor_helpers.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor_helpers.cpp
@@ -34,20 +34,20 @@ tryLockUnique(jsi::Runtime &rt, const std::string &name, const std::shared_ptr<T
 void checkNotSameTensor(jsi::Runtime &rt,
                         const std::string &name1, const std::shared_ptr<TensorHostObject> &t1,
                         const std::string &name2, const std::shared_ptr<TensorHostObject> &t2) {
-    if (t1.get() == t2.get()) {
+    if (t1 == t2) {
         throw jsi::JSError(rt, std::format("{} and {} cannot be the same tensor", name1, name2));
     }
 }
 
 namespace {
 
-std::string shapeToString(const SymbolicShape &expectedShape) {
+std::string shapeToString(const SymbolicShape &shape) {
     std::string s;
-    for (size_t i = 0; i < expectedShape.size(); ++i) {
+    for (size_t i = 0; i < shape.size(); ++i) {
         if (i > 0) {
             s += ", ";
         }
-        const auto &dim = expectedShape.at(i);
+        const auto &dim = shape.at(i);
         if (std::holds_alternative<int32_t>(dim)) {
             s += std::format("{}", std::get<int32_t>(dim));
         } else if (std::holds_alternative<std::string>(dim)) {
@@ -78,8 +78,7 @@ fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
     const auto &shape = tensor->shape_;
 
     if (expectedDtype && dtype != *expectedDtype) {
-        throw jsi::JSError(rt, std::format("{} must be of type {}",
-                                           name, types::toString(*expectedDtype)));
+        throw jsi::JSError(rt, std::format("{} must be of type {}", name, types::toString(*expectedDtype)));
     }
 
     if (!expectedShape) {
@@ -92,8 +91,10 @@ fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
     }
 
     std::unordered_map<std::string, int32_t> symbolToConcrete;
+
     for (size_t i = 0; i < expectedShape->size(); ++i) {
         const auto &dim = expectedShape->at(i);
+
         if (std::holds_alternative<int32_t>(dim)) {
             const auto expected = std::get<int32_t>(dim);
             if (shape[i] != expected) {

--- a/packages/react-native-executorch/cpp/core/tensor_helpers.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor_helpers.cpp
@@ -40,16 +40,11 @@ void checkNotSameTensor(jsi::Runtime &rt,
 }
 
 namespace {
-
 std::string shapeToString(const SymbolicShape &shape) {
     std::string s;
-    for (size_t i = 0; i < shape.size(); ++i) {
-        if (i > 0) {
-            s += ", ";
-        }
-        const auto &dim = shape.at(i);
+    for (const auto &dim : shape) {
         if (std::holds_alternative<int32_t>(dim)) {
-            s += std::format("{}", std::get<int32_t>(dim));
+            s += std::to_string(std::get<int32_t>(dim));
         } else if (std::holds_alternative<std::string>(dim)) {
             s += std::get<std::string>(dim);
         } else {
@@ -59,10 +54,14 @@ std::string shapeToString(const SymbolicShape &shape) {
                              rangeDim.max,
                              rangeDim.step ? std::format(" step {}", *rangeDim.step) : "");
         }
+        s += ", ";
     }
-    return std::format("[{}]", s);
+    if (!shape.empty()) {
+        s.pop_back();
+        s.pop_back();
+    }
+    return "[" + s + "]";
 }
-
 } // namespace
 
 std::shared_ptr<TensorHostObject>

--- a/packages/react-native-executorch/cpp/core/tensor_helpers.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor_helpers.cpp
@@ -1,0 +1,99 @@
+#include "tensor_helpers.h"
+#include "dtype.h"
+
+#include <format>
+#include <unordered_map>
+
+namespace rnexecutorch::core::tensor {
+namespace types = rnexecutorch::core::types;
+
+std::shared_lock<std::shared_mutex>
+tryLockShared(jsi::Runtime &rt, const std::string &name, const std::shared_ptr<TensorHostObject> &tensor) {
+    std::shared_lock<std::shared_mutex> lock(tensor->mutex_, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        throw jsi::JSError(rt, std::format("{} tensor is currently in use", name));
+    }
+    if (!tensor->data_) {
+        throw jsi::JSError(rt, std::format("{} tensor has been disposed", name));
+    }
+    return lock;
+}
+
+std::unique_lock<std::shared_mutex>
+tryLockUnique(jsi::Runtime &rt, const std::string &name, const std::shared_ptr<TensorHostObject> &tensor) {
+    std::unique_lock<std::shared_mutex> lock(tensor->mutex_, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        throw jsi::JSError(rt, std::format("{} tensor is currently in use", name));
+    }
+    if (!tensor->data_) {
+        throw jsi::JSError(rt, std::format("{} tensor has been disposed", name));
+    }
+    return lock;
+}
+
+void checkNotSameTensor(jsi::Runtime &rt,
+                        const std::string &name1, const std::shared_ptr<TensorHostObject> &t1,
+                        const std::string &name2, const std::shared_ptr<TensorHostObject> &t2) {
+    if (t1.get() == t2.get()) {
+        throw jsi::JSError(rt, std::format("{} and {} cannot be the same tensor", name1, name2));
+    }
+}
+
+std::shared_ptr<TensorHostObject>
+fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
+       std::optional<DType> expectedDtype, const std::optional<SymbolicShape> &expectedShape) {
+
+    if (!value.isObject() || !value.asObject(rt).isHostObject<TensorHostObject>(rt)) {
+        throw jsi::JSError(rt, name + " must be a Tensor");
+    }
+
+    auto tensor = value.asObject(rt).getHostObject<TensorHostObject>(rt);
+    auto dtype = tensor->dtype_;
+    auto shape = tensor->shape_;
+
+    if (expectedDtype && dtype != *expectedDtype) {
+        throw jsi::JSError(rt, std::format("{} must be of type {}",
+                                           name, types::toString(*expectedDtype)));
+    }
+
+    if (expectedShape) {
+        std::string shapeStr = "[";
+        for (size_t i = 0; i < expectedShape->size(); ++i) {
+            if (i > 0) {
+                shapeStr += ", ";
+            }
+            const auto &dim = expectedShape->at(i);
+            if (std::holds_alternative<int32_t>(dim)) {
+                shapeStr += std::to_string(std::get<int32_t>(dim));
+            } else {
+                shapeStr += std::get<std::string>(dim);
+            }
+        }
+        shapeStr += "]";
+
+        if (shape.size() != expectedShape->size()) {
+            throw jsi::JSError(rt, std::format("{} must have shape {} (expected {} dimensions, got {})",
+                                               name, shapeStr, expectedShape->size(), shape.size()));
+        }
+
+        std::unordered_map<std::string, int32_t> symbolMap;
+        for (size_t i = 0; i < expectedShape->size(); ++i) {
+            const auto &dim = expectedShape->at(i);
+            if (std::holds_alternative<int32_t>(dim)) {
+                if (shape[i] != std::get<int32_t>(dim)) {
+                    throw jsi::JSError(rt, std::format("{} must have shape {} (dim {} mismatch: expected {}, got {})",
+                                                       name, shapeStr, i, std::get<int32_t>(dim), shape[i]));
+                }
+            } else {
+                const auto &symbol = std::get<std::string>(dim);
+                if (symbolMap.contains(symbol) && shape[i] != symbolMap[symbol]) {
+                    throw jsi::JSError(rt, std::format("{} must have shape {} (dim '{}' mismatch: expected {}, got {})",
+                                                       name, shapeStr, i, symbolMap[symbol], shape[i]));
+                }
+                symbolMap[symbol] = shape[i];
+            }
+        }
+    }
+    return tensor;
+}
+} // namespace rnexecutorch::core::tensor

--- a/packages/react-native-executorch/cpp/core/tensor_helpers.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor_helpers.cpp
@@ -1,11 +1,13 @@
 #include "tensor_helpers.h"
-#include "dtype.h"
 
 #include <format>
 #include <unordered_map>
 
+#include "dtype.h"
+
 namespace rnexecutorch::core::tensor {
 namespace types = rnexecutorch::core::types;
+namespace conversions = rnexecutorch::core::conversions;
 
 std::shared_lock<std::shared_mutex>
 tryLockShared(jsi::Runtime &rt, const std::string &name, const std::shared_ptr<TensorHostObject> &tensor) {
@@ -68,11 +70,12 @@ std::shared_ptr<TensorHostObject>
 fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
        std::optional<DType> expectedDtype, const std::optional<SymbolicShape> &expectedShape) {
 
-    if (!value.isObject() || !value.asObject(rt).isHostObject<TensorHostObject>(rt)) {
+    auto obj = conversions::asType<jsi::Object>(rt, name, value);
+    if (!obj.isHostObject<TensorHostObject>(rt)) {
         throw jsi::JSError(rt, name + " must be a Tensor");
     }
 
-    auto tensor = value.asObject(rt).getHostObject<TensorHostObject>(rt);
+    auto tensor = obj.getHostObject<TensorHostObject>(rt);
     const auto &dtype = tensor->dtype_;
     const auto &shape = tensor->shape_;
 

--- a/packages/react-native-executorch/cpp/core/tensor_helpers.h
+++ b/packages/react-native-executorch/cpp/core/tensor_helpers.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <concepts>
 #include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <ranges>
 #include <shared_mutex>
 #include <string>
 #include <vector>
@@ -18,7 +20,14 @@ namespace rnexecutorch::core::tensor {
 namespace jsi = facebook::jsi;
 
 using rnexecutorch::core::types::DType;
-using SymbolicShape = std::vector<std::variant<int32_t, std::string>>;
+
+struct RangeDim {
+    int32_t min;
+    int32_t max;
+    std::optional<int32_t> step;
+};
+
+using SymbolicShape = std::vector<std::variant<int32_t, std::string, RangeDim>>;
 
 [[nodiscard]] std::shared_lock<std::shared_mutex>
 tryLockShared(jsi::Runtime &rt, const std::string &name, const std::shared_ptr<TensorHostObject> &tensor);
@@ -34,9 +43,12 @@ std::shared_ptr<TensorHostObject>
 fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
        std::optional<DType> expectedDtype, const std::optional<SymbolicShape> &expectedShape);
 
+template <typename Range>
+    requires std::ranges::input_range<Range> &&
+             std::convertible_to<std::ranges::range_value_t<Range>, int32_t>
 inline std::shared_ptr<TensorHostObject>
 fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
-       std::optional<DType> expectedDtype, const std::vector<int32_t> &expectedShape) {
+       std::optional<DType> expectedDtype, const Range &expectedShape) {
     SymbolicShape convertedShape(expectedShape.begin(), expectedShape.end());
     return fromJs(rt, name, value, expectedDtype, std::move(convertedShape));
 }

--- a/packages/react-native-executorch/cpp/core/tensor_helpers.h
+++ b/packages/react-native-executorch/cpp/core/tensor_helpers.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <vector>
+
+#include <jsi/jsi.h>
+
+#include "conversions.h"
+#include "dtype.h"
+#include "tensor.h"
+
+namespace rnexecutorch::core::tensor {
+namespace jsi = facebook::jsi;
+
+using rnexecutorch::core::types::DType;
+using SymbolicShape = std::vector<std::variant<int32_t, std::string>>;
+
+[[nodiscard]] std::shared_lock<std::shared_mutex>
+tryLockShared(jsi::Runtime &rt, const std::string &name, const std::shared_ptr<TensorHostObject> &tensor);
+
+[[nodiscard]] std::unique_lock<std::shared_mutex>
+tryLockUnique(jsi::Runtime &rt, const std::string &name, const std::shared_ptr<TensorHostObject> &tensor);
+
+void checkNotSameTensor(jsi::Runtime &rt,
+                        const std::string &name1, const std::shared_ptr<TensorHostObject> &t1,
+                        const std::string &name2, const std::shared_ptr<TensorHostObject> &t2);
+
+std::shared_ptr<TensorHostObject>
+fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
+       std::optional<DType> expectedDtype, const std::optional<SymbolicShape> &expectedShape);
+
+inline std::shared_ptr<TensorHostObject>
+fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
+       std::optional<DType> expectedDtype, const std::vector<int32_t> &expectedShape) {
+    SymbolicShape convertedShape(expectedShape.begin(), expectedShape.end());
+    return fromJs(rt, name, value, expectedDtype, std::move(convertedShape));
+}
+} // namespace rnexecutorch::core::tensor

--- a/packages/react-native-executorch/cpp/core/tensor_helpers.h
+++ b/packages/react-native-executorch/cpp/core/tensor_helpers.h
@@ -2,6 +2,7 @@
 
 #include <concepts>
 #include <cstdint>
+#include <initializer_list>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -103,5 +104,19 @@ fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
        std::optional<DType> expectedDtype, const Range &expectedShape) {
     SymbolicShape convertedShape(expectedShape.begin(), expectedShape.end());
     return fromJs(rt, name, value, expectedDtype, std::move(convertedShape));
+}
+
+/**
+ * @overload
+ *
+ * Convenience wrapper that accepts an initializer list of symbolic shape
+ * elements. Allows passing shape constraints like `{"H", "W", 1}` directly
+ * without typing SymbolicShape explicitly.
+ */
+inline std::shared_ptr<TensorHostObject>
+fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
+       std::optional<DType> expectedDtype,
+       std::initializer_list<std::variant<int32_t, std::string, RangeDim>> expectedShape) {
+    return fromJs(rt, name, value, expectedDtype, std::optional<SymbolicShape>(expectedShape));
 }
 } // namespace rnexecutorch::core::tensor

--- a/packages/react-native-executorch/cpp/core/tensor_helpers.h
+++ b/packages/react-native-executorch/cpp/core/tensor_helpers.h
@@ -8,13 +8,14 @@
 #include <ranges>
 #include <shared_mutex>
 #include <string>
+#include <variant>
 #include <vector>
-
-#include <jsi/jsi.h>
 
 #include "conversions.h"
 #include "dtype.h"
 #include "tensor.h"
+
+#include <jsi/jsi.h>
 
 namespace rnexecutorch::core::tensor {
 namespace jsi = facebook::jsi;
@@ -22,27 +23,78 @@ namespace jsi = facebook::jsi;
 using rnexecutorch::core::types::DType;
 
 struct RangeDim {
-    int32_t min;
-    int32_t max;
+    int32_t min = 0;
+    int32_t max = 0;
     std::optional<int32_t> step;
 };
 
 using SymbolicShape = std::vector<std::variant<int32_t, std::string, RangeDim>>;
 
+/**
+ * Tries to acquire a shared (read) lock on the underlying tensor resource.
+ * Throws a facebook::jsi::JSError if the lock is currently held uniquely by
+ * another thread or if the tensor has already been disposed.
+ *
+ * @param rt The JSI runtime instance.
+ * @param name The name/context of the tensor for error messages.
+ * @param tensor Shared pointer to the TensorHostObject.
+ * @return A shared lock protecting the tensor data.
+ */
 [[nodiscard]] std::shared_lock<std::shared_mutex>
 tryLockShared(jsi::Runtime &rt, const std::string &name, const std::shared_ptr<TensorHostObject> &tensor);
 
+/**
+ * Tries to acquire a unique (write) lock on the underlying tensor resource.
+ * Throws a facebook::jsi::JSError if the lock is currently held by another
+ * thread or if the tensor has already been disposed.
+ *
+ * @param rt The JSI runtime instance.
+ * @param name The name/context of the tensor for error messages.
+ * @param tensor Shared pointer to the TensorHostObject.
+ * @return A unique lock protecting the tensor data.
+ */
 [[nodiscard]] std::unique_lock<std::shared_mutex>
 tryLockUnique(jsi::Runtime &rt, const std::string &name, const std::shared_ptr<TensorHostObject> &tensor);
 
+/**
+ * Validates that two JSI Tensor parameters do not point to the exact same
+ * underlying TensorHostObject instance, preventing mutation aliasing issues.
+ * Throws a facebook::jsi::JSError if they are the same tensor.
+ *
+ * @param rt The JSI runtime instance.
+ * @param name1 Context name of the first tensor.
+ * @param t1 The first tensor.
+ * @param name2 Context name of the second tensor.
+ * @param t2 The second tensor.
+ */
 void checkNotSameTensor(jsi::Runtime &rt,
                         const std::string &name1, const std::shared_ptr<TensorHostObject> &t1,
                         const std::string &name2, const std::shared_ptr<TensorHostObject> &t2);
 
+/**
+ * Extracts, type-checks, and shape-validates a TensorHostObject from a JSI
+ * Value parameter. Throws a facebook::jsi::JSError with precise details if type
+ * checking or shape validation fails.
+ *
+ * @param rt The JSI runtime instance.
+ * @param name Parameter name for contextual error messages.
+ * @param value The JSI value to extract the Tensor from.
+ * @param expectedDtype Optional expected DType constraint.
+ * @param expectedShape Optional expected shape (SymbolicShape) constraint.
+ * @return Shared pointer to the validated TensorHostObject.
+ */
 std::shared_ptr<TensorHostObject>
 fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
        std::optional<DType> expectedDtype, const std::optional<SymbolicShape> &expectedShape);
 
+/**
+ * @overload
+ *
+ * Convenience wrapper that accepts any concrete C++ range as the expected shape
+ * (e.g. std::vector<int32_t>).
+ *
+ * @tparam Range The type of the expected shape container.
+ */
 template <typename Range>
     requires std::ranges::input_range<Range> &&
              std::convertible_to<std::ranges::range_value_t<Range>, int32_t>

--- a/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
@@ -3,7 +3,9 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <format>
 #include <numeric>
+#include <optional>
 #include <shared_mutex>
 #include <stdexcept>
 #include <utility>
@@ -13,11 +15,15 @@
 
 #include "core/dtype.h"
 #include "core/tensor.h"
+#include "core/tensor_helpers.h"
 #include "utils.h"
 
 namespace rnexecutorch::extensions::cv::box_ops {
 namespace jsi = facebook::jsi;
-using rnexecutorch::core::tensor::TensorHostObject;
+namespace tensor = rnexecutorch::core::tensor;
+namespace conversions = rnexecutorch::core::conversions;
+
+using rnexecutorch::core::types::DType;
 
 namespace {
 enum class BoxFormat {
@@ -75,35 +81,18 @@ void install_nms(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: nms(boxes, scores, options)");
         }
 
-        if (!args[0].isObject() || !args[0].asObject(rt).isHostObject<TensorHostObject>(rt) ||
-            !args[1].isObject() || !args[1].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "nms: boxes and scores must be Tensors");
-        }
+        auto boxes = tensor::fromJs(rt, "nms: boxes", args[0], DType::float32, tensor::SymbolicShape{"N", 4});
+        auto scores = tensor::fromJs(rt, "nms: scores", args[1], DType::float32, tensor::SymbolicShape{boxes->shape_[0]});
 
-        if (!args[2].isObject()) {
-            throw jsi::JSError(rt, "nms: options must be an object");
-        }
+        tensor::checkNotSameTensor(rt, "nms: boxes", boxes, "nms: scores", scores);
+        auto boxesLock = tensor::tryLockShared(rt, "nms: boxes", boxes);
+        auto scoresLock = tensor::tryLockShared(rt, "nms: scores", scores);
 
-        auto boxes = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
-        auto scores = args[1].asObject(rt).getHostObject<TensorHostObject>(rt);
-        auto opts = args[2].asObject(rt);
-
-        if (boxes.get() == scores.get()) {
-            throw jsi::JSError(rt, "nms: boxes and scores cannot be the same tensor.");
-        }
-
-        if (!opts.hasProperty(rt, "iouThreshold") ||
-            !opts.hasProperty(rt, "boxFormat") ||
-            !opts.hasProperty(rt, "confidenceThreshold") ||
-            !opts.hasProperty(rt, "nmsType")) {
-            throw jsi::JSError(rt, "nms: options must specify iouThreshold, boxFormat, confidenceThreshold, and nmsType");
-        }
-
-        const float iouThreshold = static_cast<float>(opts.getProperty(rt, "iouThreshold").asNumber());
-        const float confidenceThreshold = static_cast<float>(opts.getProperty(rt, "confidenceThreshold").asNumber());
-
-        const std::string nmsTypeStr = opts.getProperty(rt, "nmsType").asString(rt).utf8(rt);
-        const std::string boxFormatStr = opts.getProperty(rt, "boxFormat").asString(rt).utf8(rt);
+        const auto opts = args[2].asObject(rt);
+        const auto nmsTypeStr = conversions::getRequiredProperty<std::string>(rt, "nms", opts, "nmsType");
+        const auto boxFormatStr = conversions::getRequiredProperty<std::string>(rt, "nms", opts, "boxFormat");
+        const auto iouThreshold = conversions::getRequiredProperty<float>(rt, "nms", opts, "iouThreshold");
+        const auto confidenceThreshold = conversions::getRequiredProperty<float>(rt, "nms", opts, "confidenceThreshold");
 
         NmsType nmsType{};
         BoxFormat boxFormat{};
@@ -111,37 +100,10 @@ void install_nms(jsi::Runtime &rt, jsi::Object &module) {
             nmsType = parseNmsType(nmsTypeStr);
             boxFormat = parseBoxFormat(boxFormatStr);
         } catch (const std::invalid_argument &e) {
-            throw jsi::JSError(rt, "nms: " + std::string(e.what()));
+            throw jsi::JSError(rt, std::format("nms: {}", e.what()));
         }
 
-        std::shared_lock<std::shared_mutex> boxesLock(boxes->mutex_, std::try_to_lock);
-        std::shared_lock<std::shared_mutex> scoresLock(scores->mutex_, std::try_to_lock);
-
-        if (!boxesLock.owns_lock() || !scoresLock.owns_lock()) {
-            throw jsi::JSError(rt, "nms: one of the tensors is currently locked");
-        }
-
-        if (!boxes->data_ || !scores->data_) {
-            throw jsi::JSError(rt, "nms: tensors must not be disposed");
-        }
-
-        if (scores->shape_.size() != 1) {
-            throw jsi::JSError(rt, "nms: scores must be a 1D tensor with shape [N]");
-        }
         std::int32_t numAnchors = scores->shape_[0];
-
-        if (boxes->shape_.size() != 2 || boxes->shape_[1] != 4) {
-            throw jsi::JSError(rt, "nms: boxes must be a 2D tensor with shape [N, 4]");
-        }
-
-        if (boxes->shape_[0] != numAnchors) {
-            throw jsi::JSError(rt, "nms: boxes and scores must have the same number of elements");
-        }
-
-        if (boxes->dtype_ != rnexecutorch::core::types::DType::float32 || scores->dtype_ != rnexecutorch::core::types::DType::float32) {
-            throw jsi::JSError(rt, "nms: boxes and scores must have dtype float32");
-        }
-
         const auto *boxesPtr = reinterpret_cast<const float *>(boxes->data_.get());
         const auto *scoresPtr = reinterpret_cast<const float *>(scores->data_.get());
 
@@ -233,11 +195,7 @@ void install_nms(jsi::Runtime &rt, jsi::Object &module) {
         case NmsType::Weighted: {
             jsi::Array resultGroups = jsi::Array(rt, groups.size());
             for (size_t i = 0; i < groups.size(); ++i) {
-                const jsi::Array singleGroup = jsi::Array(rt, groups[i].size());
-                for (size_t j = 0; j < groups[i].size(); ++j) {
-                    singleGroup.setValueAtIndex(rt, j, jsi::Value(static_cast<double>(groups[i][j])));
-                }
-                resultGroups.setValueAtIndex(rt, i, singleGroup);
+                resultGroups.setValueAtIndex(rt, i, conversions::toJsiArray(rt, groups[i]));
             }
             return resultGroups;
         }
@@ -254,56 +212,32 @@ void install_restrictToBox(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: restrictToBox(src, dst, boxTuple, format)");
         }
 
-        if (!args[0].isObject() || !args[0].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "restrictToBox: src must be a Tensor");
-        }
+        auto src = tensor::fromJs(rt, "restrictToBox: src", args[0], std::nullopt, tensor::SymbolicShape{"H", "W", "C"});
+        auto dst = tensor::fromJs(rt, "restrictToBox: dst", args[1], src->dtype_, src->shape_);
 
-        if (!args[1].isObject() || !args[1].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "restrictToBox: dst must be a Tensor");
-        }
+        tensor::checkNotSameTensor(rt, "restrictToBox: src", src, "restrictToBox: dst", dst);
+        auto srcLock = tensor::tryLockShared(rt, "restrictToBox: src", src);
+        auto dstLock = tensor::tryLockUnique(rt, "restrictToBox: dst", dst);
 
-        if (!args[2].isObject() || !args[2].asObject(rt).isArray(rt)) {
-            throw jsi::JSError(rt, "restrictToBox: boxTuple must be an Array");
-        }
-
-        if (!args[3].isString()) {
-            throw jsi::JSError(rt, "restrictToBox: format must be a String");
-        }
-
-        auto src = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
-        auto dst = args[1].asObject(rt).getHostObject<TensorHostObject>(rt);
-        auto boxTuple = args[2].asObject(rt).asArray(rt);
-        std::string boxFormatStr = args[3].asString(rt).utf8(rt);
-
-        if (boxTuple.size(rt) != 4) {
+        auto boxVec = conversions::asVector<float>(rt, "restrictToBox: boxTuple", args[2]);
+        if (boxVec.size() != 4) {
             throw jsi::JSError(rt, "restrictToBox: boxTuple must contain exactly 4 coordinates");
         }
 
+        auto boxFormatStr = conversions::asType<std::string>(rt, "restrictToBox: format", args[3]);
         BoxFormat boxFormat{};
         try {
             boxFormat = parseBoxFormat(boxFormatStr);
         } catch (const std::invalid_argument &e) {
-            throw jsi::JSError(rt, "restrictToBox: " + std::string(e.what()));
+            throw jsi::JSError(rt, std::format("restrictToBox: {}", e.what()));
         }
 
-        float a = static_cast<float>(boxTuple.getValueAtIndex(rt, 0).asNumber());
-        float b = static_cast<float>(boxTuple.getValueAtIndex(rt, 1).asNumber());
-        float c = static_cast<float>(boxTuple.getValueAtIndex(rt, 2).asNumber());
-        float d = static_cast<float>(boxTuple.getValueAtIndex(rt, 3).asNumber());
+        float a = boxVec[0];
+        float b = boxVec[1];
+        float c = boxVec[2];
+        float d = boxVec[3];
 
         auto [xmin, ymin, xmax, ymax] = decodeToXyxy(a, b, c, d, boxFormat);
-
-        if (src.get() == dst.get()) {
-            throw jsi::JSError(rt, "restrictToBox: In-place operations (src == dst) are not supported.");
-        }
-
-        if (src->shape_ != dst->shape_) {
-            throw jsi::JSError(rt, "restrictToBox: src and dst must have the same shape");
-        }
-
-        if (src->shape_.size() != 3) {
-            throw jsi::JSError(rt, "restrictToBox: src must be a 3D tensor of shape [H, W, C]");
-        }
 
         int32_t H = src->shape_[0];
         int32_t W = src->shape_[1];
@@ -321,36 +255,21 @@ void install_restrictToBox(jsi::Runtime &rt, jsi::Object &module) {
 
         bool isEmpty = (x2 < x1) || (y2 < y1);
 
-        if (src->dtype_ != dst->dtype_) {
-            throw jsi::JSError(rt, "restrictToBox: src and dst must have the same dtype");
-        }
-
-        std::shared_lock<std::shared_mutex> srcLock(src->mutex_, std::try_to_lock);
-        std::unique_lock<std::shared_mutex> dstLock(dst->mutex_, std::try_to_lock);
-        if (!srcLock.owns_lock() || !dstLock.owns_lock()) {
-            throw jsi::JSError(rt, "restrictToBox: tensors in use");
-        }
-
-        if (!src->data_ || !dst->data_) {
-            throw jsi::JSError(rt, "restrictToBox: tensors must not be disposed");
-        }
-
-        int32_t cvType{};
         try {
-            cvType = CV_MAKETYPE(dtypeToCvDepth(src->dtype_), C);
-        } catch (const std::invalid_argument &e) {
+            const int32_t cvType = CV_MAKETYPE(dtypeToCvDepth(src->dtype_), C);
+
+            ::cv::Mat srcMat(H, W, cvType, src->data_.get());
+            ::cv::Mat dstMat(H, W, cvType, dst->data_.get());
+
+            dstMat.setTo(::cv::Scalar::all(0));
+            if (!isEmpty) {
+                int32_t boxW = x2 - x1 + 1;
+                int32_t boxH = y2 - y1 + 1;
+                ::cv::Rect roi(x1, y1, boxW, boxH);
+                srcMat(roi).copyTo(dstMat(roi));
+            }
+        } catch (const std::exception &e) {
             throw jsi::JSError(rt, "restrictToBox: " + std::string(e.what()));
-        }
-
-        ::cv::Mat srcMat(H, W, cvType, src->data_.get());
-        ::cv::Mat dstMat(H, W, cvType, dst->data_.get());
-
-        dstMat.setTo(::cv::Scalar::all(0));
-        if (!isEmpty) {
-            int32_t boxW = x2 - x1 + 1;
-            int32_t boxH = y2 - y1 + 1;
-            ::cv::Rect roi(x1, y1, boxW, boxH);
-            srcMat(roi).copyTo(dstMat(roi));
         }
 
         return jsi::Value(rt, args[1]);

--- a/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
@@ -81,8 +81,8 @@ void install_nms(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: nms(boxes, scores, options)");
         }
 
-        auto boxes = tensor::fromJs(rt, "nms: boxes", args[0], DType::float32, tensor::SymbolicShape{"N", 4});
-        auto scores = tensor::fromJs(rt, "nms: scores", args[1], DType::float32, tensor::SymbolicShape{boxes->shape_[0]});
+        auto boxes = tensor::fromJs(rt, "nms: boxes", args[0], DType::float32, {"N", 4});
+        auto scores = tensor::fromJs(rt, "nms: scores", args[1], DType::float32, {boxes->shape_[0]});
 
         tensor::checkNotSameTensor(rt, "nms: boxes", boxes, "nms: scores", scores);
         auto boxesLock = tensor::tryLockShared(rt, "nms: boxes", boxes);
@@ -212,7 +212,7 @@ void install_restrictToBox(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: restrictToBox(src, dst, boxTuple, format)");
         }
 
-        auto src = tensor::fromJs(rt, "restrictToBox: src", args[0], std::nullopt, tensor::SymbolicShape{"H", "W", "C"});
+        auto src = tensor::fromJs(rt, "restrictToBox: src", args[0], std::nullopt, {"H", "W", "C"});
         auto dst = tensor::fromJs(rt, "restrictToBox: dst", args[1], src->dtype_, src->shape_);
 
         tensor::checkNotSameTensor(rt, "restrictToBox: src", src, "restrictToBox: dst", dst);

--- a/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/box_ops.cpp
@@ -11,12 +11,12 @@
 #include <utility>
 #include <vector>
 
-#include <opencv2/core.hpp>
-
 #include "core/dtype.h"
 #include "core/tensor.h"
 #include "core/tensor_helpers.h"
 #include "utils.h"
+
+#include <opencv2/core.hpp>
 
 namespace rnexecutorch::extensions::cv::box_ops {
 namespace jsi = facebook::jsi;
@@ -88,11 +88,11 @@ void install_nms(jsi::Runtime &rt, jsi::Object &module) {
         auto boxesLock = tensor::tryLockShared(rt, "nms: boxes", boxes);
         auto scoresLock = tensor::tryLockShared(rt, "nms: scores", scores);
 
-        const auto opts = args[2].asObject(rt);
-        const auto nmsTypeStr = conversions::getRequiredProperty<std::string>(rt, "nms", opts, "nmsType");
-        const auto boxFormatStr = conversions::getRequiredProperty<std::string>(rt, "nms", opts, "boxFormat");
-        const auto iouThreshold = conversions::getRequiredProperty<float>(rt, "nms", opts, "iouThreshold");
-        const auto confidenceThreshold = conversions::getRequiredProperty<float>(rt, "nms", opts, "confidenceThreshold");
+        auto opts = conversions::asType<jsi::Object>(rt, "nms: options", args[2]);
+        auto nmsTypeStr = conversions::getRequiredProperty<std::string>(rt, "nms: options", opts, "nmsType");
+        auto boxFormatStr = conversions::getRequiredProperty<std::string>(rt, "nms: options", opts, "boxFormat");
+        auto iouThreshold = conversions::getRequiredProperty<float>(rt, "nms: options", opts, "iouThreshold");
+        auto confidenceThreshold = conversions::getRequiredProperty<float>(rt, "nms: options", opts, "confidenceThreshold");
 
         NmsType nmsType{};
         BoxFormat boxFormat{};

--- a/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <numeric>
+#include <optional>
 #include <stdexcept>
 #include <utility>
 
@@ -10,11 +11,15 @@
 
 #include "core/dtype.h"
 #include "core/tensor.h"
+#include "core/tensor_helpers.h"
 #include "utils.h"
 
 namespace rnexecutorch::extensions::cv::image_ops {
 namespace jsi = facebook::jsi;
-using TensorHostObject = rnexecutorch::core::tensor::TensorHostObject;
+namespace tensor = rnexecutorch::core::tensor;
+namespace conversions = rnexecutorch::core::conversions;
+
+using rnexecutorch::core::types::DType;
 
 namespace {
 int interpToFlag(const std::string &interp) {
@@ -59,77 +64,17 @@ void install_resize(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: resize(src, dst, options)");
         }
 
-        if (!args[0].isObject() || !args[0].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "resize: src must be a Tensor");
-        }
+        auto src = tensor::fromJs(rt, "resize: src", args[0], std::nullopt, tensor::SymbolicShape{"H", "W", "C"});
+        auto dst = tensor::fromJs(rt, "resize: dst", args[1], src->dtype_, tensor::SymbolicShape{"H'", "W'", src->shape_[2]});
 
-        if (!args[1].isObject() || !args[1].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "resize: dst must be a Tensor");
-        }
+        tensor::checkNotSameTensor(rt, "resize: src", src, "resize: dst", dst);
+        auto srcLock = tensor::tryLockShared(rt, "resize: src", src);
+        auto dstLock = tensor::tryLockUnique(rt, "resize: dst", dst);
 
-        if (!args[2].isObject()) {
-            throw jsi::JSError(rt, "resize: options must be an object");
-        }
-
-        auto src = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
-        auto dst = args[1].asObject(rt).getHostObject<TensorHostObject>(rt);
-
-        if (src.get() == dst.get()) {
-            throw jsi::JSError(rt, "resize: In-place operations (src == dst) are not supported.");
-        }
-        auto opts = args[2].asObject(rt);
-
-        if (!opts.hasProperty(rt, "mode") || !opts.getProperty(rt, "mode").isString()) {
-            throw jsi::JSError(rt, "resize: options.mode is required and must be a string");
-        }
-
-        if (!opts.hasProperty(rt, "interpolation") || !opts.getProperty(rt, "interpolation").isString()) {
-            throw jsi::JSError(rt, "resize: options.interpolation is required and must be a string");
-        }
-
-        if (!opts.hasProperty(rt, "padValue") || !opts.getProperty(rt, "padValue").isNumber()) {
-            throw jsi::JSError(rt, "resize: options.padValue is required and must be a number");
-        }
-
-        auto mode = opts.getProperty(rt, "mode").asString(rt).utf8(rt);
-        auto interp = opts.getProperty(rt, "interpolation").asString(rt).utf8(rt);
-        const double padValue = opts.getProperty(rt, "padValue").asNumber();
-
-        if (src->shape_.size() != 3) {
-            throw jsi::JSError(rt, "resize: src must be [H, W, C]");
-        }
-
-        if (dst->shape_.size() != 3) {
-            throw jsi::JSError(rt, "resize: dst must be [H, W, C]");
-        }
-
-        if (src->shape_[2] != dst->shape_[2]) {
-            throw jsi::JSError(rt, "resize: src and dst must have the same number of channels");
-        }
-
-        if (src->dtype_ != dst->dtype_) {
-            throw jsi::JSError(rt, "resize: src and dst must have the same dtype");
-        }
-
-        // shared on src (read-only), unique on dst (write)
-
-        std::shared_lock<std::shared_mutex> srcLock(src->mutex_, std::try_to_lock);
-        if (!srcLock.owns_lock()) {
-            throw jsi::JSError(rt, "resize: src tensor is currently in use");
-        }
-
-        std::unique_lock<std::shared_mutex> dstLock(dst->mutex_, std::try_to_lock);
-        if (!dstLock.owns_lock()) {
-            throw jsi::JSError(rt, "resize: dst tensor is currently in use");
-        }
-
-        if (!src->data_) {
-            throw jsi::JSError(rt, "resize: src tensor has been disposed");
-        }
-
-        if (!dst->data_) {
-            throw jsi::JSError(rt, "resize: dst tensor has been disposed");
-        }
+        const auto opts = args[2].asObject(rt);
+        const auto mode = conversions::getRequiredProperty<std::string>(rt, "resize: options", opts, "mode");
+        const auto interp = conversions::getRequiredProperty<std::string>(rt, "resize: options", opts, "interpolation");
+        const auto padValue = conversions::getRequiredProperty<double>(rt, "resize: options", opts, "padValue");
 
         const int32_t srcH = src->shape_[0];
         const int32_t srcW = src->shape_[1];
@@ -142,29 +87,35 @@ void install_resize(jsi::Runtime &rt, jsi::Object &module) {
         try {
             cvType = CV_MAKETYPE(dtypeToCvDepth(src->dtype_), channels);
             interpFlag = interpToFlag(interp);
-        } catch (const std::invalid_argument &e) {
+        } catch (const std::exception &e) {
             throw jsi::JSError(rt, "resize: " + std::string(e.what()));
         }
 
-        const ::cv::Mat srcMat(srcH, srcW, cvType, src->data_.get());
-        ::cv::Mat dstMat(dstH, dstW, cvType, dst->data_.get());
+        try {
+            const ::cv::Mat srcMat(srcH, srcW, cvType, src->data_.get());
+            ::cv::Mat dstMat(dstH, dstW, cvType, dst->data_.get());
 
-        if (mode == "stretch") {
-            ::cv::resize(srcMat, dstMat, dstMat.size(), 0, 0, interpFlag);
-        } else if (mode == "letterbox") {
-            const FitBox fit = computeFit(srcW, srcH, dstW, dstH, /*inner=*/true);
+            if (mode == "stretch") {
+                ::cv::resize(srcMat, dstMat, dstMat.size(), 0, 0, interpFlag);
+            } else if (mode == "letterbox") {
+                const FitBox fit = computeFit(srcW, srcH, dstW, dstH, /*inner=*/true);
 
-            dstMat.setTo(::cv::Scalar::all(padValue));
-            ::cv::Mat roi = dstMat(::cv::Rect(fit.offX, fit.offY, fit.w, fit.h));
-            ::cv::resize(srcMat, roi, roi.size(), 0, 0, interpFlag);
-        } else if (mode == "crop") {
-            const FitBox fit = computeFit(srcW, srcH, dstW, dstH, /*inner=*/false);
+                dstMat.setTo(::cv::Scalar::all(padValue));
+                ::cv::Mat roi = dstMat(::cv::Rect(fit.offX, fit.offY, fit.w, fit.h));
+                ::cv::resize(srcMat, roi, roi.size(), 0, 0, interpFlag);
+            } else if (mode == "crop") {
+                const FitBox fit = computeFit(srcW, srcH, dstW, dstH, /*inner=*/false);
 
-            ::cv::Mat scaled;
-            ::cv::resize(srcMat, scaled, ::cv::Size(fit.w, fit.h), 0, 0, interpFlag);
-            scaled(::cv::Rect(fit.offX, fit.offY, dstW, dstH)).copyTo(dstMat);
-        } else {
-            throw jsi::JSError(rt, "resize: unknown mode '" + mode + "'. Use 'stretch', 'letterbox', or 'crop'");
+                ::cv::Mat scaled;
+                ::cv::resize(srcMat, scaled, ::cv::Size(fit.w, fit.h), 0, 0, interpFlag);
+                scaled(::cv::Rect(fit.offX, fit.offY, dstW, dstH)).copyTo(dstMat);
+            } else {
+                throw jsi::JSError(rt, "resize: unknown mode '" + mode + "'. Use 'stretch', 'letterbox', or 'crop'");
+            }
+        } catch (const jsi::JSError &) {
+            throw;
+        } catch (const std::exception &e) {
+            throw jsi::JSError(rt, "resize: " + std::string(e.what()));
         }
 
         return jsi::Value(rt, args[1]);
@@ -246,64 +197,19 @@ void install_cvtColor(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: cvtColor(src, dst, code)");
         }
 
-        if (!args[0].isObject() || !args[0].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "cvtColor: src must be a Tensor");
-        }
+        auto src = tensor::fromJs(rt, "cvtColor: src", args[0], std::nullopt, tensor::SymbolicShape{"H", "W", "C"});
+        auto dst = tensor::fromJs(rt, "cvtColor: dst", args[1], src->dtype_, tensor::SymbolicShape{src->shape_[0], src->shape_[1], "C'"});
 
-        if (!args[1].isObject() || !args[1].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "cvtColor: dst must be a Tensor");
-        }
-
-        if (!args[2].isString()) {
-            throw jsi::JSError(rt, "cvtColor: code must be a string");
-        }
-
-        auto src = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
-        auto dst = args[1].asObject(rt).getHostObject<TensorHostObject>(rt);
-
-        if (src.get() == dst.get()) {
-            throw jsi::JSError(rt, "cvtColor: In-place operations (src == dst) are not supported.");
-        }
-        auto code = args[2].asString(rt).utf8(rt);
-
-        if (src->shape_.size() != 3) {
-            throw jsi::JSError(rt, "cvtColor: src must be a 3D tensor [H, W, C]");
-        }
-
-        if (dst->shape_.size() != 3) {
-            throw jsi::JSError(rt, "cvtColor: dst must be a 3D tensor [H, W, C]");
-        }
-
-        if (src->shape_[0] != dst->shape_[0] || src->shape_[1] != dst->shape_[1]) {
-            throw jsi::JSError(rt, "cvtColor: src and dst spatial dimensions (H, W) must match");
-        }
-
-        if (src->dtype_ != dst->dtype_) {
-            throw jsi::JSError(rt, "cvtColor: src and dst must have the same dtype");
-        }
-
-        std::shared_lock<std::shared_mutex> srcLock(src->mutex_, std::try_to_lock);
-        if (!srcLock.owns_lock()) {
-            throw jsi::JSError(rt, "cvtColor: src tensor is currently in use");
-        }
-
-        std::unique_lock<std::shared_mutex> dstLock(dst->mutex_, std::try_to_lock);
-        if (!dstLock.owns_lock()) {
-            throw jsi::JSError(rt, "cvtColor: dst tensor is currently in use");
-        }
-
-        if (!src->data_) {
-            throw jsi::JSError(rt, "cvtColor: src tensor has been disposed");
-        }
-
-        if (!dst->data_) {
-            throw jsi::JSError(rt, "cvtColor: dst tensor has been disposed");
-        }
+        tensor::checkNotSameTensor(rt, "cvtColor: src", src, "cvtColor: dst", dst);
+        auto srcLock = tensor::tryLockShared(rt, "cvtColor: src", src);
+        auto dstLock = tensor::tryLockUnique(rt, "cvtColor: dst", dst);
 
         const int32_t srcH = src->shape_[0];
         const int32_t srcW = src->shape_[1];
         const int32_t srcC = src->shape_[2];
         const int32_t dstC = dst->shape_[2];
+
+        auto code = conversions::asType<std::string>(rt, "cvtColor: code", args[2]);
 
         int cvSrcType{};
         int cvDstType{};
@@ -317,7 +223,7 @@ void install_cvtColor(jsi::Runtime &rt, jsi::Object &module) {
             ::cv::Mat dstMat(srcH, srcW, cvDstType, dst->data_.get());
 
             ::cv::cvtColor(srcMat, dstMat, flag);
-        } catch (const std::invalid_argument &e) {
+        } catch (const std::exception &e) {
             throw jsi::JSError(rt, "cvtColor: " + std::string(e.what()));
         }
 
@@ -334,79 +240,33 @@ void install_toChannelsFirst(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: toChannelsFirst(src, dst)");
         }
 
-        if (!args[0].isObject() || !args[0].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "toChannelsFirst: src must be a Tensor");
-        }
+        auto src = tensor::fromJs(rt, "toChannelsFirst: src", args[0], std::nullopt, tensor::SymbolicShape{"H", "W", "C"});
+        auto dst = tensor::fromJs(rt, "toChannelsFirst: dst", args[1], src->dtype_, tensor::SymbolicShape{src->shape_[2], src->shape_[0], src->shape_[1]});
 
-        if (!args[1].isObject() || !args[1].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "toChannelsFirst: dst must be a Tensor");
-        }
-
-        auto src = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
-        auto dst = args[1].asObject(rt).getHostObject<TensorHostObject>(rt);
-
-        if (src.get() == dst.get()) {
-            throw jsi::JSError(rt, "toChannelsFirst: In-place operations (src == dst) are not supported.");
-        }
-
-        if (src->shape_.size() != 3) {
-            throw jsi::JSError(rt, "toChannelsFirst: src must be a 3D tensor [H, W, C]");
-        }
-
-        if (src->dtype_ != dst->dtype_) {
-            throw jsi::JSError(rt, "toChannelsFirst: src and dst must have the same dtype");
-        }
+        tensor::checkNotSameTensor(rt, "toChannelsFirst: src", src, "toChannelsFirst: dst", dst);
+        auto srcLock = tensor::tryLockShared(rt, "toChannelsFirst: src", src);
+        auto dstLock = tensor::tryLockUnique(rt, "toChannelsFirst: dst", dst);
 
         const int32_t srcH = src->shape_[0];
         const int32_t srcW = src->shape_[1];
         const int32_t srcC = src->shape_[2];
 
-        if (dst->shape_.size() != 3) {
-            throw jsi::JSError(rt, "toChannelsFirst: dst must be a 3D tensor [C, H, W]");
-        }
-        const int32_t dstC = dst->shape_[0];
-        const int32_t dstH = dst->shape_[1];
-        const int32_t dstW = dst->shape_[2];
-
-        if (srcH != dstH || srcW != dstW || srcC != dstC) {
-            throw jsi::JSError(rt, "toChannelsFirst: src and dst spatial dimensions and channel counts must match");
-        }
-
-        std::shared_lock<std::shared_mutex> srcLock(src->mutex_, std::try_to_lock);
-        if (!srcLock.owns_lock()) {
-            throw jsi::JSError(rt, "toChannelsFirst: src tensor is currently in use");
-        }
-
-        std::unique_lock<std::shared_mutex> dstLock(dst->mutex_, std::try_to_lock);
-        if (!dstLock.owns_lock()) {
-            throw jsi::JSError(rt, "toChannelsFirst: dst tensor is currently in use");
-        }
-
-        if (!src->data_) {
-            throw jsi::JSError(rt, "toChannelsFirst: src tensor has been disposed");
-        }
-
-        if (!dst->data_) {
-            throw jsi::JSError(rt, "toChannelsFirst: dst tensor has been disposed");
-        }
-
-        int cvType{};
         try {
-            cvType = CV_MAKETYPE(dtypeToCvDepth(src->dtype_), srcC);
-        } catch (const std::invalid_argument &e) {
+            const int cvType = CV_MAKETYPE(dtypeToCvDepth(src->dtype_), srcC);
+
+            const ::cv::Mat srcMat(srcH, srcW, cvType, src->data_.get());
+            std::vector<::cv::Mat> channels;
+            ::cv::split(srcMat, channels);
+
+            const size_t hw = static_cast<size_t>(srcH) * static_cast<size_t>(srcW);
+            const size_t elemSize = rnexecutorch::core::types::elementSize(src->dtype_);
+            uint8_t *dstPtr = dst->data_.get();
+
+            for (size_t i = 0; std::cmp_less(i, srcC); ++i) {
+                std::memcpy(dstPtr + i * hw * elemSize, channels[i].data, hw * elemSize);
+            }
+        } catch (const std::exception &e) {
             throw jsi::JSError(rt, "toChannelsFirst: " + std::string(e.what()));
-        }
-
-        const ::cv::Mat srcMat(srcH, srcW, cvType, src->data_.get());
-        std::vector<::cv::Mat> channels;
-        ::cv::split(srcMat, channels);
-
-        const size_t hw = static_cast<size_t>(srcH) * static_cast<size_t>(srcW);
-        const size_t elemSize = rnexecutorch::core::types::elementSize(src->dtype_);
-        uint8_t *dstPtr = dst->data_.get();
-
-        for (size_t i = 0; std::cmp_less(i, srcC); ++i) {
-            std::memcpy(dstPtr + i * hw * elemSize, channels[i].data, hw * elemSize);
         }
 
         return jsi::Value(rt, args[1]);
@@ -422,80 +282,34 @@ void install_toChannelsLast(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: toChannelsLast(src, dst)");
         }
 
-        if (!args[0].isObject() || !args[0].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "toChannelsLast: src must be a Tensor");
-        }
+        auto src = tensor::fromJs(rt, "toChannelsLast: src", args[0], std::nullopt, tensor::SymbolicShape{"C", "H", "W"});
+        auto dst = tensor::fromJs(rt, "toChannelsLast: dst", args[1], src->dtype_, tensor::SymbolicShape{src->shape_[1], src->shape_[2], src->shape_[0]});
 
-        if (!args[1].isObject() || !args[1].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "toChannelsLast: dst must be a Tensor");
-        }
-
-        auto src = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
-        auto dst = args[1].asObject(rt).getHostObject<TensorHostObject>(rt);
-
-        if (src.get() == dst.get()) {
-            throw jsi::JSError(rt, "toChannelsLast: In-place operations (src == dst) are not supported.");
-        }
-
-        if (src->shape_.size() != 3) {
-            throw jsi::JSError(rt, "toChannelsLast: src must be a 3D tensor [C, H, W]");
-        }
-
-        if (src->dtype_ != dst->dtype_) {
-            throw jsi::JSError(rt, "toChannelsLast: src and dst must have the same dtype");
-        }
+        tensor::checkNotSameTensor(rt, "toChannelsLast: src", src, "toChannelsLast: dst", dst);
+        auto srcLock = tensor::tryLockShared(rt, "toChannelsLast: src", src);
+        auto dstLock = tensor::tryLockUnique(rt, "toChannelsLast: dst", dst);
 
         const int32_t srcC = src->shape_[0];
         const int32_t srcH = src->shape_[1];
         const int32_t srcW = src->shape_[2];
 
-        if (dst->shape_.size() != 3) {
-            throw jsi::JSError(rt, "toChannelsLast: dst must be a 3D tensor [H, W, C]");
-        }
-        const int32_t dstH = dst->shape_[0];
-        const int32_t dstW = dst->shape_[1];
-        const int32_t dstC = dst->shape_[2];
-
-        if (srcH != dstH || srcW != dstW || srcC != dstC) {
-            throw jsi::JSError(rt, "toChannelsLast: src and dst spatial dimensions and channel counts must match");
-        }
-
-        std::shared_lock<std::shared_mutex> srcLock(src->mutex_, std::try_to_lock);
-        if (!srcLock.owns_lock()) {
-            throw jsi::JSError(rt, "toChannelsLast: src tensor is currently in use");
-        }
-
-        std::unique_lock<std::shared_mutex> dstLock(dst->mutex_, std::try_to_lock);
-        if (!dstLock.owns_lock()) {
-            throw jsi::JSError(rt, "toChannelsLast: dst tensor is currently in use");
-        }
-
-        if (!src->data_) {
-            throw jsi::JSError(rt, "toChannelsLast: src tensor has been disposed");
-        }
-
-        if (!dst->data_) {
-            throw jsi::JSError(rt, "toChannelsLast: dst tensor has been disposed");
-        }
-
-        int cvDepth{};
         try {
-            cvDepth = dtypeToCvDepth(src->dtype_);
-        } catch (const std::invalid_argument &e) {
+            const int cvDepth = dtypeToCvDepth(src->dtype_);
+
+            const size_t hw = static_cast<size_t>(srcH) * static_cast<size_t>(srcW);
+            const size_t elemSize = rnexecutorch::core::types::elementSize(src->dtype_);
+            uint8_t *srcPtr = src->data_.get();
+
+            std::vector<::cv::Mat> channels;
+            for (size_t i = 0; std::cmp_less(i, srcC); ++i) {
+                channels.emplace_back(srcH, srcW, cvDepth, srcPtr + i * hw * elemSize);
+            }
+
+            ::cv::Mat dstMat(srcH, srcW, CV_MAKETYPE(cvDepth, srcC), dst->data_.get());
+            ::cv::merge(channels, dstMat);
+        } catch (const std::exception &e) {
             throw jsi::JSError(rt, "toChannelsLast: " + std::string(e.what()));
         }
-
-        const size_t hw = static_cast<size_t>(srcH) * static_cast<size_t>(srcW);
-        const size_t elemSize = rnexecutorch::core::types::elementSize(src->dtype_);
-        uint8_t *srcPtr = src->data_.get();
-
-        std::vector<::cv::Mat> channels;
-        for (size_t i = 0; std::cmp_less(i, srcC); ++i) {
-            channels.emplace_back(srcH, srcW, cvDepth, srcPtr + i * hw * elemSize);
-        }
-
-        ::cv::Mat dstMat(dstH, dstW, CV_MAKETYPE(cvDepth, dstC), dst->data_.get());
-        ::cv::merge(channels, dstMat);
 
         return jsi::Value(rt, args[1]);
     };
@@ -510,114 +324,55 @@ void install_normalize(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: normalize(src, dst, options)");
         }
 
-        if (!args[0].isObject() || !args[0].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "normalize: src must be a Tensor");
-        }
+        auto src = tensor::fromJs(rt, "normalize: src", args[0], std::nullopt, tensor::SymbolicShape{"C", "H", "W"});
+        auto dst = tensor::fromJs(rt, "normalize: dst", args[1], std::nullopt, src->shape_);
 
-        if (!args[1].isObject() || !args[1].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "normalize: dst must be a Tensor");
-        }
+        tensor::checkNotSameTensor(rt, "normalize: src", src, "normalize: dst", dst);
+        auto srcLock = tensor::tryLockShared(rt, "normalize: src", src);
+        auto dstLock = tensor::tryLockUnique(rt, "normalize: dst", dst);
 
-        if (!args[2].isObject()) {
-            throw jsi::JSError(rt, "normalize: options must be an object");
-        }
-
-        auto src = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
-        auto dst = args[1].asObject(rt).getHostObject<TensorHostObject>(rt);
-
-        if (src.get() == dst.get()) {
-            throw jsi::JSError(rt, "normalize: In-place operations (src == dst) are not supported.");
-        }
         auto opts = args[2].asObject(rt);
 
-        if (src->shape_.size() != 3) {
-            throw jsi::JSError(rt, "normalize: src must be a 3D tensor [C, H, W]");
-        }
-
-        int32_t c = src->shape_[0];
+        const int32_t c = src->shape_[0];
         const int32_t h = src->shape_[1];
         const int32_t w = src->shape_[2];
 
-        if (dst->shape_.size() != 3 ||
-            dst->shape_[0] != c ||
-            dst->shape_[1] != h ||
-            dst->shape_[2] != w) {
-            throw jsi::JSError(rt, "normalize: src and dst shapes must match exactly ([C, H, W])");
-        }
-
-        auto getNormalizeOption = [&](const char *name) -> std::vector<double> {
-            if (!opts.hasProperty(rt, name)) {
-                throw jsi::JSError(rt, "normalize: options." + std::string(name) + " is required");
-            }
-
-            auto val = opts.getProperty(rt, name);
+        auto getNormalizeOption = [&](const char *optName) -> std::vector<double> {
+            auto val = conversions::getRequiredProperty<jsi::Value>(rt, "normalize", opts, optName);
             std::vector<double> result(static_cast<size_t>(c));
-
             if (val.isNumber()) {
                 std::ranges::fill(result, val.asNumber());
-            } else if (val.isObject() && val.asObject(rt).isArray(rt)) {
-                auto arr = val.asObject(rt).asArray(rt);
-                if (arr.length(rt) != static_cast<size_t>(c)) {
-                    throw jsi::JSError(rt, "normalize: options." + std::string(name) +
-                                               " array length must be exactly equal to channels");
-                }
-                for (size_t i = 0; std::cmp_less(i, c); ++i) {
-                    auto item = arr.getValueAtIndex(rt, i);
-                    if (!item.isNumber()) {
-                        throw jsi::JSError(rt, "normalize: options." + std::string(name) +
-                                                   " array must contain only numbers");
-                    }
-                    result[i] = item.asNumber();
-                }
             } else {
-                throw jsi::JSError(rt, "normalize: options." + std::string(name) +
-                                           " must be a number or an array of numbers");
+                auto arr = conversions::asVector<double>(rt, std::format("normalize: options.{}", optName), val);
+                if (arr.size() != static_cast<size_t>(c)) {
+                    throw jsi::JSError(rt, std::format("normalize: options.{} array length must be exactly equal to channels", optName));
+                }
+                result = std::move(arr);
             }
-
             return result;
         };
 
         std::vector<double> alpha = getNormalizeOption("alpha");
         std::vector<double> beta = getNormalizeOption("beta");
 
-        std::shared_lock<std::shared_mutex> srcLock(src->mutex_, std::try_to_lock);
-        if (!srcLock.owns_lock()) {
-            throw jsi::JSError(rt, "normalize: src tensor is currently in use");
-        }
-
-        std::unique_lock<std::shared_mutex> dstLock(dst->mutex_, std::try_to_lock);
-        if (!dstLock.owns_lock()) {
-            throw jsi::JSError(rt, "normalize: dst tensor is currently in use");
-        }
-
-        if (!src->data_) {
-            throw jsi::JSError(rt, "normalize: src tensor has been disposed");
-        }
-
-        if (!dst->data_) {
-            throw jsi::JSError(rt, "normalize: dst tensor has been disposed");
-        }
-
-        int srcDepthType{};
-        int dstDepthType{};
         try {
-            srcDepthType = dtypeToCvDepth(src->dtype_);
-            dstDepthType = dtypeToCvDepth(dst->dtype_);
-        } catch (const std::invalid_argument &e) {
+            const int srcDepthType = dtypeToCvDepth(src->dtype_);
+            const int dstDepthType = dtypeToCvDepth(dst->dtype_);
+
+            const size_t srcElemSize = rnexecutorch::core::types::elementSize(src->dtype_);
+            const size_t dstElemSize = rnexecutorch::core::types::elementSize(dst->dtype_);
+            uint8_t *srcPtr = src->data_.get();
+            uint8_t *dstPtr = dst->data_.get();
+
+            const size_t plane = static_cast<size_t>(h) * static_cast<size_t>(w);
+            for (size_t ch = 0; std::cmp_less(ch, c); ++ch) {
+                const ::cv::Mat srcChannel(h, w, srcDepthType, srcPtr + ch * plane * srcElemSize);
+                ::cv::Mat dstChannel(h, w, dstDepthType, dstPtr + ch * plane * dstElemSize);
+
+                srcChannel.convertTo(dstChannel, dstDepthType, alpha[ch], beta[ch]);
+            }
+        } catch (const std::exception &e) {
             throw jsi::JSError(rt, "normalize: " + std::string(e.what()));
-        }
-
-        const size_t srcElemSize = rnexecutorch::core::types::elementSize(src->dtype_);
-        const size_t dstElemSize = rnexecutorch::core::types::elementSize(dst->dtype_);
-        uint8_t *srcPtr = src->data_.get();
-        uint8_t *dstPtr = dst->data_.get();
-
-        const size_t plane = static_cast<size_t>(h) * static_cast<size_t>(w);
-        for (size_t ch = 0; std::cmp_less(ch, c); ++ch) {
-            const ::cv::Mat srcChannel(h, w, srcDepthType, srcPtr + ch * plane * srcElemSize);
-            ::cv::Mat dstChannel(h, w, dstDepthType, dstPtr + ch * plane * dstElemSize);
-
-            srcChannel.convertTo(dstChannel, dstDepthType, alpha[ch], beta[ch]);
         }
 
         return jsi::Value(rt, args[1]);
@@ -633,64 +388,33 @@ void install_applyColormap(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: applyColormap(src, dst, colormap)");
         }
 
-        if (!args[0].isObject() || !args[0].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "applyColormap: src must be a Tensor");
-        }
-        if (!args[1].isObject() || !args[1].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "applyColormap: dst must be a Tensor");
-        }
-
-        auto src = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
-        auto dst = args[1].asObject(rt).getHostObject<TensorHostObject>(rt);
-        constexpr size_t numRgbaChannels = 4;
-
-        if (src->dtype_ != rnexecutorch::core::types::DType::int32) {
-            throw jsi::JSError(rt, "applyColormap: src must be int32");
-        }
-        if (dst->dtype_ != rnexecutorch::core::types::DType::uint8) {
-            throw jsi::JSError(rt, "applyColormap: dst must be uint8");
-        }
-        if (dst->numel_ != src->numel_ * numRgbaChannels) {
-            throw jsi::JSError(rt, "applyColormap: dst must have exactly 4 times the number of elements as src (RGBA channels)");
-        }
-
         if (!args[2].isObject() || !args[2].asObject(rt).isArray(rt)) {
             throw jsi::JSError(rt, "applyColormap: colormap must be an array");
+        }
+
+        auto src = tensor::fromJs(rt, "applyColormap: src", args[0], DType::int32, std::nullopt);
+        auto dst = tensor::fromJs(rt, "applyColormap: dst", args[1], DType::uint8, std::nullopt);
+
+        tensor::checkNotSameTensor(rt, "applyColormap: src", src, "applyColormap: dst", dst);
+        auto srcLock = tensor::tryLockShared(rt, "applyColormap: src", src);
+        auto dstLock = tensor::tryLockUnique(rt, "applyColormap: dst", dst);
+
+        constexpr size_t numRgbaChannels = 4;
+        if (dst->numel_ != src->numel_ * numRgbaChannels) {
+            throw jsi::JSError(rt, "applyColormap: dst must have exactly 4 times the number of elements as src (RGBA channels)");
         }
 
         auto colormapArray = args[2].asObject(rt).asArray(rt);
         const size_t numColors = colormapArray.size(rt);
         std::vector<std::array<uint8_t, numRgbaChannels>> lut(numColors);
         for (size_t i = 0; i < numColors; ++i) {
-            auto colorVal = colormapArray.getValueAtIndex(rt, i);
-            if (!colorVal.isObject() || !colorVal.asObject(rt).isArray(rt)) {
-                throw jsi::JSError(rt, "applyColormap: colormap entry must be an array");
-            }
-            auto color = colorVal.asObject(rt).asArray(rt);
-            if (color.size(rt) != numRgbaChannels) {
+            auto colorVec = conversions::asVector<uint8_t>(rt, "applyColormap: colormap entry", colormapArray.getValueAtIndex(rt, i));
+            if (colorVec.size() != numRgbaChannels) {
                 throw jsi::JSError(rt, "applyColormap: colormap entry must be an RGBA color array of size 4");
             }
             for (size_t c = 0; c < numRgbaChannels; ++c) {
-                auto channelVal = color.getValueAtIndex(rt, c);
-                if (!channelVal.isNumber()) {
-                    throw jsi::JSError(rt, "applyColormap: colormap channel value must be a number");
-                }
-                const double val = channelVal.asNumber();
-                if (std::isnan(val) || val < 0.0 || val > 255.0) {
-                    throw jsi::JSError(rt, "applyColormap: colormap channel value must be between 0 and 255");
-                }
-                lut[i][c] = static_cast<uint8_t>(val);
+                lut[i][c] = colorVec[c];
             }
-        }
-
-        std::shared_lock<std::shared_mutex> srcLock(src->mutex_, std::try_to_lock);
-        std::unique_lock<std::shared_mutex> dstLock(dst->mutex_, std::try_to_lock);
-        if (!srcLock.owns_lock() || !dstLock.owns_lock()) {
-            throw jsi::JSError(rt, "applyColormap: tensors in use");
-        }
-
-        if (!src->data_ || !dst->data_) {
-            throw jsi::JSError(rt, "applyColormap: tensor has been disposed");
         }
 
         const size_t pixels = src->numel_;

--- a/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
@@ -65,8 +65,8 @@ void install_resize(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: resize(src, dst, options)");
         }
 
-        auto src = tensor::fromJs(rt, "resize: src", args[0], std::nullopt, tensor::SymbolicShape{"H", "W", "C"});
-        auto dst = tensor::fromJs(rt, "resize: dst", args[1], src->dtype_, tensor::SymbolicShape{"H'", "W'", src->shape_[2]});
+        auto src = tensor::fromJs(rt, "resize: src", args[0], std::nullopt, {"H", "W", "C"});
+        auto dst = tensor::fromJs(rt, "resize: dst", args[1], src->dtype_, {"H'", "W'", src->shape_[2]});
 
         tensor::checkNotSameTensor(rt, "resize: src", src, "resize: dst", dst);
         auto srcLock = tensor::tryLockShared(rt, "resize: src", src);
@@ -198,8 +198,8 @@ void install_cvtColor(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: cvtColor(src, dst, code)");
         }
 
-        auto src = tensor::fromJs(rt, "cvtColor: src", args[0], std::nullopt, tensor::SymbolicShape{"H", "W", "C"});
-        auto dst = tensor::fromJs(rt, "cvtColor: dst", args[1], src->dtype_, tensor::SymbolicShape{src->shape_[0], src->shape_[1], "C'"});
+        auto src = tensor::fromJs(rt, "cvtColor: src", args[0], std::nullopt, {"H", "W", "C"});
+        auto dst = tensor::fromJs(rt, "cvtColor: dst", args[1], src->dtype_, {src->shape_[0], src->shape_[1], "C'"});
 
         tensor::checkNotSameTensor(rt, "cvtColor: src", src, "cvtColor: dst", dst);
         auto srcLock = tensor::tryLockShared(rt, "cvtColor: src", src);
@@ -241,8 +241,8 @@ void install_toChannelsFirst(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: toChannelsFirst(src, dst)");
         }
 
-        auto src = tensor::fromJs(rt, "toChannelsFirst: src", args[0], std::nullopt, tensor::SymbolicShape{"H", "W", "C"});
-        auto dst = tensor::fromJs(rt, "toChannelsFirst: dst", args[1], src->dtype_, tensor::SymbolicShape{src->shape_[2], src->shape_[0], src->shape_[1]});
+        auto src = tensor::fromJs(rt, "toChannelsFirst: src", args[0], std::nullopt, {"H", "W", "C"});
+        auto dst = tensor::fromJs(rt, "toChannelsFirst: dst", args[1], src->dtype_, {src->shape_[2], src->shape_[0], src->shape_[1]});
 
         tensor::checkNotSameTensor(rt, "toChannelsFirst: src", src, "toChannelsFirst: dst", dst);
         auto srcLock = tensor::tryLockShared(rt, "toChannelsFirst: src", src);
@@ -283,8 +283,8 @@ void install_toChannelsLast(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: toChannelsLast(src, dst)");
         }
 
-        auto src = tensor::fromJs(rt, "toChannelsLast: src", args[0], std::nullopt, tensor::SymbolicShape{"C", "H", "W"});
-        auto dst = tensor::fromJs(rt, "toChannelsLast: dst", args[1], src->dtype_, tensor::SymbolicShape{src->shape_[1], src->shape_[2], src->shape_[0]});
+        auto src = tensor::fromJs(rt, "toChannelsLast: src", args[0], std::nullopt, {"C", "H", "W"});
+        auto dst = tensor::fromJs(rt, "toChannelsLast: dst", args[1], src->dtype_, {src->shape_[1], src->shape_[2], src->shape_[0]});
 
         tensor::checkNotSameTensor(rt, "toChannelsLast: src", src, "toChannelsLast: dst", dst);
         auto srcLock = tensor::tryLockShared(rt, "toChannelsLast: src", src);
@@ -325,7 +325,7 @@ void install_normalize(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: normalize(src, dst, options)");
         }
 
-        auto src = tensor::fromJs(rt, "normalize: src", args[0], std::nullopt, tensor::SymbolicShape{"C", "H", "W"});
+        auto src = tensor::fromJs(rt, "normalize: src", args[0], std::nullopt, {"C", "H", "W"});
         auto dst = tensor::fromJs(rt, "normalize: dst", args[1], std::nullopt, src->shape_);
 
         tensor::checkNotSameTensor(rt, "normalize: src", src, "normalize: dst", dst);
@@ -390,8 +390,8 @@ void install_applyColormap(jsi::Runtime &rt, jsi::Object &module) {
         }
 
         auto colormapArray = conversions::asType<jsi::Array>(rt, "applyColormap: colormap", args[2]);
-        auto src = tensor::fromJs(rt, "applyColormap: src", args[0], DType::int32, tensor::SymbolicShape{"H", "W", 1});
-        auto dst = tensor::fromJs(rt, "applyColormap: dst", args[1], DType::uint8, tensor::SymbolicShape{src->shape_[0], src->shape_[1], 4});
+        auto src = tensor::fromJs(rt, "applyColormap: src", args[0], DType::int32, {"H", "W", 1});
+        auto dst = tensor::fromJs(rt, "applyColormap: dst", args[1], DType::uint8, {src->shape_[0], src->shape_[1], 4});
 
         tensor::checkNotSameTensor(rt, "applyColormap: src", src, "applyColormap: dst", dst);
         auto srcLock = tensor::tryLockShared(rt, "applyColormap: src", src);

--- a/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
+++ b/packages/react-native-executorch/cpp/extensions/cv/image_ops.cpp
@@ -2,17 +2,18 @@
 
 #include <algorithm>
 #include <cmath>
-#include <numeric>
+#include <cstring>
+#include <format>
 #include <optional>
 #include <stdexcept>
 #include <utility>
-
-#include <opencv2/imgproc.hpp>
 
 #include "core/dtype.h"
 #include "core/tensor.h"
 #include "core/tensor_helpers.h"
 #include "utils.h"
+
+#include <opencv2/imgproc.hpp>
 
 namespace rnexecutorch::extensions::cv::image_ops {
 namespace jsi = facebook::jsi;
@@ -71,7 +72,7 @@ void install_resize(jsi::Runtime &rt, jsi::Object &module) {
         auto srcLock = tensor::tryLockShared(rt, "resize: src", src);
         auto dstLock = tensor::tryLockUnique(rt, "resize: dst", dst);
 
-        const auto opts = args[2].asObject(rt);
+        const auto opts = conversions::asType<jsi::Object>(rt, "resize: options", args[2]);
         const auto mode = conversions::getRequiredProperty<std::string>(rt, "resize: options", opts, "mode");
         const auto interp = conversions::getRequiredProperty<std::string>(rt, "resize: options", opts, "interpolation");
         const auto padValue = conversions::getRequiredProperty<double>(rt, "resize: options", opts, "padValue");
@@ -331,17 +332,17 @@ void install_normalize(jsi::Runtime &rt, jsi::Object &module) {
         auto srcLock = tensor::tryLockShared(rt, "normalize: src", src);
         auto dstLock = tensor::tryLockUnique(rt, "normalize: dst", dst);
 
-        auto opts = args[2].asObject(rt);
+        auto opts = conversions::asType<jsi::Object>(rt, "normalize: options", args[2]);
 
         const int32_t c = src->shape_[0];
         const int32_t h = src->shape_[1];
         const int32_t w = src->shape_[2];
 
         auto getNormalizeOption = [&](const char *optName) -> std::vector<double> {
-            auto val = conversions::getRequiredProperty<jsi::Value>(rt, "normalize", opts, optName);
+            auto val = conversions::getRequiredProperty<jsi::Value>(rt, "normalize: options", opts, optName);
             std::vector<double> result(static_cast<size_t>(c));
             if (val.isNumber()) {
-                std::ranges::fill(result, val.asNumber());
+                std::ranges::fill(result, conversions::asType<double>(rt, std::format("normalize: options.{}", optName), val));
             } else {
                 auto arr = conversions::asVector<double>(rt, std::format("normalize: options.{}", optName), val);
                 if (arr.size() != static_cast<size_t>(c)) {
@@ -388,23 +389,16 @@ void install_applyColormap(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: applyColormap(src, dst, colormap)");
         }
 
-        if (!args[2].isObject() || !args[2].asObject(rt).isArray(rt)) {
-            throw jsi::JSError(rt, "applyColormap: colormap must be an array");
-        }
-
-        auto src = tensor::fromJs(rt, "applyColormap: src", args[0], DType::int32, std::nullopt);
-        auto dst = tensor::fromJs(rt, "applyColormap: dst", args[1], DType::uint8, std::nullopt);
+        auto colormapArray = conversions::asType<jsi::Array>(rt, "applyColormap: colormap", args[2]);
+        auto src = tensor::fromJs(rt, "applyColormap: src", args[0], DType::int32, tensor::SymbolicShape{"H", "W", 1});
+        auto dst = tensor::fromJs(rt, "applyColormap: dst", args[1], DType::uint8, tensor::SymbolicShape{src->shape_[0], src->shape_[1], 4});
 
         tensor::checkNotSameTensor(rt, "applyColormap: src", src, "applyColormap: dst", dst);
         auto srcLock = tensor::tryLockShared(rt, "applyColormap: src", src);
         auto dstLock = tensor::tryLockUnique(rt, "applyColormap: dst", dst);
 
         constexpr size_t numRgbaChannels = 4;
-        if (dst->numel_ != src->numel_ * numRgbaChannels) {
-            throw jsi::JSError(rt, "applyColormap: dst must have exactly 4 times the number of elements as src (RGBA channels)");
-        }
 
-        auto colormapArray = args[2].asObject(rt).asArray(rt);
         const size_t numColors = colormapArray.size(rt);
         std::vector<std::array<uint8_t, numRgbaChannels>> lut(numColors);
         for (size_t i = 0; i < numColors; ++i) {

--- a/packages/react-native-executorch/cpp/extensions/math/operations.cpp
+++ b/packages/react-native-executorch/cpp/extensions/math/operations.cpp
@@ -3,13 +3,18 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <optional>
 #include <utility>
 
 #include "core/tensor.h"
+#include "core/tensor_helpers.h"
 
 namespace rnexecutorch::extensions::math {
 namespace jsi = facebook::jsi;
-using TensorHostObject = rnexecutorch::core::tensor::TensorHostObject;
+namespace conversions = rnexecutorch::core::conversions;
+
+namespace tensor = rnexecutorch::core::tensor;
+using rnexecutorch::core::types::DType;
 
 void install_sigmoid(jsi::Runtime &rt, jsi::Object &module) {
     const auto *name = "sigmoid";
@@ -18,50 +23,12 @@ void install_sigmoid(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: sigmoid(src, dst)");
         }
 
-        if (!args[0].isObject() || !args[0].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "sigmoid: src must be a Tensor");
-        }
+        auto src = tensor::fromJs(rt, "sigmoid: src", args[0], DType::float32, std::nullopt);
+        auto dst = tensor::fromJs(rt, "sigmoid: dst", args[1], DType::float32, src->shape_);
 
-        if (!args[1].isObject() || !args[1].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "sigmoid: dst must be a Tensor");
-        }
-
-        auto src = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
-        auto dst = args[1].asObject(rt).getHostObject<TensorHostObject>(rt);
-
-        if (src.get() == dst.get()) {
-            throw jsi::JSError(rt, "sigmoid: In-place operations (src == dst) are not supported.");
-        }
-
-        if (src->shape_ != dst->shape_) {
-            throw jsi::JSError(rt, "sigmoid: src and dst must have the same shape");
-        }
-
-        if (src->dtype_ != dst->dtype_) {
-            throw jsi::JSError(rt, "sigmoid: src and dst must have the same dtype");
-        }
-
-        if (src->dtype_ != rnexecutorch::core::types::DType::float32) {
-            throw jsi::JSError(rt, "sigmoid: only float32 tensors are supported");
-        }
-
-        std::shared_lock<std::shared_mutex> srcLock(src->mutex_, std::try_to_lock);
-        if (!srcLock.owns_lock()) {
-            throw jsi::JSError(rt, "sigmoid: src tensor is currently in use");
-        }
-
-        std::unique_lock<std::shared_mutex> dstLock(dst->mutex_, std::try_to_lock);
-        if (!dstLock.owns_lock()) {
-            throw jsi::JSError(rt, "sigmoid: dst tensor is currently in use");
-        }
-
-        if (!src->data_) {
-            throw jsi::JSError(rt, "sigmoid: src tensor has been disposed");
-        }
-
-        if (!dst->data_) {
-            throw jsi::JSError(rt, "sigmoid: dst tensor has been disposed");
-        }
+        tensor::checkNotSameTensor(rt, "sigmoid: src", src, "sigmoid: dst", dst);
+        auto srcLock = tensor::tryLockShared(rt, "sigmoid: src", src);
+        auto dstLock = tensor::tryLockUnique(rt, "sigmoid: dst", dst);
 
         const auto countElements = src->numel_;
         const auto *srcData = reinterpret_cast<const float *>(src->data_.get());
@@ -84,42 +51,18 @@ void install_softmax(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: softmax(src, dst, axis)");
         }
 
-        if (!args[0].isObject() || !args[0].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "softmax: src must be a Tensor");
-        }
+        auto src = tensor::fromJs(rt, "softmax: src", args[0], DType::float32, std::nullopt);
+        auto dst = tensor::fromJs(rt, "softmax: dst", args[1], DType::float32, src->shape_);
 
-        if (!args[1].isObject() || !args[1].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "softmax: dst must be a Tensor");
-        }
-
-        auto src = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
-        auto dst = args[1].asObject(rt).getHostObject<TensorHostObject>(rt);
-
-        if (src.get() == dst.get()) {
-            throw jsi::JSError(rt, "softmax: In-place operations (src == dst) are not supported.");
-        }
-
-        if (src->shape_ != dst->shape_) {
-            throw jsi::JSError(rt, "softmax: src and dst must have the same shape");
-        }
-
-        if (src->dtype_ != dst->dtype_) {
-            throw jsi::JSError(rt, "softmax: src and dst must have the same dtype");
-        }
-
-        if (src->dtype_ != rnexecutorch::core::types::DType::float32) {
-            throw jsi::JSError(rt, "softmax: only float32 tensors are supported");
-        }
+        tensor::checkNotSameTensor(rt, "softmax: src", src, "softmax: dst", dst);
+        auto srcLock = tensor::tryLockShared(rt, "softmax: src", src);
+        auto dstLock = tensor::tryLockUnique(rt, "softmax: dst", dst);
 
         if (src->shape_.empty()) {
             throw jsi::JSError(rt, "softmax: src must have at least one dimension");
         }
 
-        if (!args[2].isNumber()) {
-            throw jsi::JSError(rt, "softmax: axis must be a number");
-        }
-
-        int axis = static_cast<int>(args[2].asNumber());
+        int axis = conversions::asType<int32_t>(rt, "softmax: axis", args[2]);
         const int rank = static_cast<int>(src->shape_.size());
 
         // Support negative axis indices like numpy (e.g., axis=-1 means last
@@ -131,24 +74,6 @@ void install_softmax(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "softmax: axis is out of range");
         }
         const auto axisIdx = static_cast<size_t>(axis);
-
-        std::shared_lock<std::shared_mutex> srcLock(src->mutex_, std::try_to_lock);
-        if (!srcLock.owns_lock()) {
-            throw jsi::JSError(rt, "softmax: src tensor is currently in use");
-        }
-
-        std::unique_lock<std::shared_mutex> dstLock(dst->mutex_, std::try_to_lock);
-        if (!dstLock.owns_lock()) {
-            throw jsi::JSError(rt, "softmax: dst tensor is currently in use");
-        }
-
-        if (!src->data_) {
-            throw jsi::JSError(rt, "softmax: src tensor has been disposed");
-        }
-
-        if (!dst->data_) {
-            throw jsi::JSError(rt, "softmax: dst tensor has been disposed");
-        }
 
         const auto *srcData = reinterpret_cast<const float *>(src->data_.get());
         auto *dstData = reinterpret_cast<float *>(dst->data_.get());
@@ -203,34 +128,14 @@ void install_argmax(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: argmax(src, dst, axis)");
         }
 
-        if (!args[0].isObject() || !args[0].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "argmax: src must be a Tensor");
-        }
+        auto src = tensor::fromJs(rt, "argmax: src", args[0], DType::float32, std::nullopt);
+        auto dst = tensor::fromJs(rt, "argmax: dst", args[1], DType::int32, std::nullopt);
 
-        if (!args[1].isObject() || !args[1].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "argmax: dst must be a Tensor");
-        }
+        tensor::checkNotSameTensor(rt, "argmax: src", src, "argmax: dst", dst);
+        auto srcLock = tensor::tryLockShared(rt, "argmax: src", src);
+        auto dstLock = tensor::tryLockUnique(rt, "argmax: dst", dst);
 
-        auto src = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
-        auto dst = args[1].asObject(rt).getHostObject<TensorHostObject>(rt);
-
-        if (src.get() == dst.get()) {
-            throw jsi::JSError(rt, "argmax: In-place operations (src == dst) are not supported.");
-        }
-
-        if (src->dtype_ != rnexecutorch::core::types::DType::float32) {
-            throw jsi::JSError(rt, "argmax: src must be float32");
-        }
-
-        if (dst->dtype_ != rnexecutorch::core::types::DType::int32) {
-            throw jsi::JSError(rt, "argmax: dst must be int32");
-        }
-
-        if (!args[2].isNumber()) {
-            throw jsi::JSError(rt, "argmax: axis must be a number");
-        }
-
-        int axis = static_cast<int>(args[2].asNumber());
+        int axis = conversions::asType<int32_t>(rt, "argmax: axis", args[2]);
         const int rank = static_cast<int>(src->shape_.size());
 
         // Support negative axis indices like numpy (e.g., axis=-1 means last
@@ -247,20 +152,6 @@ void install_argmax(jsi::Runtime &rt, jsi::Object &module) {
         dstExpectedShape[axisIdx] = 1;
         if (dst->shape_ != dstExpectedShape) {
             throw jsi::JSError(rt, "argmax: dst shape must match src shape but with axis dimension 1");
-        }
-
-        std::shared_lock<std::shared_mutex> srcLock(src->mutex_, std::try_to_lock);
-        std::unique_lock<std::shared_mutex> dstLock(dst->mutex_, std::try_to_lock);
-        if (!srcLock.owns_lock() || !dstLock.owns_lock()) {
-            throw jsi::JSError(rt, "argmax: tensors in use");
-        }
-
-        if (!src->data_) {
-            throw jsi::JSError(rt, "argmax: src tensor has been disposed");
-        }
-
-        if (!dst->data_) {
-            throw jsi::JSError(rt, "argmax: dst tensor has been disposed");
         }
 
         const auto *srcData = reinterpret_cast<const float *>(src->data_.get());
@@ -310,51 +201,14 @@ void install_threshold(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "Usage: threshold(src, dst, threshold)");
         }
 
-        if (!args[0].isObject() || !args[0].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "threshold: src must be a Tensor");
-        }
+        auto src = tensor::fromJs(rt, "threshold: src", args[0], DType::float32, std::nullopt);
+        auto dst = tensor::fromJs(rt, "threshold: dst", args[1], DType::float32, src->shape_);
 
-        if (!args[1].isObject() || !args[1].asObject(rt).isHostObject<TensorHostObject>(rt)) {
-            throw jsi::JSError(rt, "threshold: dst must be a Tensor");
-        }
+        tensor::checkNotSameTensor(rt, "threshold: src", src, "threshold: dst", dst);
+        auto srcLock = tensor::tryLockShared(rt, "threshold: src", src);
+        auto dstLock = tensor::tryLockUnique(rt, "threshold: dst", dst);
 
-        if (!args[2].isNumber()) {
-            throw jsi::JSError(rt, "threshold: threshold must be a number");
-        }
-
-        auto src = args[0].asObject(rt).getHostObject<TensorHostObject>(rt);
-        auto dst = args[1].asObject(rt).getHostObject<TensorHostObject>(rt);
-        auto thresholdVal = static_cast<float>(args[2].asNumber());
-
-        if (src.get() == dst.get()) {
-            throw jsi::JSError(rt, "threshold: In-place operations (src == dst) are not supported.");
-        }
-
-        if (src->shape_ != dst->shape_) {
-            throw jsi::JSError(rt, "threshold: src and dst must have the same shape");
-        }
-
-        if (src->dtype_ != rnexecutorch::core::types::DType::float32) {
-            throw jsi::JSError(rt, "threshold: src must be a float32 tensor");
-        }
-
-        if (dst->dtype_ != rnexecutorch::core::types::DType::float32) {
-            throw jsi::JSError(rt, "threshold: dst must be a float32 tensor");
-        }
-
-        std::shared_lock<std::shared_mutex> srcLock(src->mutex_, std::try_to_lock);
-        std::unique_lock<std::shared_mutex> dstLock(dst->mutex_, std::try_to_lock);
-        if (!srcLock.owns_lock() || !dstLock.owns_lock()) {
-            throw jsi::JSError(rt, "threshold: tensors in use");
-        }
-
-        if (!src->data_) {
-            throw jsi::JSError(rt, "threshold: src tensor has been disposed");
-        }
-
-        if (!dst->data_) {
-            throw jsi::JSError(rt, "threshold: dst tensor has been disposed");
-        }
+        auto thresholdVal = conversions::asType<float>(rt, "threshold: threshold", args[2]);
 
         const auto *srcData = reinterpret_cast<const float *>(src->data_.get());
         auto *dstData = reinterpret_cast<float *>(dst->data_.get());

--- a/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
+++ b/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
@@ -1,13 +1,17 @@
 #include "tokenizer.h"
 
 #include <cstdint>
+#include <format>
 #include <stdexcept>
 #include <utility>
 
 #include <pytorch/tokenizers/error.h>
 
+#include "core/conversions.h"
+
 namespace rnexecutorch::extensions::nlp::tokenizer {
 namespace jsi = facebook::jsi;
+namespace conversions = rnexecutorch::core::conversions;
 
 namespace {
 // Number of BOS/EOS tokens to add on top of what the tokenizer.json defines.
@@ -82,20 +86,13 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
                 throw jsi::JSError(rt, "encode: Tokenizer has been disposed");
             }
 
-            auto text = args[0].asString(rt).utf8(rt);
+            auto text = conversions::asType<std::string>(rt, "encode: text", args[0]);
             auto result = self->tokenizer_->encode(text, kNumAddedBosTokens, kNumAddedEosTokens);
             if (!result.ok()) {
-                throw jsi::JSError(rt, "encode: Failed to encode input: " +
-                                           toString(result.error()));
+                throw jsi::JSError(rt, std::format("encode: Failed to encode input: {}", toString(result.error())));
             }
 
-            const auto &ids = result.get();
-            auto jsArray = jsi::Array(rt, ids.size());
-            for (size_t i = 0; i < ids.size(); ++i) {
-                jsArray.setValueAtIndex(rt, i, static_cast<double>(ids[i]));
-            }
-
-            return jsArray;
+            return conversions::toJsiArray(rt, result.get());
         };
         return jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "encode"), 1, fnBody);
     }
@@ -107,17 +104,10 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
                 throw jsi::JSError(rt, "decode: Usage: decode(tokens, skipSpecialTokens?)");
             }
 
-            if (!args[0].isObject() || !args[0].asObject(rt).isArray(rt)) {
-                throw jsi::JSError(rt, "decode: Expected arg0 to be an array");
-            }
-
             // skipSpecialTokens is optional and defaults to true.
             bool skipSpecialTokens = true;
             if (count == 2 && !args[1].isUndefined()) {
-                if (!args[1].isBool()) {
-                    throw jsi::JSError(rt, "decode: Expected arg1 to be a boolean");
-                }
-                skipSpecialTokens = args[1].asBool();
+                skipSpecialTokens = conversions::asType<bool>(rt, "decode: skipSpecialTokens", args[1]);
             }
 
             std::unique_lock<std::mutex> lock(self->mutex_, std::try_to_lock);
@@ -129,17 +119,7 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
                 throw jsi::JSError(rt, "decode: Tokenizer has been disposed");
             }
 
-            auto tokensArray = args[0].asObject(rt).asArray(rt);
-
-            std::vector<uint64_t> tokens;
-            tokens.reserve(tokensArray.size(rt));
-            for (size_t i = 0; i < tokensArray.size(rt); ++i) {
-                auto val = tokensArray.getValueAtIndex(rt, i);
-                if (!val.isNumber()) {
-                    throw jsi::JSError(rt, "decode: Expected tokens[" + std::to_string(i) + "] to be a number");
-                }
-                tokens.push_back(static_cast<uint64_t>(val.asNumber()));
-            }
+            auto tokens = conversions::asVector<uint64_t>(rt, "decode: tokens", args[0]);
 
             if (tokens.empty()) {
                 return jsi::String::createFromUtf8(rt, "");
@@ -147,8 +127,7 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
 
             auto result = self->tokenizer_->decode(tokens, skipSpecialTokens);
             if (!result.ok()) {
-                throw jsi::JSError(rt, "decode: Failed to decode tokens: " +
-                                           toString(result.error()));
+                throw jsi::JSError(rt, std::format("decode: Failed to decode tokens: {}", toString(result.error())));
             }
 
             return jsi::String::createFromUtf8(rt, result.get());
@@ -197,11 +176,10 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
                 throw jsi::JSError(rt, "idToToken: Tokenizer has been disposed");
             }
 
-            auto tokenId = static_cast<uint64_t>(args[0].asNumber());
+            auto tokenId = conversions::asType<uint64_t>(rt, "idToToken: id", args[0]);
             auto result = self->tokenizer_->id_to_piece(tokenId);
             if (!result.ok()) {
-                throw jsi::JSError(rt, "idToToken: Failed to convert id to token: " +
-                                           toString(result.error()));
+                throw jsi::JSError(rt, std::format("idToToken: Failed to convert id to token: {}", toString(result.error())));
             }
 
             return jsi::String::createFromUtf8(rt, result.get());
@@ -216,10 +194,6 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
                 throw jsi::JSError(rt, "tokenToId: Usage: tokenToId(token)");
             }
 
-            if (!args[0].isString()) {
-                throw jsi::JSError(rt, "tokenToId: Expected arg0 to be a string");
-            }
-
             std::unique_lock<std::mutex> lock(self->mutex_, std::try_to_lock);
             if (!lock.owns_lock()) {
                 throw jsi::JSError(rt, "tokenToId: Tokenizer is currently in use");
@@ -229,11 +203,10 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
                 throw jsi::JSError(rt, "tokenToId: Tokenizer has been disposed");
             }
 
-            auto token = args[0].asString(rt).utf8(rt);
+            auto token = conversions::asType<std::string>(rt, "tokenToId: token", args[0]);
             auto result = self->tokenizer_->piece_to_id(token);
             if (!result.ok()) {
-                throw jsi::JSError(rt, "tokenToId: Failed to convert token to id: " +
-                                           toString(result.error()));
+                throw jsi::JSError(rt, std::format("tokenToId: Failed to convert token to id: {}", toString(result.error())));
             }
 
             return static_cast<double>(result.get());
@@ -283,16 +256,12 @@ void install_loadTokenizer(jsi::Runtime &rt, jsi::Object &module) {
             throw jsi::JSError(rt, "loadTokenizer: Usage: loadTokenizer(arg0)");
         }
 
-        if (!args[0].isString()) {
-            throw jsi::JSError(rt, "loadTokenizer: Expected arg0 to be a string");
-        }
-
-        auto tokenizerPath = args[0].asString(rt).utf8(rt);
+        auto tokenizerPath = conversions::asType<std::string>(rt, "loadTokenizer: path", args[0]);
         try {
             auto tokenizerInstance = std::make_shared<TokenizerHostObject>(tokenizerPath);
             return jsi::Object::createFromHostObject(rt, tokenizerInstance);
         } catch (const std::exception &e) {
-            throw jsi::JSError(rt, std::string("loadTokenizer: ") + e.what());
+            throw jsi::JSError(rt, std::format("loadTokenizer: {}", e.what()));
         }
     };
     auto fn = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name), 1, fnBody);

--- a/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
+++ b/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
@@ -73,10 +73,6 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
                 throw jsi::JSError(rt, "encode: Usage: encode(text)");
             }
 
-            if (!args[0].isString()) {
-                throw jsi::JSError(rt, "encode: Expected arg0 to be a string");
-            }
-
             std::unique_lock<std::mutex> lock(self->mutex_, std::try_to_lock);
             if (!lock.owns_lock()) {
                 throw jsi::JSError(rt, "encode: Tokenizer is currently in use");
@@ -161,10 +157,6 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
         auto fnBody = [self](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
             if (count != 1) {
                 throw jsi::JSError(rt, "idToToken: Usage: idToToken(id)");
-            }
-
-            if (!args[0].isNumber()) {
-                throw jsi::JSError(rt, "idToToken: Expected arg0 to be a number");
             }
 
             std::unique_lock<std::mutex> lock(self->mutex_, std::try_to_lock);

--- a/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
+++ b/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
@@ -5,9 +5,9 @@
 #include <stdexcept>
 #include <utility>
 
-#include <pytorch/tokenizers/error.h>
-
 #include "core/conversions.h"
+
+#include <pytorch/tokenizers/error.h>
 
 namespace rnexecutorch::extensions::nlp::tokenizer {
 namespace jsi = facebook::jsi;
@@ -245,7 +245,7 @@ void install_loadTokenizer(jsi::Runtime &rt, jsi::Object &module) {
     const auto *name = "loadTokenizer";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
         if (count != 1) {
-            throw jsi::JSError(rt, "loadTokenizer: Usage: loadTokenizer(arg0)");
+            throw jsi::JSError(rt, "loadTokenizer: Usage: loadTokenizer(path)");
         }
 
         auto tokenizerPath = conversions::asType<std::string>(rt, "loadTokenizer: path", args[0]);

--- a/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.h
+++ b/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.h
@@ -20,7 +20,7 @@ public:
     std::vector<facebook::jsi::PropNameID> getPropertyNames(facebook::jsi::Runtime &rt) override;
 
 private:
-    const std::string tokenizerPath_;
+    std::string tokenizerPath_;
     std::unique_ptr<tokenizers::HFTokenizer> tokenizer_;
     std::mutex mutex_;
 };

--- a/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.h
+++ b/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.h
@@ -20,7 +20,7 @@ public:
     std::vector<facebook::jsi::PropNameID> getPropertyNames(facebook::jsi::Runtime &rt) override;
 
 private:
-    std::string tokenizerPath_;
+    const std::string tokenizerPath_;
     std::unique_ptr<tokenizers::HFTokenizer> tokenizer_;
     std::mutex mutex_;
 };


### PR DESCRIPTION
## Description

Refactors the C++ layer by pulling two families of scattered, copy-pasted utilities out of individual translation units and into purpose-built, reusable modules:

- `cpp/core/conversions.{h,cpp}`  JSI -> C++ type coercions
- `cpp/core/tensor_helpers.{h,cpp}`: tensor acquisition, locking, and shape/dtype validation

### Motivation

The old code had two recurring problems that became impossible to ignore as the extension surface grew:

#### JSI coercion was inlined everywhere
Every file that needed to read a number, string, or array out of a `jsi::Value` had its own copy of the same defensive checks, cast chains, and error-message construction. A bug or policy change (e.g. how `null` is treated, or which format an error message takes) had to be hunted down and patched in every translation unit independently.

#### Tensor validation was duplicated across all extension operations
Every operation in `box_ops`, `image_ops`, `operations`, and `tokenizer` that accepted a `Tensor` argument re-implemented the same sequence: unwrap the `jsi::Value`, cast to `TensorHostObject`, acquire the appropriate
shared/exclusive lock, and assert dtype + shape constraints. This led to subtle inconsistencies in error messages and locking strategies between operations. 


### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

- [ ] Build all example apps on both Android and iOS and test that nothing is broken.

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

Closes #1270
Closes #1268 

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

Since this PR changes quite a lot of stuff in `core/` it can also be used for #1268 
