### PR TITLE
[RNE Rewrite] fix(example): add bottom safe area inset to classification screen

### DIFF
--- a/apps/computer-vision/app/classification/index.tsx
+++ b/apps/computer-vision/app/classification/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, Platform } from 'react-native';
-import { commonStyles, ColorPalette } from '../../theme';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { commonStyles, ColorPalette, theme } from '../../theme';
 import { useImage } from '@shopify/react-native-skia';
 import { useClassifier, models } from 'react-native-executorch';
 import ScreenWrapper from '../../components/ScreenWrapper';
@@ -28,6 +29,7 @@ const MODEL_OPTIONS: ModelOption[] = [
 ];
 
 function ClassificationContent() {
+  const insets = useSafeAreaInsets();
   const [selectedModel, setSelectedModel] = useState<any>(MODEL_OPTIONS[0].value);
   const [imageUri, setImageUri] = useState<string | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
@@ -97,7 +99,10 @@ function ClassificationContent() {
   return (
     <ScrollView
       style={commonStyles.container}
-      contentContainerStyle={commonStyles.contentContainer}
+      contentContainerStyle={[
+        commonStyles.contentContainer,
+        { paddingBottom: insets.bottom + theme.spacing.large },
+      ]}
     >
       <Text style={commonStyles.description}>
         Upload or capture an image to identify objects using a classifier.


### PR DESCRIPTION
## Description

Follow-up PR to two problems raised in review of #1296 
- https://github.com/software-mansion/react-native-executorch/pull/1296#issuecomment-4876709762
- https://github.com/software-mansion/react-native-executorch/pull/1296#issuecomment-4876868932

It
- Fixes the classification example screen to not overlap with Android navigation buttons.
- Leaves the default YOLO threshold as `0.25` since it is the official recommended default value (see: [ultralytics docs](https://docs.ultralytics.com/modes/predict#fixed-shape-vs-minimum-rectangle-rect:~:text=float-,0.25,-Sets%20the%20minimum))

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

- [ ] Run the computer-vision app on Android and confirm that there is no overlap with navigation buttons.

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
