### PR TITLE
fix(resource-fetcher): avoid `this` in static `fs` field initializer

### DIFF
--- a/packages/react-native-executorch/src/utils/ResourceFetcher.ts
+++ b/packages/react-native-executorch/src/utils/ResourceFetcher.ts
@@ -138,8 +138,10 @@ export class ResourceFetcher {
      * @remarks
      * **REQUIRED**: Used internally for reading configuration files (e.g., tokenizer configs).
      */
+    // Reference the class by name: `this` inside a static-field arrow gets
+    // rebound to module scope by Babel under RN's hermes transform profiles.
     readAsString: async (path: string) => {
-      return this.getAdapter().readAsString(path);
+      return ResourceFetcher.getAdapter().readAsString(path);
     },
   };
 }


### PR DESCRIPTION
## Description

`ResourceFetcher.fs.readAsString` is an async arrow inside a **static class-field initializer** and relies on `this` binding to the class. Because the package resolves through the `"react-native": "src/index"` entry, Metro compiles this TypeScript source with the **consuming app's** Babel config. Under `@react-native/babel-preset` with `unstable_transformProfile: 'hermes-stable'` (or `'hermes-canary'`), the async transform hoists the arrow's `this` capture to module scope:

```js
var _this = this; // module scope!
class ResourceFetcher {
  static fs = { readAsString: /* ... */ _this.getAdapter().readAsString(path) /* ... */ };
}
```

`_this.getAdapter` is `undefined`, so **every model load fails** with `TypeError: undefined is not a function` inside `LLMController.load`, right after the download finishes — on both iOS and Android. The `default` transform profile compiles it correctly, which is why this only bites apps that opt into the hermes profiles.

Fix: reference the class by name instead of `this`. One line, no behavior change.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

1. In a bare RN app (RN 0.86, New Architecture) set `unstable_transformProfile: 'hermes-stable'` on `@react-native/babel-preset` in `babel.config.js`.
2. Load any LLM, e.g. `useLLM({ model: GEMMA4_E2B })`, on a physical device.
3. Without this patch: load fails with `TypeError: undefined is not a function` after the download completes. With it: the model loads and generates.

Reproducible without a device: run `@babel/core` on `src/utils/ResourceFetcher.ts` with the preset above and inspect the output — the `var _this = this` hoist lands at module scope.

Verified end-to-end on a physical iPhone 16 with `GEMMA4_E2B` (MLX backend): download → load → generation all work with this patch (applied via `yarn patch` against 0.9.2).

### Screenshots

N/A

### Related issues

N/A

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

A repo-wide sweep found no other `this` usage inside static-field initializers, so this is the only affected site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
