### PR TITLE
[RNE Rewrite] Deduplicate tokenizer result-unwrapping with a local `unwrap` helper

### DIFF
--- a/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
+++ b/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
@@ -47,6 +47,14 @@ std::string toString(tokenizers::Error error) {
     }
     return "Unknown(" + std::to_string(static_cast<int32_t>(error)) + ")";
 }
+
+template <typename T>
+T unwrap(jsi::Runtime &rt, const std::string &ctx, tokenizers::Result<T> result) {
+    if (!result.ok()) {
+        throw jsi::JSError(rt, std::format("{}: {}", ctx, toString(result.error())));
+    }
+    return std::move(result.get());
+}
 } // namespace
 
 TokenizerHostObject::TokenizerHostObject(std::string tokenizerPath)
@@ -83,12 +91,10 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
             }
 
             auto text = conversions::asType<std::string>(rt, "encode: text", args[0]);
-            auto result = self->tokenizer_->encode(text, kNumAddedBosTokens, kNumAddedEosTokens);
-            if (!result.ok()) {
-                throw jsi::JSError(rt, std::format("encode: Failed to encode input: {}", toString(result.error())));
-            }
+            auto tokens = unwrap(rt, "encode: Failed to encode input",
+                                 self->tokenizer_->encode(text, kNumAddedBosTokens, kNumAddedEosTokens));
 
-            return conversions::toJsiArray(rt, result.get());
+            return conversions::toJsiArray(rt, tokens);
         };
         return jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "encode"), 1, fnBody);
     }
@@ -121,12 +127,10 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
                 return jsi::String::createFromUtf8(rt, "");
             }
 
-            auto result = self->tokenizer_->decode(tokens, skipSpecialTokens);
-            if (!result.ok()) {
-                throw jsi::JSError(rt, std::format("decode: Failed to decode tokens: {}", toString(result.error())));
-            }
+            auto text = unwrap(rt, "decode: Failed to decode tokens",
+                               self->tokenizer_->decode(tokens, skipSpecialTokens));
 
-            return jsi::String::createFromUtf8(rt, result.get());
+            return jsi::String::createFromUtf8(rt, text);
         };
         return jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "decode"), 1, fnBody);
     }
@@ -169,12 +173,10 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
             }
 
             auto tokenId = conversions::asType<uint64_t>(rt, "idToToken: id", args[0]);
-            auto result = self->tokenizer_->id_to_piece(tokenId);
-            if (!result.ok()) {
-                throw jsi::JSError(rt, std::format("idToToken: Failed to convert id to token: {}", toString(result.error())));
-            }
+            auto token = unwrap(rt, "idToToken: Failed to convert id to token",
+                                self->tokenizer_->id_to_piece(tokenId));
 
-            return jsi::String::createFromUtf8(rt, result.get());
+            return jsi::String::createFromUtf8(rt, token);
         };
         return jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "idToToken"), 1, fnBody);
     }
@@ -196,12 +198,10 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
             }
 
             auto token = conversions::asType<std::string>(rt, "tokenToId: token", args[0]);
-            auto result = self->tokenizer_->piece_to_id(token);
-            if (!result.ok()) {
-                throw jsi::JSError(rt, std::format("tokenToId: Failed to convert token to id: {}", toString(result.error())));
-            }
+            auto tokenId = unwrap(rt, "tokenToId: Failed to convert token to id",
+                                  self->tokenizer_->piece_to_id(token));
 
-            return static_cast<double>(result.get());
+            return static_cast<double>(tokenId);
         };
         return jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "tokenToId"), 1, fnBody);
     }


### PR DESCRIPTION
## Description

The five `TokenizerHostObject` methods (`encode`, `decode`, `idToToken`, `tokenToId`, and the encode path) each hand-rolled the same block around a `tokenizers::Result`:

```cpp
auto result = self->tokenizer_->encode(...);
if (!result.ok()) {
    throw jsi::JSError(rt, std::format("encode: Failed to encode input: {}", toString(result.error())));
}
return conversions::toJsiArray(rt, result.get());
```

Replaced with a local `unwrap` helper in the file's anonymous namespace, mirroring the one already in `core/model.cpp`. That existing helper is file-local and typed to `executorch::runtime::Result`, so it cannot be reused here — the tokenizer returns `tokenizers::Result` carrying a distinct `tokenizers::Error` (which is why this file already has its own `toString`). Following the established per-file convention rather than hoisting a shared helper into core keeps the change scoped and leaves core untouched.

Behaviour is identical: same error messages, same exceptions.

Split out of #1319 so the `std::span` refactor and this cleanup can be reviewed independently. Part of the broader tokenizer host-object cleanup tracked in #1316.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

Behaviour-preserving; verification is compile-only, not yet run on a device.

`tokenizer.cpp` compiles clean under the project's strict warning set from `.clangd`:

```
cd packages/react-native-executorch
clang++ -fsyntax-only $(tr '\n' ' ' < compile_flags.txt) \
  -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion cpp/extensions/nlp/tokenizer.cpp
```

To exercise at runtime: the tokenizer screen in `apps/nlp`.

### Related issues

Part of #1316

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings