### PR TITLE
@bh/model-validation

### DIFF
--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "dtype.h"
+#include "model_companion_parser.h"
 #include "tensor_helpers.h"
 
 #include <jsi/jsi.h>
@@ -21,7 +22,6 @@
 namespace {
 namespace jsi = facebook::jsi;
 namespace types = rnexecutorch::core::types;
-namespace tensor = rnexecutorch::core::tensor;
 
 template <typename T>
 T unwrap(const std::string &ctx, executorch::runtime::Result<T> result) {
@@ -70,124 +70,6 @@ jsi::Object tensorMetaToJs(jsi::Runtime &rt, const executorch::runtime::TensorIn
     return jsTensorMeta;
 }
 
-/**
- * Parses compile-time dynamic dimension constraints for the inputs of a module
- * method.
- *
- * @note This is a temporary workaround. ExecuTorch (.pte) model metadata
- * natively serializes only the static upper-bound limits of dynamic/symbolic
- * dimensions, and does not expose the active dynamic range (min, max, step) at
- * runtime.
- *
- * To use this feature, the .pte model must be exported with a companion method
- * named "get_dynamic_dims_<methodName>" (e.g., "get_dynamic_dims_forward").
- *
- * Python export requirements:
- * 1. The companion method must take no arguments.
- * 2. It must return a list of outputs matching the number of Tag::Tensor inputs
- *    of the target method (scalar inputs are excluded).
- * 3. Each output must be a 2D int32 tensor of shape [rank, 3], where each row
- *    represents [min, max, step] constraints for the corresponding dimension of
- *    that input tensor.
- *
- * @param module The ExecuTorch extension module to query.
- * @param methodName The name of the target module method (e.g. "forward").
- * @return A vector of SymbolicShape objects, or std::nullopt if the companion
- *         method is not defined. If returned, the vector's size is guaranteed
- *         to equal methodMeta.num_inputs(), containing parsed SymbolicShapes
- *         for tensor inputs and empty SymbolicShapes for non-tensor inputs.
- */
-std::optional<std::vector<tensor::SymbolicShape>>
-parseDynamicInputShapes(executorch::extension::Module &module, const std::string &methodName) {
-    using executorch::aten::ScalarType;
-
-    const auto getDynamicShapesMethodName = std::format("get_dynamic_dims_{}", methodName);
-    const auto ctx = getDynamicShapesMethodName + ": ";
-
-    auto methodNames = unwrap(ctx + "failed to get method names", module.method_names());
-    if (methodName == getDynamicShapesMethodName ||
-        !methodNames.contains(getDynamicShapesMethodName)) {
-        return std::nullopt;
-    }
-
-    auto methodMeta = unwrap(std::format("{}failed to get meta for method '{}'", ctx, methodName),
-                             module.method_meta(methodName));
-
-    size_t expectedTensorInputs = 0;
-    for (size_t i = 0; i < methodMeta.num_inputs(); ++i) {
-        auto tag = unwrap(std::format("{}failed to get tag for input [{}]", ctx, i), methodMeta.input_tag(i));
-        if (tag == executorch::runtime::Tag::Tensor) {
-            expectedTensorInputs++;
-        }
-    }
-
-    auto result = unwrap(ctx + "failed to execute", module.execute(getDynamicShapesMethodName));
-    if (result.size() != expectedTensorInputs) {
-        throw std::runtime_error(std::format("{}number of outputs returned ({}) does not match the number of "
-                                             "tensor inputs declared by method '{}' ({})",
-                                             ctx, result.size(), methodName, expectedTensorInputs));
-    }
-
-    std::vector<tensor::SymbolicShape> dynamicShapes;
-    dynamicShapes.reserve(methodMeta.num_inputs());
-    size_t tensorIndex = 0;
-
-    for (size_t i = 0; i < methodMeta.num_inputs(); ++i) {
-        auto tag = unwrap(std::format("{}failed to get tag for input [{}]", ctx, i),
-                          methodMeta.input_tag(i));
-
-        if (tag != executorch::runtime::Tag::Tensor) {
-            // Emplace an empty shape for non-tensor inputs to maintain a 1-to-1
-            // index alignment between dynamicShapes and the model's inputs vector.
-            dynamicShapes.emplace_back();
-            continue;
-        }
-
-        const auto &out = result.at(tensorIndex);
-        if (!out.isTensor()) {
-            throw std::runtime_error(std::format("{}output[{}] is not a tensor", ctx, tensorIndex));
-        }
-
-        auto inputMeta = unwrap(std::format("{}failed to get tensor meta for input [{}]", ctx, i),
-                                methodMeta.input_tensor_meta(i));
-        const auto rank = inputMeta.sizes().size();
-        const auto shapeTensor = out.toTensor();
-
-        if (shapeTensor.dim() != 2 || shapeTensor.size(1) != 3 ||
-            shapeTensor.size(0) != static_cast<ssize_t>(rank) ||
-            shapeTensor.scalar_type() != ScalarType::Int) {
-            throw std::runtime_error(std::format("{}output[{}] expected to be a 2D int32_t tensor of shape [{}, 3]",
-                                                 ctx, tensorIndex, rank));
-        }
-
-        const auto *shape = shapeTensor.const_data_ptr<int32_t>();
-        tensor::SymbolicShape symbolicShape;
-        symbolicShape.reserve(rank);
-
-        for (size_t axis = 0; axis < rank; ++axis) {
-            const auto minDim = shape[axis * 3 + 0];
-            const auto maxDim = shape[axis * 3 + 1];
-            const auto step = shape[axis * 3 + 2];
-            if (minDim < 0 || maxDim < minDim || step < 1) {
-                throw std::runtime_error(std::format("{}output[{}], axis {} is invalid: "
-                                                     "expected 0 <= min <= max and step >= 1 but got [{}, {}, {}]",
-                                                     ctx, tensorIndex, axis, minDim, maxDim, step));
-            }
-            if (maxDim > inputMeta.sizes()[axis]) {
-                throw std::runtime_error(std::format("{}output[{}], axis {} max dimension ({}) "
-                                                     "exceeds model metadata upper limit ({})",
-                                                     ctx, tensorIndex, axis, maxDim, inputMeta.sizes()[axis]));
-            }
-
-            symbolicShape.emplace_back(tensor::RangeDim{.min = minDim, .max = maxDim, .step = step});
-        }
-
-        dynamicShapes.push_back(std::move(symbolicShape));
-        ++tensorIndex;
-    }
-
-    return dynamicShapes;
-}
 } // namespace
 
 namespace rnexecutorch::core::model {
@@ -199,6 +81,7 @@ using rnexecutorch::core::tensor::TensorHostObject;
 ModelHostObject::ModelHostObject(const std::string &modelPath)
     : modelPath_(modelPath),
       etModule_(std::make_unique<executorch::extension::Module>(modelPath)) {
+
     auto error = etModule_->load();
     if (!etModule_->is_loaded()) {
         const std::string errorMsg = executorch::runtime::to_string(error);
@@ -208,8 +91,18 @@ ModelHostObject::ModelHostObject(const std::string &modelPath)
     auto methodNames = unwrap("Failed to get method names", etModule_->method_names());
     for (const auto &methodName : methodNames) {
         auto dynamicShapes = parseDynamicInputShapes(*etModule_, methodName);
+        auto enumeratedShapes = parseEnumeratedInputShapes(*etModule_, methodName);
+
+        if (dynamicShapes && enumeratedShapes) {
+            throw std::runtime_error(std::format(
+                "Method '{}' cannot define both get_dynamic_dims_{} and get_enumerated_dims_{}",
+                methodName, methodName, methodName));
+        }
         if (dynamicShapes) {
-            dynamicInputShapes_.emplace(methodName, std::move(*dynamicShapes));
+            inputShapeConstraints_.emplace(methodName, std::move(*dynamicShapes));
+        }
+        if (enumeratedShapes) {
+            inputShapeConstraints_.emplace(methodName, std::move(*enumeratedShapes));
         }
     }
 }
@@ -364,9 +257,9 @@ jsi::Value ModelHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
                     auto expectedDtype = fromScalarType(rt, ctx, tensorMeta.scalar_type());
 
                     std::shared_ptr<TensorHostObject> tensorHostObject;
-                    if (self->dynamicInputShapes_.contains(methodName)) {
-                        auto expectedShape = self->dynamicInputShapes_[methodName][i];
-                        tensorHostObject = tensor::fromJs(rt, ctx, val, expectedDtype, expectedShape);
+                    if (self->inputShapeConstraints_.contains(methodName)) {
+                        auto shapeConstraint = self->inputShapeConstraints_[methodName][i];
+                        tensorHostObject = tensor::fromJs(rt, ctx, val, expectedDtype, shapeConstraint);
                     } else {
                         tensorHostObject = tensor::fromJs(rt, ctx, val, expectedDtype, tensorMeta.sizes());
                     }

--- a/packages/react-native-executorch/cpp/core/model.h
+++ b/packages/react-native-executorch/cpp/core/model.h
@@ -35,7 +35,7 @@ private:
     std::unique_ptr<executorch::extension::Module> etModule_;
     std::mutex mutex_;
 
-    std::unordered_map<std::string, std::vector<core::tensor::SymbolicShape>> dynamicInputShapes_;
+    std::unordered_map<std::string, std::vector<core::tensor::ShapeConstraint>> inputShapeConstraints_;
 };
 
 void install_loadModel(jsi::Runtime &rt, jsi::Object &module);

--- a/packages/react-native-executorch/cpp/core/model_companion_parser.cpp
+++ b/packages/react-native-executorch/cpp/core/model_companion_parser.cpp
@@ -1,0 +1,207 @@
+#include "model_companion_parser.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <executorch/runtime/core/tag.h>
+
+namespace {
+
+template <typename T>
+T unwrap(const std::string &ctx, executorch::runtime::Result<T> result) {
+    if (!result.ok()) {
+        throw std::runtime_error(
+            std::format("{}: {}", ctx, executorch::runtime::to_string(result.error())));
+    }
+    return std::move(result.get());
+}
+
+} // namespace
+
+namespace rnexecutorch::core::model {
+
+std::optional<std::vector<tensor::ShapeConstraint>>
+parseDynamicInputShapes(executorch::extension::Module &module, const std::string &methodName) {
+    using executorch::aten::ScalarType;
+
+    const auto getDynamicShapesMethodName = std::format("get_dynamic_dims_{}", methodName);
+    const auto ctx = getDynamicShapesMethodName + ": ";
+
+    auto methodNames = unwrap(ctx + "failed to get method names", module.method_names());
+    if (methodName == getDynamicShapesMethodName ||
+        !methodNames.contains(getDynamicShapesMethodName)) {
+        return std::nullopt;
+    }
+
+    auto methodMeta = unwrap(std::format("{}failed to get meta for method '{}'", ctx, methodName),
+                             module.method_meta(methodName));
+
+    size_t expectedTensorInputs = 0;
+    for (size_t i = 0; i < methodMeta.num_inputs(); ++i) {
+        auto tag = unwrap(std::format("{}failed to get tag for input [{}]", ctx, i), methodMeta.input_tag(i));
+        if (tag == executorch::runtime::Tag::Tensor) {
+            expectedTensorInputs++;
+        }
+    }
+
+    auto result = unwrap(ctx + "failed to execute", module.execute(getDynamicShapesMethodName));
+    if (result.size() != expectedTensorInputs) {
+        throw std::runtime_error(std::format("{}number of outputs returned ({}) does not match the number of "
+                                             "tensor inputs declared by method '{}' ({})",
+                                             ctx, result.size(), methodName, expectedTensorInputs));
+    }
+
+    std::vector<tensor::ShapeConstraint> dynamicShapes;
+    dynamicShapes.reserve(methodMeta.num_inputs());
+    size_t tensorIndex = 0;
+
+    for (size_t i = 0; i < methodMeta.num_inputs(); ++i) {
+        auto tag = unwrap(std::format("{}failed to get tag for input [{}]", ctx, i),
+                          methodMeta.input_tag(i));
+
+        if (tag != executorch::runtime::Tag::Tensor) {
+            dynamicShapes.emplace_back();
+            continue;
+        }
+
+        const auto &out = result.at(tensorIndex);
+        if (!out.isTensor()) {
+            throw std::runtime_error(std::format("{}output[{}] is not a tensor", ctx, tensorIndex));
+        }
+
+        auto inputMeta = unwrap(std::format("{}failed to get tensor meta for input [{}]", ctx, i),
+                                methodMeta.input_tensor_meta(i));
+        const auto rank = inputMeta.sizes().size();
+        const auto shapeTensor = out.toTensor();
+
+        if (shapeTensor.dim() != 2 || shapeTensor.size(1) != 3 ||
+            shapeTensor.size(0) != static_cast<ssize_t>(rank) ||
+            shapeTensor.scalar_type() != ScalarType::Int) {
+            throw std::runtime_error(std::format("{}output[{}] expected to be a 2D int32_t tensor of shape [{}, 3]",
+                                                 ctx, tensorIndex, rank));
+        }
+
+        const auto *shape = shapeTensor.const_data_ptr<int32_t>();
+        tensor::SymbolicShape symbolicShape;
+        symbolicShape.reserve(rank);
+
+        for (size_t axis = 0; axis < rank; ++axis) {
+            const auto minDim = shape[axis * 3 + 0];
+            const auto maxDim = shape[axis * 3 + 1];
+            const auto step = shape[axis * 3 + 2];
+            if (minDim < 0 || maxDim < minDim || step < 1) {
+                throw std::runtime_error(std::format("{}output[{}], axis {} is invalid: "
+                                                     "expected 0 <= min <= max and step >= 1 but got [{}, {}, {}]",
+                                                     ctx, tensorIndex, axis, minDim, maxDim, step));
+            }
+            if (maxDim > inputMeta.sizes()[axis]) {
+                throw std::runtime_error(std::format("{}output[{}], axis {} max dimension ({}) "
+                                                     "exceeds model metadata upper limit ({})",
+                                                     ctx, tensorIndex, axis, maxDim, inputMeta.sizes()[axis]));
+            }
+
+            symbolicShape.emplace_back(tensor::RangeDim{.min = minDim, .max = maxDim, .step = step});
+        }
+
+        dynamicShapes.emplace_back(std::move(symbolicShape));
+        ++tensorIndex;
+    }
+
+    return dynamicShapes;
+}
+
+std::optional<std::vector<tensor::ShapeConstraint>>
+parseEnumeratedInputShapes(executorch::extension::Module &module, const std::string &methodName) {
+    using executorch::aten::ScalarType;
+
+    const auto getEnumeratedShapesMethodName = std::format("get_enumerated_dims_{}", methodName);
+    const auto ctx = getEnumeratedShapesMethodName + ": ";
+
+    auto methodNames = unwrap(ctx + "failed to get method names", module.method_names());
+    if (methodName == getEnumeratedShapesMethodName ||
+        !methodNames.contains(getEnumeratedShapesMethodName)) {
+        return std::nullopt;
+    }
+
+    auto methodMeta = unwrap(std::format("{}failed to get meta for method '{}'", ctx, methodName),
+                             module.method_meta(methodName));
+
+    size_t expectedTensorInputs = 0;
+    for (size_t i = 0; i < methodMeta.num_inputs(); ++i) {
+        auto tag = unwrap(std::format("{}failed to get tag for input [{}]", ctx, i),
+                          methodMeta.input_tag(i));
+        if (tag == executorch::runtime::Tag::Tensor) {
+            expectedTensorInputs++;
+        }
+    }
+
+    auto result = unwrap(ctx + "failed to execute", module.execute(getEnumeratedShapesMethodName));
+    if (result.size() != expectedTensorInputs) {
+        throw std::runtime_error(std::format("{}number of outputs returned ({}) does not match the number of "
+                                             "tensor inputs declared by method '{}' ({})",
+                                             ctx, result.size(), methodName, expectedTensorInputs));
+    }
+
+    std::vector<tensor::ShapeConstraint> enumeratedShapes;
+    enumeratedShapes.reserve(methodMeta.num_inputs());
+    size_t tensorIndex = 0;
+
+    for (size_t i = 0; i < methodMeta.num_inputs(); ++i) {
+        auto tag = unwrap(std::format("{}failed to get tag for input [{}]", ctx, i),
+                          methodMeta.input_tag(i));
+
+        if (tag != executorch::runtime::Tag::Tensor) {
+            enumeratedShapes.emplace_back();
+            continue;
+        }
+
+        const auto &out = result.at(tensorIndex);
+        if (!out.isTensor()) {
+            throw std::runtime_error(std::format("{}output[{}] is not a tensor", ctx, tensorIndex));
+        }
+
+        auto inputMeta = unwrap(std::format("{}failed to get tensor meta for input [{}]", ctx, i),
+                                methodMeta.input_tensor_meta(i));
+        const auto rank = inputMeta.sizes().size();
+        const auto shapeTensor = out.toTensor();
+
+        if (shapeTensor.dim() != 2 ||
+            shapeTensor.size(1) != static_cast<ssize_t>(rank) ||
+            shapeTensor.scalar_type() != ScalarType::Int) {
+            throw std::runtime_error(std::format("{}output[{}] expected to be a 2D int32_t tensor of shape [num_shapes, {}]",
+                                                 ctx, tensorIndex, rank));
+        }
+
+        const auto numShapes = static_cast<size_t>(shapeTensor.size(0));
+        const auto *shapeData = shapeTensor.const_data_ptr<int32_t>();
+        std::vector<tensor::SymbolicShape> alternatives;
+        alternatives.reserve(numShapes);
+
+        for (size_t s = 0; s < numShapes; ++s) {
+            tensor::SymbolicShape singleShape;
+            singleShape.reserve(rank);
+            for (size_t axis = 0; axis < rank; ++axis) {
+                const auto dimVal = shapeData[s * rank + axis];
+                if (dimVal < 0) {
+                    throw std::runtime_error(std::format("{}output[{}], shape {}, axis {} is invalid: "
+                                                         "dimension cannot be negative ({})",
+                                                         ctx, tensorIndex, s, axis, dimVal));
+                }
+                singleShape.emplace_back(dimVal);
+            }
+            alternatives.push_back(std::move(singleShape));
+        }
+
+        enumeratedShapes.emplace_back(std::move(alternatives));
+        ++tensorIndex;
+    }
+
+    return enumeratedShapes;
+}
+
+} // namespace rnexecutorch::core::model

--- a/packages/react-native-executorch/cpp/core/model_companion_parser.h
+++ b/packages/react-native-executorch/cpp/core/model_companion_parser.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "tensor_helpers.h"
+
+#include <executorch/extension/module/module.h>
+
+namespace rnexecutorch::core::model {
+
+/**
+ * Parses compile-time dynamic dimension constraints for the inputs of a module
+ * method.
+ *
+ * @note This is a temporary workaround. ExecuTorch (.pte) model metadata
+ * natively serializes only the static upper-bound limits of dynamic/symbolic
+ * dimensions, and does not expose the active dynamic range (min, max, step) at
+ * runtime.
+ *
+ * To use this feature, the .pte model must be exported with a companion method
+ * named "get_dynamic_dims_<methodName>" (e.g., "get_dynamic_dims_forward").
+ *
+ * Python export requirements:
+ * 1. The companion method must take no arguments.
+ * 2. It must return a list of outputs matching the number of Tag::Tensor inputs
+ *    of the target method (scalar inputs are excluded).
+ * 3. Each output must be a 2D int32 tensor of shape [rank, 3], where each row
+ *    represents [min, max, step] constraints for the corresponding dimension of
+ *    that input tensor.
+ *
+ * @param module The ExecuTorch extension module to query.
+ * @param methodName The name of the target module method (e.g. "forward").
+ * @return A vector of SymbolicShape objects, or std::nullopt if the companion
+ *         method is not defined. If returned, the vector's size is guaranteed
+ *         to equal methodMeta.num_inputs(), containing parsed SymbolicShapes
+ *         for tensor inputs and empty SymbolicShapes for non-tensor inputs.
+ */
+std::optional<std::vector<tensor::ShapeConstraint>>
+parseDynamicInputShapes(executorch::extension::Module &module, const std::string &methodName);
+
+/**
+ * Parses enumerated dimension constraints for the inputs of a module method.
+ *
+ * @note Like parseDynamicInputShapes, this is a companion-method workaround.
+ *       The .pte model must be exported with a companion method named
+ *       "get_enumerated_dims_<methodName>" (e.g., "get_enumerated_dims_forward").
+ *
+ * Python export requirements:
+ * 1. The companion method must take no arguments.
+ * 2. It must return a list of outputs matching the number of Tag::Tensor inputs
+ *    of the target method (scalar inputs are excluded).
+ * 3. Each output must be a 2D int32 tensor of shape [num_shapes, rank], where
+ *    each row represents an allowed shape for the corresponding input tensor.
+ *
+ * @param module The ExecuTorch extension module to query.
+ * @param methodName The name of the target module method (e.g. "forward").
+ * @return A vector of ShapeConstraint objects, or std::nullopt if the companion
+ *         method is not defined. If returned, the vector's size is guaranteed
+ *         to equal methodMeta.num_inputs(), containing a vector of alternative
+ *         SymbolicShapes for tensor inputs and empty ShapeConstraints for
+ *         non-tensor inputs.
+ */
+std::optional<std::vector<tensor::ShapeConstraint>>
+parseEnumeratedInputShapes(executorch::extension::Module &module, const std::string &methodName);
+
+} // namespace rnexecutorch::core::model

--- a/packages/react-native-executorch/cpp/core/tensor_helpers.cpp
+++ b/packages/react-native-executorch/cpp/core/tensor_helpers.cpp
@@ -64,6 +64,45 @@ std::string shapeToString(const SymbolicShape &shape) {
     }
     return "[" + s + "]";
 }
+
+std::optional<std::string> validateShape(const std::vector<int32_t> &shape, const SymbolicShape &expectedShape) {
+    if (shape.size() != expectedShape.size()) {
+        return std::format("expected {} dimensions, got {}", expectedShape.size(), shape.size());
+    }
+
+    std::unordered_map<std::string, int32_t> symbolToConcrete;
+
+    for (size_t i = 0; i < expectedShape.size(); ++i) {
+        const auto &dim = expectedShape.at(i);
+
+        if (std::holds_alternative<int32_t>(dim)) {
+            const auto expected = std::get<int32_t>(dim);
+            if (shape[i] != expected) {
+                return std::format("dim {} mismatch: expected {}, got {}", i, expected, shape[i]);
+            }
+        } else if (std::holds_alternative<std::string>(dim)) {
+            const auto &symbol = std::get<std::string>(dim);
+            if (symbolToConcrete.contains(symbol) && shape[i] != symbolToConcrete[symbol]) {
+                return std::format("dim {} mismatch: expected {} (symbol {}), got {}",
+                                   i, symbolToConcrete[symbol], symbol, shape[i]);
+            }
+            symbolToConcrete[symbol] = shape[i];
+        } else {
+            const auto &rangeDim = std::get<RangeDim>(dim);
+            if (shape[i] < rangeDim.min) {
+                return std::format("dim {} out of range: {} < min {}", i, shape[i], rangeDim.min);
+            }
+            if (shape[i] > rangeDim.max) {
+                return std::format("dim {} out of range: {} > max {}", i, shape[i], rangeDim.max);
+            }
+            if (rangeDim.step && (shape[i] - rangeDim.min) % *rangeDim.step != 0) {
+                return std::format("dim {} must be min({}) + k*step({}), got {}",
+                                   i, rangeDim.min, *rangeDim.step, shape[i]);
+            }
+        }
+    }
+    return std::nullopt;
+}
 } // namespace
 
 std::shared_ptr<TensorHostObject>
@@ -87,44 +126,56 @@ fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
         return tensor;
     }
 
-    if (shape.size() != expectedShape->size()) {
-        throw jsi::JSError(rt, std::format("{} must have shape {} (expected {} dimensions, got {})",
-                                           name, shapeToString(*expectedShape), expectedShape->size(), shape.size()));
+    auto err = validateShape(shape, *expectedShape);
+    if (err) {
+        throw jsi::JSError(rt, std::format("{} must have shape {} ({})",
+                                           name, shapeToString(*expectedShape), *err));
     }
 
-    std::unordered_map<std::string, int32_t> symbolToConcrete;
+    return tensor;
+}
 
-    for (size_t i = 0; i < expectedShape->size(); ++i) {
-        const auto &dim = expectedShape->at(i);
+std::shared_ptr<TensorHostObject>
+fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
+       std::optional<DType> expectedDtype, const std::vector<SymbolicShape> &expectedShapes) {
 
-        if (std::holds_alternative<int32_t>(dim)) {
-            const auto expected = std::get<int32_t>(dim);
-            if (shape[i] != expected) {
-                throw jsi::JSError(rt, std::format("{} must have shape {} (dim {} mismatch: expected {}, got {})",
-                                                   name, shapeToString(*expectedShape), i, expected, shape[i]));
-            }
-        } else if (std::holds_alternative<std::string>(dim)) {
-            const auto &symbol = std::get<std::string>(dim);
-            if (symbolToConcrete.contains(symbol) && shape[i] != symbolToConcrete[symbol]) {
-                throw jsi::JSError(rt, std::format("{} must have shape {} (dim {} mismatch: expected {}, got {})",
-                                                   name, shapeToString(*expectedShape), i, symbolToConcrete[symbol], shape[i]));
-            }
-            symbolToConcrete[symbol] = shape[i];
-        } else {
-            const auto &rangeDim = std::get<RangeDim>(dim);
-            if (shape[i] < rangeDim.min) {
-                throw jsi::JSError(rt, std::format("{} must have shape {} (dim {} out of range: {} < min {})",
-                                                   name, shapeToString(*expectedShape), i, shape[i], rangeDim.min));
-            }
-            if (shape[i] > rangeDim.max) {
-                throw jsi::JSError(rt, std::format("{} must have shape {} (dim {} out of range: {} > max {})",
-                                                   name, shapeToString(*expectedShape), i, shape[i], rangeDim.max));
-            }
-            if (rangeDim.step && (shape[i] - rangeDim.min) % *rangeDim.step != 0) {
-                throw jsi::JSError(rt, std::format("{} must have shape {} (dim {} must be min({}) + k*step({}), got {})",
-                                                   name, shapeToString(*expectedShape), i, rangeDim.min, *rangeDim.step, shape[i]));
-            }
+    auto obj = conversions::asType<jsi::Object>(rt, name, value);
+    if (!obj.isHostObject<TensorHostObject>(rt)) {
+        throw jsi::JSError(rt, name + " must be a Tensor");
+    }
+
+    auto tensor = obj.getHostObject<TensorHostObject>(rt);
+    const auto &dtype = tensor->dtype_;
+    const auto &shape = tensor->shape_;
+
+    if (expectedDtype && dtype != *expectedDtype) {
+        throw jsi::JSError(rt, std::format("{} must be of type {}", name, types::toString(*expectedDtype)));
+    }
+
+    if (expectedShapes.empty()) {
+        return tensor;
+    }
+
+    std::vector<std::string> errors;
+    bool matched = false;
+    for (const auto &allowedShape : expectedShapes) {
+        auto err = validateShape(shape, allowedShape);
+        if (!err) {
+            matched = true;
+            break;
         }
+        errors.push_back(std::format("{} ({})", shapeToString(allowedShape), *err));
+    }
+
+    if (!matched) {
+        std::string errMsg = std::format("{} must match one of the allowed shapes:\n", name);
+        for (const auto &err : errors) {
+            errMsg += std::format("- {}\n", err);
+        }
+        if (!errMsg.empty()) {
+            errMsg.pop_back();
+        }
+        throw jsi::JSError(rt, errMsg);
     }
 
     return tensor;

--- a/packages/react-native-executorch/cpp/core/tensor_helpers.h
+++ b/packages/react-native-executorch/cpp/core/tensor_helpers.h
@@ -29,7 +29,9 @@ struct RangeDim {
     std::optional<int32_t> step;
 };
 
-using SymbolicShape = std::vector<std::variant<int32_t, std::string, RangeDim>>;
+using SymbolicDim = std::variant<int32_t, std::string, RangeDim>;
+using SymbolicShape = std::vector<SymbolicDim>;
+using ShapeConstraint = std::variant<SymbolicShape, std::vector<SymbolicShape>>;
 
 /**
  * Tries to acquire a shared (read) lock on the underlying tensor resource.
@@ -91,6 +93,17 @@ fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
 /**
  * @overload
  *
+ * Extracts, type-checks, and shape-validates a TensorHostObject from a JSI
+ * Value parameter against a list of alternative shapes. The tensor shape must
+ * match at least one of the shapes in the list.
+ */
+std::shared_ptr<TensorHostObject>
+fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
+       std::optional<DType> expectedDtype, const std::vector<SymbolicShape> &expectedShapes);
+
+/**
+ * @overload
+ *
  * Convenience wrapper that accepts any concrete C++ range as the expected shape
  * (e.g. std::vector<int32_t>).
  *
@@ -116,7 +129,23 @@ fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
 inline std::shared_ptr<TensorHostObject>
 fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
        std::optional<DType> expectedDtype,
-       std::initializer_list<std::variant<int32_t, std::string, RangeDim>> expectedShape) {
+       std::initializer_list<SymbolicDim> expectedShape) {
     return fromJs(rt, name, value, expectedDtype, std::optional<SymbolicShape>(expectedShape));
+}
+
+/**
+ * @overload
+ *
+ * Convenience wrapper that accepts a variant ShapeConstraint (either a single
+ * shape or a list of alternative shapes) and routes it to the correct overload.
+ */
+inline std::shared_ptr<TensorHostObject>
+fromJs(jsi::Runtime &rt, const std::string &name, const jsi::Value &value,
+       std::optional<DType> expectedDtype, const ShapeConstraint &shapeConstraint) {
+    if (std::holds_alternative<SymbolicShape>(shapeConstraint)) {
+        std::optional<SymbolicShape> shape = std::get<SymbolicShape>(shapeConstraint);
+        return fromJs(rt, name, value, expectedDtype, shape);
+    }
+    return fromJs(rt, name, value, expectedDtype, std::get<std::vector<SymbolicShape>>(shapeConstraint));
 }
 } // namespace rnexecutorch::core::tensor

--- a/packages/react-native-executorch/src/core/modelSchema.ts
+++ b/packages/react-native-executorch/src/core/modelSchema.ts
@@ -1,5 +1,5 @@
-import { type DType } from './tensor';
-import { type Model, type ExecuTorchTag, type ModelMethodMeta, type TensorMeta } from './model';
+import type { DType } from './tensor';
+import type { Model, ExecuTorchTag, ModelMethodMeta, TensorMeta } from './model';
 
 /**
  * A named symbolic dimension that acts as a wildcard during shape matching.

--- a/packages/react-native-executorch/src/core/modelSchema.ts
+++ b/packages/react-native-executorch/src/core/modelSchema.ts
@@ -2,142 +2,192 @@ import { type DType } from './tensor';
 import { type Model, type ExecuTorchTag, type ModelMethodMeta, type TensorMeta } from './model';
 
 /**
- * A single dimension in a symbolic tensor shape.
- *
- * - A **number** matches only that exact dimension size (e.g. `1`, `3`).
- * - A **string** is a symbolic variable that can match any integer and is
- *   resolved consistently within the same tensor shape (e.g. `'N'`, `'H'`,
- *   `'W'`).
+ * A named symbolic dimension that acts as a wildcard during shape matching.
  * @category Types
  */
-export type SymbolicShape = readonly (number | string)[];
+export type StaticDim = { readonly kind: 'static'; readonly symbol: string };
+
+/**
+ * A dynamic dimension that additionally requires a companion method to be exported.
+ * @category Types
+ */
+export type DynamicDim = { readonly kind: 'dynamic'; readonly symbol: string };
+
+/**
+ * A fixed concrete dimension value.
+ * @category Types
+ */
+export type ConstantDim = { readonly kind: 'constant'; readonly value: number };
+
+/**
+ * A symbolic shape as a list of typed dimension constraints.
+ * @category Types
+ */
+export type TypedShape = readonly (StaticDim | DynamicDim | ConstantDim)[];
+
+/**
+ * Creates a {@link StaticDim} — a named symbolic dimension that matches any
+ * concrete value and resolves consistently within a shape.
+ * @category Typescript API
+ * @param symbol The symbolic name (e.g. `'H'`, `'W'`, `'N'`).
+ * @returns A {@link StaticDim}.
+ */
+export const Static = (symbol: string): StaticDim => ({ kind: 'static', symbol });
+
+/**
+ * Creates a {@link DynamicDim} — like {@link Static} but additionally asserts
+ * that the model exports a companion method (`get_dynamic_dims_<method>` or
+ * `get_enumerated_dims_<method>`).
+ * @category Typescript API
+ * @param symbol The symbolic name for this dynamic dimension.
+ * @returns A {@link DynamicDim}.
+ */
+export const Dynamic = (symbol: string): DynamicDim => ({ kind: 'dynamic', symbol });
+
+/**
+ * Creates a {@link ConstantDim} — a fixed dimension that must match exactly.
+ * @category Typescript API
+ * @param value The exact dimension size.
+ * @returns A {@link ConstantDim}.
+ */
+export const Constant = (value: number): ConstantDim => ({ kind: 'constant', value });
+
+/**
+ * A dimension in any accepted format — plain numbers, strings, or typed
+ * dimension objects. Used by {@link SymbolicTensor} and {@link matchShape}.
+ * @category Types
+ */
+export type SymbolicDim = number | string | StaticDim | DynamicDim | ConstantDim;
+
+/**
+ * A shape that can mix plain numbers, strings, and typed dimension objects.
+ * @category Types
+ */
+export type SymbolicShape = readonly SymbolicDim[];
+
+const toTypedShape = (shape: SymbolicShape): TypedShape =>
+  shape.map((dim) => {
+    if (typeof dim === 'number') return Constant(dim);
+    if (typeof dim === 'string') return Static(dim);
+    return dim;
+  });
 
 /**
  * A constraint on the dtype and/or shape of a tensor input or output slot.
- *
- * Both fields are optional; omitting `dtype` skips dtype checking, and omitting
- * `shapes` (or providing an empty array) skips shape checking.
  * @category Types
  */
 export type TensorConstraint = {
-  /** If set, the tensor's dtype must match exactly. */
+  readonly kind: 'tensor';
   readonly dtype?: DType;
-  /**
-   * One or more acceptable symbolic shapes. The tensor passes validation if
-   * its concrete shape matches **at least one** of the listed shapes.
-   */
-  readonly shapes?: readonly SymbolicShape[];
+  readonly shapes?: readonly TypedShape[];
 };
+
+/**
+ * A constraint describing an expected input or output slot of a model method.
+ * @category Types
+ */
+export type ValueConstraint =
+  | { readonly kind: 'null'; tags: ['None'] }
+  | { readonly kind: 'number'; tags: ['Int', 'Double'] }
+  | { readonly kind: 'boolean'; tags: ['Bool'] }
+  | TensorConstraint;
 
 /**
  * Convenience constructor for a {@link TensorConstraint}.
  *
  * ```ts
- * // Accepts a float32 tensor with shape [1, 3, H, W] or [3, H, W]
  * SymbolicTensor('float32', [1, 3, 'H', 'W'], [3, 'H', 'W'])
- *
- * // Accepts any tensor of shape [1, N]
  * SymbolicTensor(undefined, [1, 'N'])
+ * SymbolicTensor('int64', [1, Dynamic('L')])
  * ```
  * @category Typescript API
- * @param dtype Optional dtype requirement. Pass `undefined` to skip dtype
- * checking.
- * @param shapes Zero or more acceptable symbolic shapes. An empty list skips
- * shape checking.
+ * @param dtype Optional dtype requirement. Pass `undefined` to skip dtype checking.
+ * @param shapes One or more acceptable symbolic shapes (plain or typed).
  * @returns A {@link TensorConstraint} object.
  */
-export function SymbolicTensor(
+export const SymbolicTensor = (
   dtype?: DType,
   ...shapes: readonly SymbolicShape[]
-): TensorConstraint {
-  return { dtype, shapes };
-}
-
-const primitiveTagMap = {
-  number: ['Int', 'Double'] as ExecuTorchTag[],
-  boolean: ['Bool'] as ExecuTorchTag[],
-  null: ['None'] as ExecuTorchTag[],
-} as const;
-
-/**
- * A constraint describing an expected input or output slot of a model method.
- *
- * - `'number'` — the slot must carry an integer or double primitive value.
- * - `'boolean'` — the slot must carry a boolean primitive value.
- * - `'null'` — the slot must carry a `None` value.
- * - {@link TensorConstraint} — the slot must carry a tensor, optionally with a
- *   constrained dtype and/or shape.
- * @category Types
- */
-export type ValueConstraint = keyof typeof primitiveTagMap | TensorConstraint;
+): TensorConstraint => ({ kind: 'tensor', dtype, shapes: shapes.map(toTypedShape) });
 
 /**
  * Checks whether a concrete tensor shape matches at least one of the provided
  * symbolic shapes.
- *
- * Symbolic dimensions (strings) act as named wildcards: within a single shape
- * candidate they must resolve to the same integer value every time they appear,
- * but they are not enforced consistently across different tensor slots.
  * @category Typescript API
  * @param actual The concrete shape array to test (e.g. `[1, 3, 224, 224]`).
  * @param expected One or more symbolic shapes to match against.
  * @returns `true` if `actual` matches at least one of the `expected` shapes.
  */
 export function matchShape(actual: number[], ...expected: readonly SymbolicShape[]): boolean {
-  return expected.some((shape) => {
-    if (actual.length !== shape.length) return false;
+  for (const expShape of expected) {
+    if (actual.length !== expShape.length) continue;
+
     const symbolMap = new Map<string, number>();
-    return shape.every((dim, i) => {
-      const act = actual[i]!;
-      if (typeof dim === 'number') return act === dim;
-      if (symbolMap.has(dim)) return symbolMap.get(dim) === act;
-      symbolMap.set(dim, act);
-      return true;
+    const isMatch = toTypedShape(expShape).every((expDim, i) => {
+      const actDim = actual[i]!;
+      switch (expDim.kind) {
+        case 'constant':
+          return actDim === expDim.value;
+        case 'static':
+        case 'dynamic': {
+          if (symbolMap.has(expDim.symbol)) {
+            return symbolMap.get(expDim.symbol) === actDim;
+          }
+          symbolMap.set(expDim.symbol, actDim);
+          return true;
+        }
+      }
     });
-  });
+
+    if (isMatch) return true;
+  }
+  return false;
 }
 
-// TODO: Implement cross-tensor symbol validation (e.g. enforcing that 'N' or
-// 'H' has the same value across different input/output tensors). Note that a
-// proper implementation will require backtracking/solving when multiple tensors
-// have multiple alternative shapes. For now, we just check that each tensor
-// individually matches at least one of its expected shapes, without enforcing
-// consistency of symbolic dimensions across tensors, only within each tensor.
 function validateTags(
   side: 'input' | 'output',
   expected: readonly ValueConstraint[],
   actualTags: ExecuTorchTag[],
   tensorMetas: TensorMeta[]
 ) {
-  const numTensors = expected.filter((t) => typeof t === 'object').length;
+  const numTensors = expected.filter((e) => e.kind === 'tensor').length;
   if (tensorMetas.length !== numTensors)
     throw new Error(
       `${side} tensor count mismatch: expected ${numTensors}, got ${tensorMetas.length}`
     );
 
   let tIdx = 0;
-  expected.forEach((exp, i) => {
-    const act = actualTags[i]!;
-    if (typeof exp === 'string') {
-      if (!primitiveTagMap[exp].includes(act)) {
-        throw new Error(`${side}[${i}]: expected primitive '${exp}', got '${act}'`);
-      }
-    } else {
-      if (act !== 'Tensor') {
-        throw new Error(`${side}[${i}]: expected Tensor, got primitive '${act}'`);
-      }
-      const tMeta = tensorMetas[tIdx++]!;
-      if (exp.dtype && tMeta.dtype !== exp.dtype) {
-        throw new Error(
-          `${side}[${i}]: dtype mismatch: expected '${exp.dtype}', got '${tMeta.dtype}'`
-        );
-      }
-      if (exp.shapes?.length && !matchShape(tMeta.shape, ...exp.shapes)) {
-        const expectedShapesStr = exp.shapes.map((s) => `[${s.join(',')}]`).join('|');
-        throw new Error(
-          `${side}[${i}]: shape mismatch: expected shape matching ${expectedShapesStr}, got [${tMeta.shape.join(',')}]`
-        );
-      }
+  expected.forEach((expectedTag, i) => {
+    const actualTag = actualTags[i]!;
+    switch (expectedTag.kind) {
+      case 'null':
+      case 'number':
+      case 'boolean':
+        if (!(expectedTag.tags as ExecuTorchTag[]).includes(actualTag)) {
+          throw new Error(
+            `${side}[${i}]: expected primitive '${expectedTag.kind}', got '${actualTag}'`
+          );
+        }
+        break;
+      case 'tensor':
+        if (actualTag !== 'Tensor') {
+          throw new Error(`${side}[${i}]: expected Tensor, got primitive '${actualTag}'`);
+        }
+
+        const tMeta = tensorMetas[tIdx++]!;
+        if (expectedTag.dtype && tMeta.dtype !== expectedTag.dtype) {
+          throw new Error(
+            `${side}[${i}]: dtype mismatch: expected '${expectedTag.dtype}', got '${tMeta.dtype}'`
+          );
+        }
+
+        if (expectedTag.shapes?.length && !matchShape(tMeta.shape, ...expectedTag.shapes)) {
+          const expectedShapesStr = expectedTag.shapes.map((s) => `[${s.join(',')}]`).join('|');
+          throw new Error(
+            `${side}[${i}]: shape mismatch: expected shape matching ${expectedShapesStr}, got [${tMeta.shape.join(',')}]`
+          );
+        }
+        break;
     }
   });
 }
@@ -152,22 +202,27 @@ function validateTags(
  * - That the value-tag of each slot (tensor, int, bool, etc.) is compatible
  *   with its declared {@link ValueConstraint}.
  * - For tensor slots: that the dtype and shape (if specified) satisfy the
- *
  *   {@link TensorConstraint}.
+ * - That when any tensor input uses {@link Dynamic}, the target method has a
+ *   companion method on the model.
+ *
+ * Companion methods (one per target method, named by replacing `<method>` with
+ * the actual method name):
+ * - `get_dynamic_dims_<method>` — returns per-input `[rank, 3]` int32 tensors
+ *   of `[min, max, step]` bounds.
+ * - `get_enumerated_dims_<method>` — returns per-input `[num_shapes, rank]`
+ *   int32 tensors of enumerated allowed shapes.
  *
  * On success it returns the method's {@link ModelMethodMeta}, which can be used
  * to read concrete input/output tensor shapes for pre-allocating scratch
  * tensors.
  * @remarks
- * A symbolic (string) input dimension here only relaxes *validation*. For a
- * dimension that must genuinely vary at runtime (e.g. sequence length), the
- * `.pte` must additionally be exported with a companion method
- * `get_dynamic_dims_<methodName>` (e.g. `get_dynamic_dims_forward`) that
- * returns, per tensor input, an `int32` `[rank, 3]` tensor of `[min, max, step]`
- * bounds — ExecuTorch metadata only serializes the static upper bound, so the
- * runtime reads the active range from this companion. Without it, the method
- * only accepts the exact shape it was exported with. The reported upper bound is
- * still read from `meta.inputTensorMeta`.
+ * A {@link Static} input dimension only relaxes *validation*. For a dimension
+ * that must genuinely vary at runtime (e.g. sequence length), use
+ * {@link Dynamic} to assert that the `.pte` was exported with a companion
+ * method. Without it, the method only accepts the serialized upper bound.
+ * The returned {@link ModelMethodMeta} only contains static upper bounds for
+ * dynamic dimensions — the actual runtime range is validated by the C++ layer.
  * @category Typescript API
  * @param model The compiled model to validate.
  * @param methodName The exported method name to validate (e.g. `'forward'`).
@@ -184,7 +239,8 @@ export function validateModelSchema(
   expectedInputs: readonly ValueConstraint[],
   expectedOutputs: readonly ValueConstraint[]
 ): ModelMethodMeta {
-  if (!model.getMethodNames().includes(methodName))
+  const methodNames = model.getMethodNames();
+  if (!methodNames.includes(methodName))
     throw new Error(`signature validation: '${methodName}' method not found`);
 
   const meta = model.getMethodMeta(methodName);
@@ -193,9 +249,32 @@ export function validateModelSchema(
     return (
       `signature validation failed for '${methodName}': ${errorMsg}\n` +
       `  Expected: ${JSON.stringify(expectedInputs)} -> ${JSON.stringify(expectedOutputs)}\n` +
-      `  Actual:   [${meta.inputTags.join(', ')}] -> [${meta.outputTags.join(', ')}] (metas: ${JSON.stringify(meta.inputTensorMeta)} -> ${JSON.stringify(meta.outputTensorMeta)})`
+      `  Actual:   [${meta.inputTags.join(', ')}] -> [${meta.outputTags.join(', ')}]` +
+      `  (metas: ${JSON.stringify(meta.inputTensorMeta)} -> ${JSON.stringify(meta.outputTensorMeta)})`
     );
   };
+
+  const companionMethodNames = [
+    `get_dynamic_dims_${methodName}`,
+    `get_enumerated_dims_${methodName}`,
+  ];
+
+  expectedInputs
+    .filter((e) => e.kind === 'tensor')
+    .forEach((tensor, _) => {
+      const hasCompanion = companionMethodNames.some((m) => methodNames.includes(m));
+      const hasDynamic = tensor.shapes?.some((shape) =>
+        shape.some((dim) => dim.kind === 'dynamic')
+      );
+      if (hasDynamic && !hasCompanion) {
+        throw new Error(
+          formatError(
+            `'${methodName}' has Dynamic dimension(s) but no companion method` +
+              ` ${companionMethodNames.map((m) => `'${m}'`).join(' or ')}`
+          )
+        );
+      }
+    });
 
   if (meta.inputTags.length !== expectedInputs.length) {
     throw new Error(
@@ -204,6 +283,7 @@ export function validateModelSchema(
       )
     );
   }
+
   if (meta.outputTags.length !== expectedOutputs.length) {
     throw new Error(
       formatError(

--- a/packages/react-native-executorch/src/core/modelSchema.ts
+++ b/packages/react-native-executorch/src/core/modelSchema.ts
@@ -36,8 +36,8 @@ export const Static = (symbol: string): StaticDim => ({ kind: 'static', symbol }
 
 /**
  * Creates a {@link DynamicDim} — like {@link Static} but additionally asserts
- * that the model exports a companion method (`get_dynamic_dims_<method>` or
- * `get_enumerated_dims_<method>`).
+ * that the model exports a companion method declaring the runtime-enforced
+ * range of this dimension. See {@link validateModelSchema}.
  * @category Typescript API
  * @param symbol The symbolic name for this dynamic dimension.
  * @returns A {@link DynamicDim}.
@@ -204,7 +204,7 @@ function validateTags(
  * - For tensor slots: that the dtype and shape (if specified) satisfy the
  *   {@link TensorConstraint}.
  * - That when any tensor input uses {@link Dynamic}, the target method has a
- *   companion method on the model.
+ *   companion method on the model (see below).
  *
  * Companion methods (one per target method, named by replacing `<method>` with
  * the actual method name):

--- a/packages/react-native-executorch/src/extensions/nlp/tasks/textEmbedding.ts
+++ b/packages/react-native-executorch/src/extensions/nlp/tasks/textEmbedding.ts
@@ -2,7 +2,7 @@ import type { WorkletRuntime } from 'react-native-worklets';
 
 import { tensor } from '../../../core/tensor';
 import { loadModel } from '../../../core/model';
-import { validateModelSchema, SymbolicTensor } from '../../../core/modelSchema';
+import { validateModelSchema, SymbolicTensor, Dynamic } from '../../../core/modelSchema';
 import { wrapAsync } from '../../../core/runtime';
 
 import { loadTokenizer } from '../tokenizer';
@@ -70,7 +70,7 @@ export async function createTextEmbedder(
   const meta = validateModelSchema(
     model,
     'forward',
-    [SymbolicTensor('int64', [1, 'L']), SymbolicTensor('int64', [1, 'L'])],
+    [SymbolicTensor('int64', [1, Dynamic('L')]), SymbolicTensor('int64', [1, Dynamic('L')])],
     [SymbolicTensor('float32', [1, 'D'], ['D'])]
   );
   // The models are exported with a dynamic sequence dimension; the declared size

--- a/packages/react-native-executorch/src/extensions/speech/tasks/fsmnVoiceActivityDetection.ts
+++ b/packages/react-native-executorch/src/extensions/speech/tasks/fsmnVoiceActivityDetection.ts
@@ -2,7 +2,7 @@ import type { WorkletRuntime } from 'react-native-worklets';
 
 import { tensor } from '../../../core/tensor';
 import { loadModel } from '../../../core/model';
-import { validateModelSchema, SymbolicTensor } from '../../../core/modelSchema';
+import { validateModelSchema, SymbolicTensor, Dynamic } from '../../../core/modelSchema';
 import { wrapAsync } from '../../../core/runtime';
 import { extractFrames } from '../utils/vadUtils';
 
@@ -225,8 +225,8 @@ export async function createFsmnVoiceActivityDetector(
   const meta = validateModelSchema(
     model,
     'forward',
-    [SymbolicTensor('float32', ['frames', 'fftLength'])],
-    [SymbolicTensor('float32', [1, 'frames', 'classes'])]
+    [SymbolicTensor('float32', [Dynamic('frames'), 'fftLength'])],
+    [SymbolicTensor('float32', [1, Dynamic('frames'), 'classes'])]
   );
   const maxFrames = meta.inputTensorMeta[0]!.shape[0]!;
   const fftLength = meta.inputTensorMeta[0]!.shape[1]!;

--- a/packages/react-native-executorch/src/index.ts
+++ b/packages/react-native-executorch/src/index.ts
@@ -31,23 +31,10 @@ export * from './extensions/nlp/tasks/textEmbedding';
 export * from './extensions/speech/tasks/fsmnVoiceActivityDetection';
 
 // Core primitives — for library builders and power users
-export { tensor } from './core/tensor';
-export type { DType, Tensor } from './core/tensor';
-
-export { loadModel } from './core/model';
-export type {
-  Model,
-  ModelInput,
-  ModelOutput,
-  TensorMeta,
-  ModelMethodMeta,
-  ExecuTorchTag,
-} from './core/model';
-
-export { validateModelSchema, SymbolicTensor, matchShape } from './core/modelSchema';
-export type { ValueConstraint, TensorConstraint, SymbolicShape } from './core/modelSchema';
-
-export { defaultWorkletRuntime, wrapAsync } from './core/runtime';
+export * from './core/tensor';
+export * from './core/model';
+export * from './core/modelSchema';
+export * from './core/runtime';
 
 export * as math from './extensions/math';
 export * as cv from './extensions/cv';


### PR DESCRIPTION
## Description

### Summary Proof of Concept

Introduces a typed dimension model (`Static` / `Dynamic` / `Constant`) on the JS side and a companion-method parser on the C++ side so models can declare **runtime-enforced** dynamic shape constraints (min/max/step ranges *or* enumerated shape lists) that ExecuTorch's `.pte` metadata does not otherwise expose.

### Changes
- **`modelSchema.ts`** — Replaces loose `number | string` shape dims with a tagged union (`StaticDim | DynamicDim | ConstantDim`) and `Static()` / `Dynamic()` / `Constant()` constructors. `SymbolicTensor` normalizes plain numbers/strings to the typed form internally, so existing call sites keep working. `Dynamic('L')` additionally asserts the `.pte` exports a matching companion method.
- **`model_companion_parser.{h,cpp}`** — Extracts `parseDynamicInputShapes` (formerly inlined in `model.cpp`) and adds `parseEnumeratedInputShapes` for the `get_enumerated_dims_<method>` variant. Same tensor-shape contract (`[rank, 3]` int32 for ranges; `[num_shapes, rank]` int32 for enums) — kept identical to avoid a breaking change to the Python export convention.
- **`tensor_helpers.h`** — Introduces `ShapeConstraint = variant<SymbolicShape, vector<SymbolicShape>>` and a routing `fromJs` overload so a single constraints map can hold either range or enum shapes without leaking the distinction into `Model`.
- **`model.{h,cpp}`** — Renames `dynamicInputShapes_` → `inputShapeConstraints_`; rejects methods that define both companion flavors as mutually exclusive.
- **Extensions** — `textEmbedding` and `fsmnVoiceActivityDetection` adopt `Dynamic(...)` to declare the symbolic dims that already required companion methods in practice.

### Design rationale
- **Tagged union over plain primitives** on the JS side makes the *intent* of a dimension (named wildcard vs. companion-method-backed dynamic vs. literal) plain at the call site, while `toTypedShape` keeps the public API source-compatible.
- **Companion-method approach (vs. parsing `.pte` metadata)** is the only way to recover min/max/step ranges today — ExecuTorch serializes only the static upper bound. Reusing it for enumerated shapes keeps a single extension mechanism.
- **`ShapeConstraint` variant + routing overload** centralizes range/enum dispatch in `tensor_helpers` rather than `model.cpp`, so `Model` stays agnostic of the constraint flavor and future constraint types stay pluggable.
- **Mutual-exclusion guard** prevents ambiguous exports (both `get_dynamic_dims_*` and `get_enumerated_dims_*`) at load time rather than at validation time.

### Load-time (JS) vs. runtime (C++)

This split is intentional because the `.pte` metadata only serializes the **static upper bounds** of dynamic dimensions — the actual `[min, max, step]` ranges and enumerated shape lists are only retrievable by executing the companion method, and the C++ layer has to run them anyway.

- **Load-time (`validateModelSchema`):** pure metadata check run once when a schema is bound to a model in `loadModel`. Verifies tag counts, dtype, static shape signature, and — new in this branch — asserts that any input shape using `Dynamic(...)` has a corresponding companion method present in `model.getMethodNames()`. Surfaces misconfigured schemas (`Dynamic` without a companion, or non-matching shapes) as a hard error **before** any forward call instead of silently degrading to static-upper-bound-only behavior.
- **Runtime (`Model` ctor + per-call `tensor::fromJs`):** the `Model` constructor executes each companion method **once**, caches the parsed `ShapeConstraint`s into `inputShapeConstraints_`, and rejects methods that declare both `get_dynamic_dims_*` and `get_enumerated_dims_*`. On every `forward`, `fromJs` resolves the per-input constraint and validates the **concrete** incoming tensor against the actual dynamic range or enumerated list — this is where the real numeric bounds get enforced, not in JS.

### Why validation isn't duplicated at load-time

The companion methods *could* be executed from JS at validate-time (the module is loaded by then, and the cost is negligible), but doing so duplicates work the runtime already does:

- **JS validation is declarative.** `validateModelSchema` is intentionally a pure function of `(modelMetadata, schema)`. `Dynamic(...)` is a *promise* the schema makes about the model export ("this dim is genuinely dynamic and a companion exists"), not a specification of numeric values the schema enforces. The schema layer only needs to confirm the promise is honored — which a `methodNames.includes(...)` check already does — and let the runtime enforce the actual numbers.
- **No duplicated work.** C++ `Model` must parse the companion output into `inputShapeConstraints_` regardless, since `fromJs` enforces per-input bounds on every forward. Executing and parsing the same companions again from JS would establish a second representation of the same constraint with no mechanism to keep them in sync across rebinds/reloads.
- **Clear runtime errors.** C++ runtime validation already produces actionable error messages (range violations, dtype mismatch, shape mismatch) before the forward hits ExecuTorch. There is no debugging-information gap that running the companions at validate-time would close.

### Known limitation: cross-tensor constraints

Per-tensor runtime validation is *not* complete — `fromJs` validates each input tensor against its own `ShapeConstraint` independently and cannot enforce consistency of a shared symbolic dim across multiple inputs. Concretely, passing `tokens` and `mask` of mismatched `L` to `textEmbedding` bypasses our validators and surfaces as an opaque ExecuTorch internal error deep in the forward.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->
- [ ] Build and run all example apps to check that there are no regressions.

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

#1323 

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
