### PR TITLE
fix(android): forward ExecuTorch consumer ProGuard rules

### DIFF
--- a/packages/react-native-executorch/android/build.gradle
+++ b/packages/react-native-executorch/android/build.gradle
@@ -115,6 +115,7 @@ android {
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
+    consumerProguardFiles "consumer-proguard-rules.pro"
     externalNativeBuild {
         cmake {
           abiFilters (*reactNativeArchitectures())

--- a/packages/react-native-executorch/android/consumer-proguard-rules.pro
+++ b/packages/react-native-executorch/android/consumer-proguard-rules.pro
@@ -1,0 +1,51 @@
+# Ported from ExecuTorch's official Android consumer rules:
+# https://github.com/pytorch/executorch/blob/904c667007aed15e9a3bb8278aa271b479450c85/extension/android/executorch_android/consumer-proguard-rules.pro
+
+# ExecuTorch Android AAR — Consumer ProGuard/R8 Rules
+#
+# These rules are automatically applied to any app that depends on the
+# ExecuTorch AAR. They prevent R8/ProGuard from stripping classes and
+# methods that are called from native (JNI) code.
+
+# Keep ExecuTorch classes and members annotated with @DoNotStrip.
+# Scoped to org.pytorch.executorch to avoid affecting unrelated libraries.
+-keep @com.facebook.jni.annotations.DoNotStrip class org.pytorch.executorch.** { *; }
+-keepclassmembers class org.pytorch.executorch.** {
+    @com.facebook.jni.annotations.DoNotStrip *;
+}
+
+# Keep all native methods across ExecuTorch packages.
+# Use -keepclasseswithmembers (not -keepclasseswithmembernames) to prevent
+# both shrinking and obfuscation of JNI entry points.
+-keepclasseswithmembers class org.pytorch.executorch.** {
+    native <methods>;
+}
+
+# Keep HybridData fields (accessed by fbjni via reflection).
+-keepclassmembers class org.pytorch.executorch.** {
+    com.facebook.jni.HybridData *;
+}
+
+# Keep ExecutorchRuntimeException and its factory/subclasses.
+# These are instantiated from JNI via jni_helper.cpp.
+-keep class org.pytorch.executorch.ExecutorchRuntimeException { *; }
+-keep class org.pytorch.executorch.ExecutorchRuntimeException$* { *; }
+
+# Keep EValue (fields and type codes accessed from native code).
+-keep class org.pytorch.executorch.EValue { *; }
+
+# Keep Tensor and its inner classes. The Tensor class has methods and fields
+# accessed from JNI (dtypeJniCode, shape, getRawDataBuffer, nativeNewTensor).
+-keep class org.pytorch.executorch.Tensor { *; }
+-keep class org.pytorch.executorch.Tensor$* { *; }
+
+# Keep LlmCallback interface methods (invoked from native code).
+-keep interface org.pytorch.executorch.extension.llm.LlmCallback { *; }
+
+# Keep AsrCallback interface methods (invoked from native code).
+-keep interface org.pytorch.executorch.extension.asr.AsrCallback { *; }
+
+# --- react-native-executorch rules (not from upstream) ---
+
+# RNE's own JNI entry point, resolved by literal descriptor from C++.
+-keep class com.swmansion.rnexecutorch.ETInstaller { *; }


### PR DESCRIPTION
## Description

Fixes an Android release crash caused by R8 removing ExecuTorch classes that are accessed during JNI initialization.

at minified release builds without the consumer rules, the app crashes during `ETInstaller` initialization:

```text
java.lang.ClassNotFoundException: org.pytorch.executorch.Module
at java.lang.System.loadLibrary(...)
at com.swmansion.rnexecutorch.ETInstaller.<init>(...)
```
This PR ports the upstream rules and registers them through `consumerProguardFiles`

The first two rules ared covered with RN's own consumer rules, but are intentionally retained to keep the upstream ExecuTorch rule block intact. The rule that fixes the observed `Module` crash is:

```proguard
-keepclasseswithmembers class org.pytorch.executorch.** {
    native <methods>;
}
```
### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

1. Enable R8/ProGuard for the release build.
2. Build the minified release APK
3. Verify that JNI-accessed classes retain their names in mapping.txt

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

Android-only; iOS does not use R8. tested on a android physical device(galaxy s20 FE)

The upstream ExecuTorch rules are copied without semantic changes.

