### PR TITLE
[RNE Rewrite] Integrate resource fetcher (react-native-blob-util)

### DIFF
--- a/.cspell-wordlist.txt
+++ b/.cspell-wordlist.txt
@@ -306,3 +306,5 @@ Roboflow
 Ultralytics
 
 
+subtag
+subtags

--- a/apps/computer-vision/package.json
+++ b/apps/computer-vision/package.json
@@ -37,6 +37,7 @@
     "expo-router": "~56.2.9",
     "react": "19.2.3",
     "react-native": "0.85.3",
+    "react-native-blob-util": "^0.24.0",
     "react-native-drawer-layout": "^4.2.2",
     "react-native-executorch": "workspace:*",
     "react-native-gesture-handler": "~2.31.1",

--- a/apps/nlp/package.json
+++ b/apps/nlp/package.json
@@ -27,6 +27,7 @@
     "expo-router": "~56.2.9",
     "react": "19.2.3",
     "react-native": "0.85.3",
+    "react-native-blob-util": "^0.24.0",
     "react-native-drawer-layout": "^4.2.2",
     "react-native-executorch": "workspace:*",
     "react-native-gesture-handler": "~2.31.1",

--- a/apps/speech/package.json
+++ b/apps/speech/package.json
@@ -27,6 +27,7 @@
     "react": "19.2.3",
     "react-native": "0.85.3",
     "react-native-audio-api": "0.13.1",
+    "react-native-blob-util": "^0.24.0",
     "react-native-device-info": "^15.0.2",
     "react-native-drawer-layout": "^4.2.2",
     "react-native-executorch": "workspace:*",

--- a/packages/react-native-executorch/cpp/core/install.cpp
+++ b/packages/react-native-executorch/cpp/core/install.cpp
@@ -6,6 +6,7 @@
 namespace rnexecutorch::core {
 void install(facebook::jsi::Runtime &rt, facebook::jsi::Object &module) {
     utils::install_getExecuTorchRegisteredBackends(rt, module);
+    utils::install_isEmulator(rt, module);
     model::install_loadModel(rt, module);
     tensor::install_createTensor(rt, module);
 }

--- a/packages/react-native-executorch/cpp/core/utils.cpp
+++ b/packages/react-native-executorch/cpp/core/utils.cpp
@@ -5,8 +5,53 @@
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/core/error.h>
 
+#if defined(__ANDROID__)
+#include <sys/system_properties.h>
+#elif defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
 namespace rnexecutorch::core::utils {
 namespace jsi = facebook::jsi;
+
+namespace {
+// Detects an Android emulator / iOS simulator. On Android the build
+// fingerprint and hardware name identify the AVD images (goldfish and ranchu
+// are the QEMU-based emulator kernels); on Apple platforms the simulator is
+// known at compile time.
+bool isEmulator() {
+#if defined(__ANDROID__)
+    auto readProp = [](const char *key) -> std::string {
+#if __ANDROID_API__ >= 26
+        const prop_info *pi = __system_property_find(key);
+        if (pi == nullptr) {
+            return "";
+        }
+        std::string result;
+        __system_property_read_callback(
+            pi,
+            [](void *cookie, const char * /*name*/, const char *value, uint32_t /*serial*/) {
+                *static_cast<std::string *>(cookie) = value;
+            },
+            &result);
+        return result;
+#else
+        char value[PROP_VALUE_MAX] = {0};
+        __system_property_get(key, value);
+        return {value};
+#endif
+    };
+
+    const std::string fingerprint = readProp("ro.build.fingerprint");
+    const std::string hardware = readProp("ro.hardware");
+    return fingerprint.rfind("generic", 0) == 0 || hardware == "goldfish" || hardware == "ranchu";
+#elif defined(__APPLE__) && TARGET_OS_SIMULATOR
+    return true;
+#else
+    return false;
+#endif
+}
+} // namespace
 
 void install_getExecuTorchRegisteredBackends(jsi::Runtime &rt, jsi::Object &module) {
     const auto *name = "getExecuTorchRegisteredBackends";
@@ -30,5 +75,9 @@ void install_getExecuTorchRegisteredBackends(jsi::Runtime &rt, jsi::Object &modu
     auto fn = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name), 0, fnBody);
 
     module.setProperty(rt, name, fn);
+}
+
+void install_isEmulator(jsi::Runtime &rt, jsi::Object &module) {
+    module.setProperty(rt, "isEmulator", jsi::Value(isEmulator()));
 }
 } // namespace rnexecutorch::core::utils

--- a/packages/react-native-executorch/cpp/core/utils.cpp
+++ b/packages/react-native-executorch/cpp/core/utils.cpp
@@ -15,10 +15,13 @@ namespace rnexecutorch::core::utils {
 namespace jsi = facebook::jsi;
 
 namespace {
-// Detects an Android emulator / iOS simulator. On Android the build
-// fingerprint and hardware name identify the AVD images (goldfish and ranchu
-// are the QEMU-based emulator kernels); on Apple platforms the simulator is
-// known at compile time.
+// Detects an Android emulator / iOS simulator. On Android no single property
+// covers every image, so we check three: the build fingerprint (`generic...`
+// for AOSP images), the hardware name (`goldfish`/`ranchu` are the QEMU
+// emulator kernels, `cutf`/`vsoc` prefixes are Cuttlefish virtual devices), and
+// the product model (Play-store and SDK images report `sdk_gphone`,
+// `google_sdk`, `Emulator` or `Cuttlefish`). On Apple platforms the simulator
+// is known at compile time.
 bool isEmulator() {
 #if defined(__ANDROID__)
     auto readProp = [](const char *key) -> std::string {
@@ -42,9 +45,27 @@ bool isEmulator() {
 #endif
     };
 
+    const auto startsWith = [](const std::string &value, const char *prefix) {
+        return value.rfind(prefix, 0) == 0;
+    };
+
     const std::string fingerprint = readProp("ro.build.fingerprint");
+    if (startsWith(fingerprint, "generic") || startsWith(fingerprint, "unknown")) {
+        return true;
+    }
+
     const std::string hardware = readProp("ro.hardware");
-    return fingerprint.rfind("generic", 0) == 0 || hardware == "goldfish" || hardware == "ranchu";
+    if (hardware == "goldfish" || hardware == "ranchu" || startsWith(hardware, "cutf") ||
+        startsWith(hardware, "vsoc")) {
+        return true;
+    }
+
+    const std::string model = readProp("ro.product.model");
+    return model.find("sdk_gphone") != std::string::npos ||
+           model.find("google_sdk") != std::string::npos ||
+           model.find("Emulator") != std::string::npos ||
+           model.find("Android SDK built for") != std::string::npos ||
+           model.find("Cuttlefish") != std::string::npos;
 #elif defined(__APPLE__) && TARGET_OS_SIMULATOR
     return true;
 #else

--- a/packages/react-native-executorch/cpp/core/utils.h
+++ b/packages/react-native-executorch/cpp/core/utils.h
@@ -3,5 +3,22 @@
 #include <jsi/jsi.h>
 
 namespace rnexecutorch::core::utils {
+/**
+ * Installs `getExecuTorchRegisteredBackends()`, returning the names of the
+ * ExecuTorch backends compiled into the native binary.
+ *
+ * @param rt The active JavaScript runtime.
+ * @param module The `__rnexecutorch_jsi__` module object to install onto.
+ */
 void install_getExecuTorchRegisteredBackends(facebook::jsi::Runtime &rt, facebook::jsi::Object &module);
+
+/**
+ * Installs the `isEmulator` boolean, reporting whether the app is running on an
+ * Android emulator or an iOS simulator. Used to keep development traffic out of
+ * anonymous download analytics.
+ *
+ * @param rt The active JavaScript runtime.
+ * @param module The `__rnexecutorch_jsi__` module object to install onto.
+ */
+void install_isEmulator(facebook::jsi::Runtime &rt, facebook::jsi::Object &module);
 } // namespace rnexecutorch::core::utils

--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -85,7 +85,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-fs": "^2.20.0",
+    "react-native-blob-util": "^0.24.0",
     "react-native-worklets": "*"
   },
   "devDependencies": {
@@ -96,8 +96,8 @@
     "del-cli": "^6.0.0",
     "react": "19.2.0",
     "react-native": "0.83.6",
+    "react-native-blob-util": "^0.24.0",
     "react-native-builder-bob": "^0.40.18",
-    "react-native-fs": "^2.20.0",
     "react-native-worklets": "0.9.1",
     "typescript": "~5.9.2"
   },

--- a/packages/react-native-executorch/src/fetcher/ResourceFetcher.ts
+++ b/packages/react-native-executorch/src/fetcher/ResourceFetcher.ts
@@ -1,11 +1,20 @@
 /* eslint-disable no-bitwise */
+import { Platform } from 'react-native';
 import RNBlobUtil from 'react-native-blob-util';
 import { triggerDownloadEvent, triggerHuggingFaceDownloadCounter } from './telemetry';
 
-// Persistent, per-app directory where downloaded model assets are cached. We use
-// DocumentDir rather than CacheDir so the OS won't evict large models between
-// runs, forcing a costly re-download.
-const RNE_DIRECTORY = `${RNBlobUtil.fs.dirs.DocumentDir}/react-native-executorch`;
+const IS_ANDROID = Platform.OS === 'android';
+
+// Persistent, per-app directory where downloaded model assets are cached.
+//   iOS: internal DocumentDir (not CacheDir) so the OS won't evict large models
+//        between runs and force a costly re-download.
+//   Android: the app-private EXTERNAL files dir (getExternalFilesDir), so the
+//        system DownloadManager can write there and same-volume moves stay cheap
+//        even for multi-GB files. Falls back to DocumentDir if unmounted.
+const ANDROID_DIRECTORY = RNBlobUtil.fs.dirs.SDCardDir || RNBlobUtil.fs.dirs.DocumentDir;
+const RNE_DIRECTORY = IS_ANDROID
+  ? `${ANDROID_DIRECTORY}/react-native-executorch`
+  : `${RNBlobUtil.fs.dirs.DocumentDir}/react-native-executorch`;
 
 /**
  * Progress callback reporting overall completion as a fraction in `[0, 1]`.
@@ -21,8 +30,8 @@ export interface DownloadOptions {
   /** Called with overall progress in `[0, 1]` as bytes arrive. */
   onProgress?: DownloadProgressCallback;
   /**
-   * Aborts the download. Bytes fetched so far are kept on disk so a later
-   * {@link download} of the same source resumes instead of restarting.
+   * Aborts the download. On iOS the bytes fetched so far are kept on disk so a
+   * later {@link download} of the same source resumes instead of restarting.
    */
   signal?: AbortSignal;
 }
@@ -79,15 +88,10 @@ interface DownloadOneCallbacks {
 }
 
 /**
- * Downloads a single remote file into the cache with HTTP-Range resume support.
- * Returns the local path. `canResume` is set to `false` on an internal retry to
- * avoid recursing forever when partial-file assembly fails.
+ * Downloads a single remote file into the cache, dispatching to the
+ * platform-appropriate backend. Returns the local path.
  */
-async function downloadOne(
-  url: string,
-  cb: DownloadOneCallbacks,
-  canResume = true
-): Promise<string> {
+async function downloadOne(url: string, cb: DownloadOneCallbacks): Promise<string> {
   const dest = cachePathFor(url);
 
   // Cache hit — nothing to download.
@@ -97,14 +101,83 @@ async function downloadOne(
     return dest;
   }
 
-  // Count this actual (non-cached) fetch once — not on the internal retry.
-  if (canResume) {
-    triggerHuggingFaceDownloadCounter(url);
-    triggerDownloadEvent(url);
-  }
+  // Count this actual (non-cached) fetch once.
+  triggerHuggingFaceDownloadCounter(url);
+  triggerDownloadEvent(url);
 
   await RNBlobUtil.fs.mkdir(RNE_DIRECTORY).catch(() => {});
 
+  return IS_ANDROID ? downloadViaDownloadManager(url, dest, cb) : downloadViaStream(url, dest, cb);
+}
+
+/**
+ * Android backend: the system DownloadManager streams to app-private external
+ * storage. Unlike blob-util's in-process reader it handles files larger than
+ * 2 GB, keeps downloading while the app is backgrounded or killed, and resumes
+ * across transient network drops on its own — so no manual Range logic here.
+ */
+async function downloadViaDownloadManager(
+  url: string,
+  dest: string,
+  cb: DownloadOneCallbacks
+): Promise<string> {
+  const tmp = `${dest}.downloading`;
+  await RNBlobUtil.fs.unlink(tmp).catch(() => {});
+
+  if (cb.signal?.aborted) throw abortError();
+
+  const task = RNBlobUtil.config({
+    addAndroidDownloads: {
+      useDownloadManager: true,
+      path: tmp,
+      notification: false,
+      mediaScannable: false,
+      mime: 'application/octet-stream',
+    },
+  }).fetch('GET', url);
+
+  const onAbort = () => task.cancel();
+  cb.signal?.addEventListener('abort', onAbort);
+
+  // DownloadManager reports total as -1 until the size is known; forward the
+  // received byte count regardless so byte-weighted progress still advances.
+  task.progress({ count: 100 }, (received, total) => {
+    const recv = Number(received);
+    const tot = Number(total);
+    cb.onBytes?.(recv, tot > 0 ? tot : recv);
+  });
+
+  try {
+    await task;
+  } catch (e) {
+    await RNBlobUtil.fs.unlink(tmp).catch(() => {});
+    throw cb.signal?.aborted ? abortError() : e;
+  } finally {
+    cb.signal?.removeEventListener('abort', onAbort);
+  }
+
+  // DownloadManager doesn't surface an HTTP status; an empty file means failure.
+  const size = await fileSize(tmp);
+  if (size <= 0) {
+    await RNBlobUtil.fs.unlink(tmp).catch(() => {});
+    throw new Error(`Download of ${url} failed (empty response).`);
+  }
+  await RNBlobUtil.fs.mv(tmp, dest);
+  return dest;
+}
+
+/**
+ * iOS backend: blob-util streams via NSURLSession straight to disk. Interrupted
+ * downloads resume from a `.partial` file via an HTTP Range request. `canResume`
+ * is set to `false` on an internal retry to avoid recursing forever if
+ * partial-file assembly ever fails.
+ */
+async function downloadViaStream(
+  url: string,
+  dest: string,
+  cb: DownloadOneCallbacks,
+  canResume = true
+): Promise<string> {
   const part = `${dest}.partial`;
   if (!canResume) await RNBlobUtil.fs.unlink(part).catch(() => {});
   const offset = canResume ? await fileSize(part) : 0;
@@ -169,7 +242,7 @@ async function downloadOne(
     // once as a plain full download so correctness never depends on resume.
     await RNBlobUtil.fs.unlink(part).catch(() => {});
     await RNBlobUtil.fs.unlink(target).catch(() => {});
-    if (canResume) return downloadOne(url, cb, false);
+    if (canResume) return downloadViaStream(url, dest, cb, false);
     throw assemblyErr;
   }
 }
@@ -179,9 +252,10 @@ async function downloadOne(
  * resolves with their local file paths.
  *
  * Local paths (anything not starting with `http`) are returned unchanged.
- * Remote files are streamed to disk with resume support: an interrupted
- * download continues from where it stopped on the next call rather than
- * restarting. When several sources are passed, overall progress is weighted by
+ * Remote files are downloaded to a persistent cache: on Android via the system
+ * DownloadManager (handles multi-GB files and continues in the background), on
+ * iOS via a streaming request that resumes an interrupted download from where
+ * it stopped. When several sources are passed, overall progress is weighted by
  * their byte sizes so a large model isn't reported the same as a tiny
  * tokenizer.
  * @category Fetching

--- a/packages/react-native-executorch/src/fetcher/ResourceFetcher.ts
+++ b/packages/react-native-executorch/src/fetcher/ResourceFetcher.ts
@@ -87,10 +87,8 @@ interface DownloadOneCallbacks {
   signal?: AbortSignal;
 }
 
-/**
- * Downloads a single remote file into the cache, dispatching to the
- * platform-appropriate backend. Returns the local path.
- */
+// Downloads a single remote file into the cache, dispatching to the
+// platform-appropriate backend. Returns the local path.
 async function downloadOne(url: string, cb: DownloadOneCallbacks): Promise<string> {
   const dest = cachePathFor(url);
 
@@ -110,12 +108,10 @@ async function downloadOne(url: string, cb: DownloadOneCallbacks): Promise<strin
   return IS_ANDROID ? downloadViaDownloadManager(url, dest, cb) : downloadViaStream(url, dest, cb);
 }
 
-/**
- * Android backend: the system DownloadManager streams to app-private external
- * storage. Unlike blob-util's in-process reader it handles files larger than
- * 2 GB, keeps downloading while the app is backgrounded or killed, and resumes
- * across transient network drops on its own — so no manual Range logic here.
- */
+// Android backend: the system DownloadManager streams to app-private external
+// storage. Unlike blob-util's in-process reader it handles files larger than
+// 2 GB, keeps downloading while the app is in the background or killed, and
+// resumes across transient network drops on its own — so no manual Range logic.
 async function downloadViaDownloadManager(
   url: string,
   dest: string,
@@ -166,12 +162,10 @@ async function downloadViaDownloadManager(
   return dest;
 }
 
-/**
- * iOS backend: blob-util streams via NSURLSession straight to disk. Interrupted
- * downloads resume from a `.partial` file via an HTTP Range request. `canResume`
- * is set to `false` on an internal retry to avoid recursing forever if
- * partial-file assembly ever fails.
- */
+// iOS backend: blob-util streams via the iOS URL session straight to disk.
+// Interrupted downloads resume from a `.partial` file via an HTTP Range request.
+// `canResume` is set to `false` on an internal retry to avoid recursing forever
+// if partial-file assembly ever fails.
 async function downloadViaStream(
   url: string,
   dest: string,
@@ -258,7 +252,7 @@ async function downloadViaStream(
  * it stopped. When several sources are passed, overall progress is weighted by
  * their byte sizes so a large model isn't reported the same as a tiny
  * tokenizer.
- * @category Fetching
+ * @category Utils
  * @param source A single URL/local path, or an array of them.
  * @param options Progress and cancellation options.
  * @returns The local path (for a single source) or paths (for an array),

--- a/packages/react-native-executorch/src/fetcher/ResourceFetcher.ts
+++ b/packages/react-native-executorch/src/fetcher/ResourceFetcher.ts
@@ -1,0 +1,244 @@
+/* eslint-disable no-bitwise */
+import RNBlobUtil from 'react-native-blob-util';
+import { triggerDownloadEvent, triggerHuggingFaceDownloadCounter } from './telemetry';
+
+// Persistent, per-app directory where downloaded model assets are cached. We use
+// DocumentDir rather than CacheDir so the OS won't evict large models between
+// runs, forcing a costly re-download.
+const RNE_DIRECTORY = `${RNBlobUtil.fs.dirs.DocumentDir}/react-native-executorch`;
+
+/**
+ * Progress callback reporting overall completion as a fraction in `[0, 1]`.
+ * @category Types
+ */
+export type DownloadProgressCallback = (progress: number) => void;
+
+/**
+ * Options controlling a {@link download} call.
+ * @category Types
+ */
+export interface DownloadOptions {
+  /** Called with overall progress in `[0, 1]` as bytes arrive. */
+  onProgress?: DownloadProgressCallback;
+  /**
+   * Aborts the download. Bytes fetched so far are kept on disk so a later
+   * {@link download} of the same source resumes instead of restarting.
+   */
+  signal?: AbortSignal;
+}
+
+// djb2 — cheap, dependency-free hash used to derive a stable cache key per URL.
+const djb2 = (s: string): number => {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = (((h << 5) + h) ^ s.charCodeAt(i)) >>> 0;
+  }
+  return h;
+};
+
+const isRemote = (source: string): boolean => /^https?:\/\//.test(source);
+
+function cachePathFor(url: string): string {
+  const urlWithoutQuery = url.split('?')[0]!;
+  const basename = urlWithoutQuery.split('/').pop() || 'model';
+  // Hash guards against basename collisions across different repos/versions.
+  return `${RNE_DIRECTORY}/${djb2(urlWithoutQuery)}_${basename}`;
+}
+
+async function fileSize(path: string): Promise<number> {
+  try {
+    const stat = await RNBlobUtil.fs.stat(path);
+    return Number(stat.size) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+// Best-effort remote content length via a HEAD request; 0 when unknown.
+async function remoteSize(url: string): Promise<number> {
+  try {
+    const res = await fetch(url, { method: 'HEAD' });
+    const len = res.headers.get('content-length');
+    return len ? Number(len) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function abortError(): Error {
+  const err = new Error('The download was aborted.');
+  err.name = 'AbortError';
+  return err;
+}
+
+interface DownloadOneCallbacks {
+  // Reports absolute received/total bytes for this file, including any bytes
+  // already present from a previous partial download.
+  onBytes?: (received: number, total: number) => void;
+  signal?: AbortSignal;
+}
+
+/**
+ * Downloads a single remote file into the cache with HTTP-Range resume support.
+ * Returns the local path. `canResume` is set to `false` on an internal retry to
+ * avoid recursing forever when partial-file assembly fails.
+ */
+async function downloadOne(
+  url: string,
+  cb: DownloadOneCallbacks,
+  canResume = true
+): Promise<string> {
+  const dest = cachePathFor(url);
+
+  // Cache hit — nothing to download.
+  if (await RNBlobUtil.fs.exists(dest)) {
+    const size = await fileSize(dest);
+    cb.onBytes?.(size, size);
+    return dest;
+  }
+
+  // Count this actual (non-cached) fetch once — not on the internal retry.
+  if (canResume) {
+    triggerHuggingFaceDownloadCounter(url);
+    triggerDownloadEvent(url);
+  }
+
+  await RNBlobUtil.fs.mkdir(RNE_DIRECTORY).catch(() => {});
+
+  const part = `${dest}.partial`;
+  if (!canResume) await RNBlobUtil.fs.unlink(part).catch(() => {});
+  const offset = canResume ? await fileSize(part) : 0;
+
+  // Resumed byte ranges land in a separate chunk file that we append onto the
+  // partial; fresh downloads stream straight into the partial.
+  const target = offset > 0 ? `${dest}.chunk` : part;
+  await RNBlobUtil.fs.unlink(target).catch(() => {}); // clear any stale chunk
+
+  const headers: Record<string, string> = {};
+  if (offset > 0) headers.Range = `bytes=${offset}-`;
+
+  if (cb.signal?.aborted) throw abortError();
+
+  const task = RNBlobUtil.config({ path: target, fileCache: true }).fetch('GET', url, headers);
+  const onAbort = () => task.cancel();
+  cb.signal?.addEventListener('abort', onAbort);
+
+  task.progress({ count: 20 }, (received, total) => {
+    const recv = Number(received);
+    const tot = Number(total);
+    cb.onBytes?.(offset + recv, offset + tot);
+  });
+
+  let status: number;
+  try {
+    const res = await task;
+    status = res.info().status;
+  } catch (e) {
+    // Network drop / cancel. Keep the fresh partial for a future resume, but
+    // discard a resumed chunk — its offset assumptions may not hold.
+    if (offset > 0) await RNBlobUtil.fs.unlink(target).catch(() => {});
+    throw cb.signal?.aborted ? abortError() : e;
+  } finally {
+    cb.signal?.removeEventListener('abort', onAbort);
+  }
+
+  try {
+    if (status === 416) {
+      // Range not satisfiable — the partial already holds the whole file.
+      await RNBlobUtil.fs.unlink(target).catch(() => {});
+    } else if (status >= 400) {
+      await RNBlobUtil.fs.unlink(target).catch(() => {});
+      throw new Error(`Download of ${url} failed with HTTP status ${status}.`);
+    } else if (offset > 0) {
+      if (status === 206) {
+        // Server honored the range: append the new bytes onto the partial.
+        await RNBlobUtil.fs.appendFile(part, `file://${target}`, 'uri');
+        await RNBlobUtil.fs.unlink(target).catch(() => {});
+      } else {
+        // Server ignored the range (200) and re-sent the whole file: replace.
+        await RNBlobUtil.fs.unlink(part).catch(() => {});
+        await RNBlobUtil.fs.mv(target, part);
+      }
+    }
+    await RNBlobUtil.fs.mv(part, dest);
+    return dest;
+  } catch (assemblyErr) {
+    // A `4xx` we deliberately threw must propagate as-is.
+    if (status >= 400 && status !== 416) throw assemblyErr;
+    // Assembling the partial failed (e.g. append unsupported). Wipe and retry
+    // once as a plain full download so correctness never depends on resume.
+    await RNBlobUtil.fs.unlink(part).catch(() => {});
+    await RNBlobUtil.fs.unlink(target).catch(() => {});
+    if (canResume) return downloadOne(url, cb, false);
+    throw assemblyErr;
+  }
+}
+
+/**
+ * Downloads one or more model resources into a persistent local cache and
+ * resolves with their local file paths.
+ *
+ * Local paths (anything not starting with `http`) are returned unchanged.
+ * Remote files are streamed to disk with resume support: an interrupted
+ * download continues from where it stopped on the next call rather than
+ * restarting. When several sources are passed, overall progress is weighted by
+ * their byte sizes so a large model isn't reported the same as a tiny
+ * tokenizer.
+ * @category Fetching
+ * @param source A single URL/local path, or an array of them.
+ * @param options Progress and cancellation options.
+ * @returns The local path (for a single source) or paths (for an array),
+ * matching the shape of `source`.
+ */
+export function download(source: string, options?: DownloadOptions): Promise<string>;
+export function download(sources: string[], options?: DownloadOptions): Promise<string[]>;
+export async function download(
+  source: string | string[],
+  options: DownloadOptions = {}
+): Promise<string | string[]> {
+  const single = !Array.isArray(source);
+  const sources = single ? [source] : source;
+
+  const remoteIndices = sources.map((s, i) => (isRemote(s) ? i : -1)).filter((i) => i >= 0);
+
+  // Nothing to fetch — every source is already a local path.
+  if (remoteIndices.length === 0) {
+    options.onProgress?.(1);
+    return single ? sources[0]! : sources;
+  }
+
+  // Weight overall progress by real byte sizes so a 1 GB model isn't treated
+  // like a 1 MB tokenizer. When any HEAD fails we fall back to equal weighting.
+  const sizes = await Promise.all(
+    sources.map((s, i) => (remoteIndices.includes(i) ? remoteSize(s) : Promise.resolve(0)))
+  );
+  const haveAllSizes = remoteIndices.every((i) => sizes[i]! > 0);
+  const total = haveAllSizes ? sizes.reduce((a, b) => a + b, 0) : remoteIndices.length;
+
+  const received = new Array<number>(sources.length).fill(0);
+  const report = () => {
+    if (!options.onProgress) return;
+    const sum = received.reduce((a, b) => a + b, 0);
+    options.onProgress(total > 0 ? Math.min(sum / total, 1) : 0);
+  };
+
+  const results: string[] = [...sources];
+  await Promise.all(
+    remoteIndices.map((i) => {
+      const url = sources[i]!;
+      // Telemetry fires inside downloadOne, only for genuine (non-cached) fetches.
+      return downloadOne(url, {
+        signal: options.signal,
+        onBytes: (recv, tot) => {
+          received[i] = haveAllSizes ? recv : tot > 0 ? recv / tot : 0;
+          report();
+        },
+      }).then((path) => {
+        results[i] = path;
+      });
+    })
+  );
+
+  options.onProgress?.(1);
+  return single ? results[0]! : results;
+}

--- a/packages/react-native-executorch/src/fetcher/fetcher.ts
+++ b/packages/react-native-executorch/src/fetcher/fetcher.ts
@@ -340,7 +340,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * @param node The value to walk.
  * @returns The set of remote URLs referenced by `node`.
  */
-export function collectRemoteSources(node: unknown): Set<string> {
+function collectRemoteSources(node: unknown): Set<string> {
   const out = new Set<string>();
 
   const visit = (current: unknown): void => {
@@ -366,7 +366,7 @@ export function collectRemoteSources(node: unknown): Set<string> {
  * @param resolved Map of remote URL to downloaded local path.
  * @returns `node` with resolved URLs swapped for local paths.
  */
-export function substituteRemoteSources<T>(node: T, resolved: ReadonlyMap<string, string>): T {
+function substituteRemoteSources<T>(node: T, resolved: ReadonlyMap<string, string>): T {
   if (typeof node === 'string') {
     return (resolved.get(node) ?? node) as T;
   }

--- a/packages/react-native-executorch/src/fetcher/fetcher.ts
+++ b/packages/react-native-executorch/src/fetcher/fetcher.ts
@@ -241,72 +241,132 @@ async function downloadViaStream(
   }
 }
 
-/**
- * Downloads one or more model resources into a persistent local cache and
- * resolves with their local file paths.
- *
- * Local paths (anything not starting with `http`) are returned unchanged.
- * Remote files are downloaded to a persistent cache: on Android via the system
- * DownloadManager (handles multi-GB files and continues in the background), on
- * iOS via a streaming request that resumes an interrupted download from where
- * it stopped. When several sources are passed, overall progress is weighted by
- * their byte sizes so a large model isn't reported the same as a tiny
- * tokenizer.
- * @category Utils
- * @param source A single URL/local path, or an array of them.
- * @param options Progress and cancellation options.
- * @returns The local path (for a single source) or paths (for an array),
- * matching the shape of `source`.
- */
-export function download(source: string, options?: DownloadOptions): Promise<string>;
-export function download(sources: string[], options?: DownloadOptions): Promise<string[]>;
-export async function download(
-  source: string | string[],
-  options: DownloadOptions = {}
-): Promise<string | string[]> {
-  const single = !Array.isArray(source);
-  const sources = single ? [source] : source;
+// Plain data containers we recurse into. Anything else (numbers, functions,
+// typed arrays, class instances) is left alone.
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
 
-  const remoteIndices = sources.map((s, i) => (isRemote(s) ? i : -1)).filter((i) => i >= 0);
+/**
+ * Walks a value and collects every distinct remote URL sitting on a string
+ * leaf. Deduplicating here means a URL repeated across fields is fetched once.
+ * @param node The value to walk.
+ * @param out Accumulator, so recursive calls share one set.
+ * @returns The set of remote URLs referenced by `node`.
+ */
+export function collectRemoteSources(node: unknown, out = new Set<string>()): Set<string> {
+  if (typeof node === 'string') {
+    if (isRemote(node)) out.add(node);
+  } else if (Array.isArray(node)) {
+    for (const item of node) collectRemoteSources(item, out);
+  } else if (isPlainObject(node)) {
+    for (const value of Object.values(node)) collectRemoteSources(value, out);
+  }
+  return out;
+}
+
+/**
+ * Rebuilds a value with every resolved URL replaced by its local path.
+ * Branches containing no resolved URL keep their original reference, so an
+ * untouched config comes back as-is and stays stable across React renders.
+ * @typeParam T The shape of the value being rewritten.
+ * @param node The value to rewrite.
+ * @param resolved Map of remote URL to downloaded local path.
+ * @returns `node` with resolved URLs swapped for local paths.
+ */
+export function substituteRemoteSources<T>(node: T, resolved: ReadonlyMap<string, string>): T {
+  if (typeof node === 'string') {
+    return (resolved.get(node) ?? node) as T;
+  }
+  if (Array.isArray(node)) {
+    let changed = false;
+    const next = node.map((item) => {
+      const mapped = substituteRemoteSources(item, resolved);
+      changed ||= mapped !== item;
+      return mapped;
+    });
+    return (changed ? next : node) as T;
+  }
+  if (isPlainObject(node)) {
+    let changed = false;
+    const next: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(node)) {
+      const mapped = substituteRemoteSources(value, resolved);
+      changed ||= mapped !== value;
+      next[key] = mapped;
+    }
+    return (changed ? next : node) as T;
+  }
+  return node;
+}
+
+/**
+ * Downloads the remote resources referenced by `source` into a persistent local
+ * cache and resolves with the same value, with every remote URL replaced by the
+ * local path it was downloaded to.
+ *
+ * `source` may be a single URL, or any nested structure of plain objects and
+ * arrays — typically a whole model config. Every string leaf that looks like an
+ * `http(s)` URL is downloaded; everything else (local paths, labels, numbers)
+ * is passed through untouched. The result therefore has exactly the same shape
+ * and type as the input and can be handed straight to a `create<Task>` factory:
+ *
+ * ```ts
+ * const model = await download(models.classification.EFFICIENTNET_V2_S.XNNPACK_FP32);
+ * const { classify, dispose } = await createClassifier(model);
+ * ```
+ *
+ * Downloads go to a persistent cache: on Android via the system DownloadManager
+ * (handles multi-GB files and continues in the background), on iOS via a
+ * streaming request that resumes an interrupted download from where it stopped.
+ * When a config references several files, overall progress is weighted by their
+ * byte sizes so a large model isn't reported the same as a tiny tokenizer.
+ * @category Utils
+ * @typeParam T The shape of the value being resolved.
+ * @param source A URL, a local path, or any nested object/array holding them.
+ * @param options Progress and cancellation options.
+ * @returns `source` with every remote URL replaced by its local file path.
+ */
+export async function download<T>(source: T, options: DownloadOptions = {}): Promise<T> {
+  const urls = [...collectRemoteSources(source)];
 
   // Nothing to fetch — every source is already a local path.
-  if (remoteIndices.length === 0) {
+  if (urls.length === 0) {
     options.onProgress?.(1);
-    return single ? sources[0]! : sources;
+    return source;
   }
 
   // Weight overall progress by real byte sizes so a 1 GB model isn't treated
   // like a 1 MB tokenizer. When any HEAD fails we fall back to equal weighting.
-  const sizes = await Promise.all(
-    sources.map((s, i) => (remoteIndices.includes(i) ? remoteSize(s) : Promise.resolve(0)))
-  );
-  const haveAllSizes = remoteIndices.every((i) => sizes[i]! > 0);
-  const total = haveAllSizes ? sizes.reduce((a, b) => a + b, 0) : remoteIndices.length;
+  const sizes = await Promise.all(urls.map(remoteSize));
+  const haveAllSizes = sizes.every((size) => size > 0);
+  const total = haveAllSizes ? sizes.reduce((a, b) => a + b, 0) : urls.length;
 
-  const received = new Array<number>(sources.length).fill(0);
+  const received = new Array<number>(urls.length).fill(0);
   const report = () => {
     if (!options.onProgress) return;
     const sum = received.reduce((a, b) => a + b, 0);
     options.onProgress(total > 0 ? Math.min(sum / total, 1) : 0);
   };
 
-  const results: string[] = [...sources];
+  const resolved = new Map<string, string>();
   await Promise.all(
-    remoteIndices.map((i) => {
-      const url = sources[i]!;
+    urls.map((url, i) =>
       // Telemetry fires inside downloadOne, only for genuine (non-cached) fetches.
-      return downloadOne(url, {
+      downloadOne(url, {
         signal: options.signal,
         onBytes: (recv, tot) => {
           received[i] = haveAllSizes ? recv : tot > 0 ? recv / tot : 0;
           report();
         },
       }).then((path) => {
-        results[i] = path;
-      });
-    })
+        resolved.set(url, path);
+      })
+    )
   );
 
   options.onProgress?.(1);
-  return single ? results[0]! : results;
+  return substituteRemoteSources(source, resolved);
 }

--- a/packages/react-native-executorch/src/fetcher/fetcher.ts
+++ b/packages/react-native-executorch/src/fetcher/fetcher.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-bitwise */
 import { Platform } from 'react-native';
 import RNBlobUtil from 'react-native-blob-util';
-import { triggerDownloadEvent, triggerHuggingFaceDownloadCounter } from './telemetry';
+import * as telemetry from './telemetry';
 
 const IS_ANDROID = Platform.OS === 'android';
 
@@ -17,23 +17,23 @@ const RNE_DIRECTORY = IS_ANDROID
   : `${RNBlobUtil.fs.dirs.DocumentDir}/react-native-executorch`;
 
 /**
- * Progress callback reporting overall completion as a fraction in `[0, 1]`.
- * @category Types
- */
-export type DownloadProgressCallback = (progress: number) => void;
-
-/**
  * Options controlling a {@link download} call.
  * @category Types
  */
 export interface DownloadOptions {
   /** Called with overall progress in `[0, 1]` as bytes arrive. */
-  onProgress?: DownloadProgressCallback;
+  onProgress?: (progress: number) => void;
   /**
    * Aborts the download. On iOS the bytes fetched so far are kept on disk so a
    * later {@link download} of the same source resumes instead of restarting.
    */
   signal?: AbortSignal;
+  /**
+   * Re-downloads every remote source even when it is already cached, replacing
+   * the cached copy. Use to recover from a corrupted file or to pick up a model
+   * that changed behind a stable URL.
+   */
+  forceDownload?: boolean;
 }
 
 // djb2 — cheap, dependency-free hash used to derive a stable cache key per URL.
@@ -80,42 +80,121 @@ function abortError(): Error {
   return err;
 }
 
-interface DownloadOneCallbacks {
+type OnBytes = (received: number, total: number) => void;
+
+interface DownloadUrlCallbacks {
   // Reports absolute received/total bytes for this file, including any bytes
   // already present from a previous partial download.
-  onBytes?: (received: number, total: number) => void;
+  onBytes?: OnBytes;
   signal?: AbortSignal;
+  forceDownload?: boolean;
 }
+
+// A download that is currently running, shared by every caller that asked for
+// the same URL while it was in flight.
+interface InFlightDownload {
+  promise: Promise<string>;
+  // Progress is fanned out to every joined caller.
+  listeners: Set<OnBytes>;
+  // Drives the underlying request; aborted only once every caller has left.
+  controller: AbortController;
+  callers: number;
+}
+
+const inFlight = new Map<string, InFlightDownload>();
 
 // Downloads a single remote file into the cache, dispatching to the
 // platform-appropriate backend. Returns the local path.
-async function downloadOne(url: string, cb: DownloadOneCallbacks): Promise<string> {
+//
+// Concurrent calls for the same URL share one request: without this, both would
+// miss the cache check, double-count the download in telemetry, and write the
+// same temporary file — on Android the second one's opening `unlink` would
+// delete the first one's partially downloaded data.
+async function downloadUrl(url: string, cb: DownloadUrlCallbacks): Promise<string> {
+  if (cb.signal?.aborted) throw abortError();
+
   const dest = cachePathFor(url);
 
-  // Cache hit — nothing to download.
-  if (await RNBlobUtil.fs.exists(dest)) {
+  if (cb.forceDownload) {
+    // Drop the cached copy so the checks below fall through to a real fetch.
+    // A download already in flight hasn't written `dest` yet, so joining it
+    // still yields freshly fetched bytes.
+    await RNBlobUtil.fs.unlink(dest).catch(() => {});
+  } else if (await RNBlobUtil.fs.exists(dest)) {
+    // Cache hit — nothing to download.
     const size = await fileSize(dest);
     cb.onBytes?.(size, size);
     return dest;
   }
 
-  // Count this actual (non-cached) fetch once.
-  triggerHuggingFaceDownloadCounter(url);
-  triggerDownloadEvent(url);
+  // Skip an entry whose last caller just left: it is already unwinding, so
+  // joining it would hand this caller someone else's cancellation.
+  const existing = inFlight.get(url);
+  if (existing && !existing.controller.signal.aborted) return joinDownload(existing, cb);
+
+  const entry: InFlightDownload = {
+    promise: Promise.resolve(''),
+    listeners: new Set(),
+    controller: new AbortController(),
+    callers: 0,
+  };
+  entry.promise = startDownload(url, dest, entry).finally(() => {
+    inFlight.delete(url);
+  });
+  inFlight.set(url, entry);
+
+  return joinDownload(entry, cb);
+}
+
+// Runs the actual request, fanning progress out to everyone who joined.
+async function startDownload(url: string, dest: string, entry: InFlightDownload): Promise<string> {
+  // Count this actual (non-cached) fetch once, no matter how many callers share it.
+  telemetry.triggerHuggingFaceDownloadCounter(url);
+  telemetry.triggerDownloadEvent(url);
 
   await RNBlobUtil.fs.mkdir(RNE_DIRECTORY).catch(() => {});
 
-  return IS_ANDROID ? downloadViaDownloadManager(url, dest, cb) : downloadViaStream(url, dest, cb);
+  const cb: DownloadUrlCallbacks = {
+    signal: entry.controller.signal,
+    onBytes: (received, total) => {
+      for (const listener of entry.listeners) listener(received, total);
+    },
+  };
+
+  return IS_ANDROID
+    ? downloadUrlViaAndroidDownloadManager(url, dest, cb)
+    : downloadUrlViaIosStream(url, dest, cb);
+}
+
+// Attaches one caller to a shared download. The caller's own signal only
+// detaches it — the request itself is cancelled once the last caller leaves.
+function joinDownload(entry: InFlightDownload, cb: DownloadUrlCallbacks): Promise<string> {
+  entry.callers += 1;
+  if (cb.onBytes) entry.listeners.add(cb.onBytes);
+
+  return new Promise<string>((resolve, reject) => {
+    const onAbort = () => {
+      if (cb.onBytes) entry.listeners.delete(cb.onBytes);
+      entry.callers -= 1;
+      if (entry.callers === 0) entry.controller.abort();
+      reject(abortError());
+    };
+    cb.signal?.addEventListener('abort', onAbort);
+
+    entry.promise.then(resolve, reject).finally(() => {
+      cb.signal?.removeEventListener('abort', onAbort);
+    });
+  });
 }
 
 // Android backend: the system DownloadManager streams to app-private external
 // storage. Unlike blob-util's in-process reader it handles files larger than
 // 2 GB, keeps downloading while the app is in the background or killed, and
 // resumes across transient network drops on its own — so no manual Range logic.
-async function downloadViaDownloadManager(
+async function downloadUrlViaAndroidDownloadManager(
   url: string,
   dest: string,
-  cb: DownloadOneCallbacks
+  cb: DownloadUrlCallbacks
 ): Promise<string> {
   const tmp = `${dest}.downloading`;
   await RNBlobUtil.fs.unlink(tmp).catch(() => {});
@@ -166,10 +245,10 @@ async function downloadViaDownloadManager(
 // Interrupted downloads resume from a `.partial` file via an HTTP Range request.
 // `canResume` is set to `false` on an internal retry to avoid recursing forever
 // if partial-file assembly ever fails.
-async function downloadViaStream(
+async function downloadUrlViaIosStream(
   url: string,
   dest: string,
-  cb: DownloadOneCallbacks,
+  cb: DownloadUrlCallbacks,
   canResume = true
 ): Promise<string> {
   const part = `${dest}.partial`;
@@ -236,7 +315,7 @@ async function downloadViaStream(
     // once as a plain full download so correctness never depends on resume.
     await RNBlobUtil.fs.unlink(part).catch(() => {});
     await RNBlobUtil.fs.unlink(target).catch(() => {});
-    if (canResume) return downloadViaStream(url, dest, cb, false);
+    if (canResume) return downloadUrlViaIosStream(url, dest, cb, false);
     throw assemblyErr;
   }
 }
@@ -253,17 +332,22 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * Walks a value and collects every distinct remote URL sitting on a string
  * leaf. Deduplicating here means a URL repeated across fields is fetched once.
  * @param node The value to walk.
- * @param out Accumulator, so recursive calls share one set.
  * @returns The set of remote URLs referenced by `node`.
  */
-export function collectRemoteSources(node: unknown, out = new Set<string>()): Set<string> {
-  if (typeof node === 'string') {
-    if (isRemote(node)) out.add(node);
-  } else if (Array.isArray(node)) {
-    for (const item of node) collectRemoteSources(item, out);
-  } else if (isPlainObject(node)) {
-    for (const value of Object.values(node)) collectRemoteSources(value, out);
-  }
+export function collectRemoteSources(node: unknown): Set<string> {
+  const out = new Set<string>();
+
+  const visit = (current: unknown): void => {
+    if (typeof current === 'string') {
+      if (isRemote(current)) out.add(current);
+    } else if (Array.isArray(current)) {
+      for (const item of current) visit(item);
+    } else if (isPlainObject(current)) {
+      for (const value of Object.values(current)) visit(value);
+    }
+  };
+
+  visit(node);
   return out;
 }
 
@@ -354,9 +438,10 @@ export async function download<T>(source: T, options: DownloadOptions = {}): Pro
   const resolved = new Map<string, string>();
   await Promise.all(
     urls.map((url, i) =>
-      // Telemetry fires inside downloadOne, only for genuine (non-cached) fetches.
-      downloadOne(url, {
+      // Telemetry fires inside downloadUrl, only for genuine (non-cached) fetches.
+      downloadUrl(url, {
         signal: options.signal,
+        forceDownload: options.forceDownload,
         onBytes: (recv, tot) => {
           received[i] = haveAllSizes ? recv : tot > 0 ? recv / tot : 0;
           report();

--- a/packages/react-native-executorch/src/fetcher/fetcher.ts
+++ b/packages/react-native-executorch/src/fetcher/fetcher.ts
@@ -74,10 +74,16 @@ async function remoteSize(url: string): Promise<number> {
   }
 }
 
-function abortError(): Error {
-  const err = new Error('The download was aborted.');
-  err.name = 'AbortError';
-  return err;
+/**
+ * Raised when a {@link download} is cancelled through its `signal`. Internal:
+ * consumers should keep matching on `error.name === 'AbortError'`, which stays
+ * the standard `AbortSignal` contract.
+ */
+export class AbortError extends Error {
+  constructor(message = 'The download was aborted.') {
+    super(message);
+    this.name = 'AbortError';
+  }
 }
 
 type OnBytes = (received: number, total: number) => void;
@@ -111,7 +117,7 @@ const inFlight = new Map<string, InFlightDownload>();
 // same temporary file — on Android the second one's opening `unlink` would
 // delete the first one's partially downloaded data.
 async function downloadUrl(url: string, cb: DownloadUrlCallbacks): Promise<string> {
-  if (cb.signal?.aborted) throw abortError();
+  if (cb.signal?.aborted) throw new AbortError();
 
   const dest = cachePathFor(url);
 
@@ -177,7 +183,7 @@ function joinDownload(entry: InFlightDownload, cb: DownloadUrlCallbacks): Promis
       if (cb.onBytes) entry.listeners.delete(cb.onBytes);
       entry.callers -= 1;
       if (entry.callers === 0) entry.controller.abort();
-      reject(abortError());
+      reject(new AbortError());
     };
     cb.signal?.addEventListener('abort', onAbort);
 
@@ -199,7 +205,7 @@ async function downloadUrlViaAndroidDownloadManager(
   const tmp = `${dest}.downloading`;
   await RNBlobUtil.fs.unlink(tmp).catch(() => {});
 
-  if (cb.signal?.aborted) throw abortError();
+  if (cb.signal?.aborted) throw new AbortError();
 
   const task = RNBlobUtil.config({
     addAndroidDownloads: {
@@ -226,7 +232,7 @@ async function downloadUrlViaAndroidDownloadManager(
     await task;
   } catch (e) {
     await RNBlobUtil.fs.unlink(tmp).catch(() => {});
-    throw cb.signal?.aborted ? abortError() : e;
+    throw cb.signal?.aborted ? new AbortError() : e;
   } finally {
     cb.signal?.removeEventListener('abort', onAbort);
   }
@@ -263,7 +269,7 @@ async function downloadUrlViaIosStream(
   const headers: Record<string, string> = {};
   if (offset > 0) headers.Range = `bytes=${offset}-`;
 
-  if (cb.signal?.aborted) throw abortError();
+  if (cb.signal?.aborted) throw new AbortError();
 
   const task = RNBlobUtil.config({ path: target, fileCache: true }).fetch('GET', url, headers);
   const onAbort = () => task.cancel();
@@ -283,7 +289,7 @@ async function downloadUrlViaIosStream(
     // Network drop / cancel. Keep the fresh partial for a future resume, but
     // discard a resumed chunk — its offset assumptions may not hold.
     if (offset > 0) await RNBlobUtil.fs.unlink(target).catch(() => {});
-    throw cb.signal?.aborted ? abortError() : e;
+    throw cb.signal?.aborted ? new AbortError() : e;
   } finally {
     cb.signal?.removeEventListener('abort', onAbort);
   }

--- a/packages/react-native-executorch/src/fetcher/index.ts
+++ b/packages/react-native-executorch/src/fetcher/index.ts
@@ -1,0 +1,2 @@
+export { download } from './ResourceFetcher';
+export type { DownloadOptions, DownloadProgressCallback } from './ResourceFetcher';

--- a/packages/react-native-executorch/src/fetcher/index.ts
+++ b/packages/react-native-executorch/src/fetcher/index.ts
@@ -1,3 +1,3 @@
 export { download } from './fetcher';
-export type { DownloadOptions, DownloadProgressCallback } from './fetcher';
+export type { DownloadOptions } from './fetcher';
 export { setTelemetryEnabled } from './telemetry';

--- a/packages/react-native-executorch/src/fetcher/index.ts
+++ b/packages/react-native-executorch/src/fetcher/index.ts
@@ -1,3 +1,3 @@
-export { download } from './ResourceFetcher';
-export type { DownloadOptions, DownloadProgressCallback } from './ResourceFetcher';
+export { download } from './fetcher';
+export type { DownloadOptions, DownloadProgressCallback } from './fetcher';
 export { setTelemetryEnabled } from './telemetry';

--- a/packages/react-native-executorch/src/fetcher/index.ts
+++ b/packages/react-native-executorch/src/fetcher/index.ts
@@ -1,2 +1,3 @@
 export { download } from './ResourceFetcher';
 export type { DownloadOptions, DownloadProgressCallback } from './ResourceFetcher';
+export { setTelemetryEnabled } from './telemetry';

--- a/packages/react-native-executorch/src/fetcher/telemetry.ts
+++ b/packages/react-native-executorch/src/fetcher/telemetry.ts
@@ -12,6 +12,13 @@ const LIB_VERSION = '0.0.0';
 // Anonymous analytics are on by default; apps opt out via setTelemetryEnabled.
 let telemetryEnabled = true;
 
+// Telemetry must never break a download, so every failure is swallowed. Surface
+// it in development so a genuinely broken payload doesn't go unnoticed.
+function warn(message: string, error: unknown): void {
+  // eslint-disable-next-line no-console
+  if (__DEV__) console.warn(`[RNE Telemetry] ${message}:`, error);
+}
+
 /**
  * Enables or disables the anonymous download analytics sent to Software Mansion.
  * Analytics are enabled by default; call `setTelemetryEnabled(false)` (e.g. once
@@ -43,8 +50,12 @@ export function triggerHuggingFaceDownloadCounter(uri: string): void {
     if (!isSwmHuggingFaceRepo(url)) return;
     const base = `${url.protocol}//${url.host}${url.pathname.split('resolve')[0]}`;
     // Fire-and-forget; its success is irrelevant to the download itself.
-    fetch(`${base}resolve/main/config.json`, { method: 'HEAD' }).catch(() => {});
-  } catch {}
+    fetch(`${base}resolve/main/config.json`, { method: 'HEAD' }).catch((e) => {
+      warn('Hugging Face download counter request failed', e);
+    });
+  } catch (e) {
+    warn('Failed to trigger the Hugging Face download counter', e);
+  }
 }
 
 function getCountryCode(): string {
@@ -52,21 +63,18 @@ function getCountryCode(): string {
     const locale = Intl.DateTimeFormat().resolvedOptions().locale;
     const region = locale.split('-').pop();
     if (region && region.length === 2) return region.toUpperCase();
-  } catch {}
+  } catch (e) {
+    warn('Failed to resolve the country code', e);
+  }
   return 'UNKNOWN';
-}
-
-// Reported by the native installer (Android build props / TARGET_OS_SIMULATOR)
-// so development traffic can be filtered out server-side.
-function isEmulator(): boolean {
-  return rnexecutorchJsi.isEmulator === true;
 }
 
 function getModelNameFromUri(uri: string): string {
   try {
     const filename = new URL(uri).pathname.split('/').pop() ?? uri;
     return filename.replace(/\.[^.]+$/, '');
-  } catch {
+  } catch (e) {
+    warn('Failed to derive the model name from the URI', e);
     return uri;
   }
 }
@@ -86,10 +94,16 @@ export function triggerDownloadEvent(uri: string): void {
       body: JSON.stringify({
         modelName: getModelNameFromUri(uri),
         countryCode: getCountryCode(),
-        isEmulator: isEmulator(),
+        // Set by the native installer (Android build props / TARGET_OS_SIMULATOR)
+        // so development traffic can be filtered out server-side.
+        isEmulator: rnexecutorchJsi.isEmulator,
         platform: Platform.OS,
         libVersion: LIB_VERSION,
       }),
-    }).catch(() => {});
-  } catch {}
+    }).catch((e) => {
+      warn('Download event request failed', e);
+    });
+  } catch (e) {
+    warn('Failed to send the download event', e);
+  }
 }

--- a/packages/react-native-executorch/src/fetcher/telemetry.ts
+++ b/packages/react-native-executorch/src/fetcher/telemetry.ts
@@ -8,9 +8,7 @@ const DOWNLOAD_EVENT_ENDPOINT = 'https://ai.swmansion.com/telemetry/downloads/ap
 // See https://github.com/software-mansion/react-native-executorch/issues/1291
 const LIB_VERSION = '0.0.0';
 
-/**
- * Whether the given URL points to a Software Mansion Hugging Face repo.
- */
+// Whether the given URL points to a Software Mansion Hugging Face repo.
 function isSwmHuggingFaceRepo(url: URL): boolean {
   return url.host === 'huggingface.co' && url.pathname.startsWith('/software-mansion');
 }

--- a/packages/react-native-executorch/src/fetcher/telemetry.ts
+++ b/packages/react-native-executorch/src/fetcher/telemetry.ts
@@ -8,6 +8,21 @@ const DOWNLOAD_EVENT_ENDPOINT = 'https://ai.swmansion.com/telemetry/downloads/ap
 // See https://github.com/software-mansion/react-native-executorch/issues/1291
 const LIB_VERSION = '0.0.0';
 
+// Anonymous analytics are on by default; apps opt out via setTelemetryEnabled.
+let telemetryEnabled = true;
+
+/**
+ * Enables or disables the anonymous download analytics sent to Software Mansion.
+ * Analytics are enabled by default; call `setTelemetryEnabled(false)` (e.g. once
+ * at app startup) to opt out. This does not affect the Hugging Face download
+ * counter, a standard model-download stat that always fires.
+ * @category Utils
+ * @param enabled Whether to send anonymous download analytics.
+ */
+export function setTelemetryEnabled(enabled: boolean): void {
+  telemetryEnabled = enabled;
+}
+
 // Whether the given URL points to a Software Mansion Hugging Face repo.
 function isSwmHuggingFaceRepo(url: URL): boolean {
   return url.host === 'huggingface.co' && url.pathname.startsWith('/software-mansion');
@@ -56,11 +71,13 @@ function getModelNameFromUri(uri: string): string {
 }
 
 /**
- * Sends an anonymous download event to the Software Mansion analytics endpoint.
- * Fire-and-forget; never throws and never blocks the download.
+ * Sends an anonymous download event to the Software Mansion analytics endpoint,
+ * unless the app has opted out via {@link setTelemetryEnabled}. Fire-and-forget;
+ * never throws and never blocks the download.
  * @param uri The URI of the downloaded resource.
  */
 export function triggerDownloadEvent(uri: string): void {
+  if (!telemetryEnabled) return;
   try {
     fetch(DOWNLOAD_EVENT_ENDPOINT, {
       method: 'POST',

--- a/packages/react-native-executorch/src/fetcher/telemetry.ts
+++ b/packages/react-native-executorch/src/fetcher/telemetry.ts
@@ -1,0 +1,79 @@
+import { Platform } from 'react-native';
+
+// Anonymous download analytics endpoint.
+const DOWNLOAD_EVENT_ENDPOINT = 'https://ai.swmansion.com/telemetry/downloads/api/downloads';
+
+// Informational only.
+// TODO: source this from the package version once version handling lands.
+// See https://github.com/software-mansion/react-native-executorch/issues/1291
+const LIB_VERSION = '0.0.0';
+
+/**
+ * Whether the given URL points to a Software Mansion Hugging Face repo.
+ */
+function isSwmHuggingFaceRepo(url: URL): boolean {
+  return url.host === 'huggingface.co' && url.pathname.startsWith('/software-mansion');
+}
+
+/**
+ * Increments the Hugging Face download counter for Software Mansion repos by
+ * issuing a HEAD request to the repo's `config.json`, following HF's
+ * download-stats convention. No-op for any other host.
+ *
+ * See https://huggingface.co/docs/hub/models-download-stats
+ * @param uri The URI of the file being downloaded.
+ */
+export function triggerHuggingFaceDownloadCounter(uri: string): void {
+  try {
+    const url = new URL(uri);
+    if (!isSwmHuggingFaceRepo(url)) return;
+    const base = `${url.protocol}//${url.host}${url.pathname.split('resolve')[0]}`;
+    // Fire-and-forget; its success is irrelevant to the download itself.
+    fetch(`${base}resolve/main/config.json`, { method: 'HEAD' }).catch(() => {});
+  } catch {}
+}
+
+function getCountryCode(): string {
+  try {
+    const locale = Intl.DateTimeFormat().resolvedOptions().locale;
+    const region = locale.split('-').pop();
+    if (region && region.length === 2) return region.toUpperCase();
+  } catch {}
+  return 'UNKNOWN';
+}
+
+// Set by the native layer when running on a simulator/emulator, so dev traffic
+// can be filtered out server-side. Absent (⇒ false) until then.
+function isEmulator(): boolean {
+  return (globalThis as { __rne_isEmulator?: boolean }).__rne_isEmulator === true;
+}
+
+function getModelNameFromUri(uri: string): string {
+  try {
+    const filename = new URL(uri).pathname.split('/').pop() ?? uri;
+    return filename.replace(/\.[^.]+$/, '');
+  } catch {
+    return uri;
+  }
+}
+
+/**
+ * Sends an anonymous download event to the Software Mansion analytics endpoint.
+ * Fire-and-forget; never throws and never blocks the download.
+ * @param uri The URI of the downloaded resource.
+ */
+export function triggerDownloadEvent(uri: string): void {
+  try {
+    fetch(DOWNLOAD_EVENT_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        modelName: getModelNameFromUri(uri),
+        countryCode: getCountryCode(),
+        isEmulator: isEmulator(),
+        platform: Platform.OS,
+        libVersion: LIB_VERSION,
+      }),
+    }).catch(() => {});
+  } catch {}
+}

--- a/packages/react-native-executorch/src/fetcher/telemetry.ts
+++ b/packages/react-native-executorch/src/fetcher/telemetry.ts
@@ -1,4 +1,5 @@
 import { Platform } from 'react-native';
+import { rnexecutorchJsi } from '../native/bridge';
 
 // Anonymous download analytics endpoint.
 const DOWNLOAD_EVENT_ENDPOINT = 'https://ai.swmansion.com/telemetry/downloads/api/downloads';
@@ -55,10 +56,10 @@ function getCountryCode(): string {
   return 'UNKNOWN';
 }
 
-// Set by the native layer when running on a simulator/emulator, so dev traffic
-// can be filtered out server-side. Absent (⇒ false) until then.
+// Reported by the native installer (Android build props / TARGET_OS_SIMULATOR)
+// so development traffic can be filtered out server-side.
 function isEmulator(): boolean {
-  return (globalThis as { __rne_isEmulator?: boolean }).__rne_isEmulator === true;
+  return rnexecutorchJsi.isEmulator === true;
 }
 
 function getModelNameFromUri(uri: string): string {

--- a/packages/react-native-executorch/src/fetcher/telemetry.ts
+++ b/packages/react-native-executorch/src/fetcher/telemetry.ts
@@ -58,11 +58,25 @@ export function triggerHuggingFaceDownloadCounter(uri: string): void {
   }
 }
 
+// Extracts the region from the device locale, or 'UNKNOWN' when it carries
+// none. Taking the last subtag would misread a language-only locale as a
+// region: 'de' would report DE, 'uk' would report UK (which most maps draw as
+// the United Kingdom) and 'sv' would report SV, El Salvador. Dropping the
+// language subtag up front makes those report UNKNOWN, which is filterable,
+// rather than a plausible-looking country that is simply wrong.
 function getCountryCode(): string {
   try {
     const locale = Intl.DateTimeFormat().resolvedOptions().locale;
-    const region = locale.split('-').pop();
-    if (region && region.length === 2) return region.toUpperCase();
+    const [, ...subtags] = locale.split('-');
+    for (const subtag of subtags) {
+      // A singleton ('u', 'x', ...) opens the extension section, e.g. the
+      // '-u-ca-gregory' in 'de-DE-u-ca-gregory'. No region subtag past here.
+      if (subtag.length === 1) break;
+      // In BCP 47 a two-letter subtag after the language is always the region,
+      // and a three-digit one is a UN M.49 area such as '419' (Latin America).
+      if (/^[a-z]{2}$/i.test(subtag)) return subtag.toUpperCase();
+      if (/^\d{3}$/.test(subtag)) return subtag;
+    }
   } catch (e) {
     warn('Failed to resolve the country code', e);
   }

--- a/packages/react-native-executorch/src/hooks/useClassifier.ts
+++ b/packages/react-native-executorch/src/hooks/useClassifier.ts
@@ -23,7 +23,7 @@ export function useClassifier<L>(config: ClassifierModel<L>, options?: { prevent
     config,
     options?.preventLoad
   );
-  const { model, error } = useModel(createClassifier<L>, resource ?? null, [resource]);
+  const { model, error } = useModel(createClassifier<L>, resource ?? null);
 
   return {
     isReady: !!model,

--- a/packages/react-native-executorch/src/hooks/useClassifier.ts
+++ b/packages/react-native-executorch/src/hooks/useClassifier.ts
@@ -19,21 +19,17 @@ import { createClassifier, type ClassifierModel } from '../extensions/cv/tasks/c
  * progress, and classification functions.
  */
 export function useClassifier<L>(config: ClassifierModel<L>, options?: { preventLoad?: boolean }) {
-  const { localPath, downloadProgress, downloadError } = useResourceDownload(
-    config.modelPath,
+  const { resource, downloadProgress, downloadError } = useResourceDownload(
+    config,
     options?.preventLoad
   );
-  const { model, error } = useModel(
-    createClassifier<L>,
-    localPath ? { ...config, modelPath: localPath } : null,
-    [localPath]
-  );
+  const { model, error } = useModel(createClassifier<L>, resource ?? null, [resource]);
 
   return {
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath,
+    localPath: resource?.modelPath,
     labels: config.modelOpts.labels,
     classify: model?.classify,
     classifyWorklet: model?.classifyWorklet,

--- a/packages/react-native-executorch/src/hooks/useClassifier.ts
+++ b/packages/react-native-executorch/src/hooks/useClassifier.ts
@@ -1,5 +1,5 @@
 import { useModel } from './useModel';
-import { useResourceDownload } from './useResourceDownload';
+import { useResourceDownload, type ResourceOptions } from './useResourceDownload';
 import { createClassifier, type ClassifierModel } from '../extensions/cv/tasks/classification';
 
 /**
@@ -12,17 +12,12 @@ import { createClassifier, type ClassifierModel } from '../extensions/cv/tasks/c
  * @category Hooks
  * @typeParam L The type representing the classification labels.
  * @param config The image classification model configuration.
- * @param options Hook options.
- * @param options.preventLoad If true, prevents downloading and compiling the
- * model.
+ * @param options Load and caching options. See {@link ResourceOptions}.
  * @returns An object containing the model's loading state, error, download
  * progress, and classification functions.
  */
-export function useClassifier<L>(config: ClassifierModel<L>, options?: { preventLoad?: boolean }) {
-  const { resource, downloadProgress, downloadError } = useResourceDownload(
-    config,
-    options?.preventLoad
-  );
+export function useClassifier<L>(config: ClassifierModel<L>, options?: ResourceOptions) {
+  const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);
   const { model, error } = useModel(createClassifier<L>, resource ?? null);
 
   return {

--- a/packages/react-native-executorch/src/hooks/useClassifier.ts
+++ b/packages/react-native-executorch/src/hooks/useClassifier.ts
@@ -29,7 +29,7 @@ export function useClassifier<L>(config: ClassifierModel<L>, options?: { prevent
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath: resource?.modelPath,
+    resource,
     labels: config.modelOpts.labels,
     classify: model?.classify,
     classifyWorklet: model?.classifyWorklet,

--- a/packages/react-native-executorch/src/hooks/useImageEmbedder.ts
+++ b/packages/react-native-executorch/src/hooks/useImageEmbedder.ts
@@ -31,7 +31,7 @@ export function useImageEmbedder(config: ImageEmbedderModel, options?: { prevent
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath: resource?.modelPath,
+    resource,
     embed: model?.embed,
     embedWorklet: model?.embedWorklet,
   };

--- a/packages/react-native-executorch/src/hooks/useImageEmbedder.ts
+++ b/packages/react-native-executorch/src/hooks/useImageEmbedder.ts
@@ -21,21 +21,17 @@ import {
  * progress, and embedding functions.
  */
 export function useImageEmbedder(config: ImageEmbedderModel, options?: { preventLoad?: boolean }) {
-  const { localPath, downloadProgress, downloadError } = useResourceDownload(
-    config.modelPath,
+  const { resource, downloadProgress, downloadError } = useResourceDownload(
+    config,
     options?.preventLoad
   );
-  const { model, error } = useModel(
-    createImageEmbedder,
-    localPath ? { ...config, modelPath: localPath } : null,
-    [localPath]
-  );
+  const { model, error } = useModel(createImageEmbedder, resource ?? null, [resource]);
 
   return {
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath,
+    localPath: resource?.modelPath,
     embed: model?.embed,
     embedWorklet: model?.embedWorklet,
   };

--- a/packages/react-native-executorch/src/hooks/useImageEmbedder.ts
+++ b/packages/react-native-executorch/src/hooks/useImageEmbedder.ts
@@ -25,7 +25,7 @@ export function useImageEmbedder(config: ImageEmbedderModel, options?: { prevent
     config,
     options?.preventLoad
   );
-  const { model, error } = useModel(createImageEmbedder, resource ?? null, [resource]);
+  const { model, error } = useModel(createImageEmbedder, resource ?? null);
 
   return {
     isReady: !!model,

--- a/packages/react-native-executorch/src/hooks/useImageEmbedder.ts
+++ b/packages/react-native-executorch/src/hooks/useImageEmbedder.ts
@@ -1,5 +1,5 @@
 import { useModel } from './useModel';
-import { useResourceDownload } from './useResourceDownload';
+import { useResourceDownload, type ResourceOptions } from './useResourceDownload';
 import {
   createImageEmbedder,
   type ImageEmbedderModel,
@@ -14,17 +14,12 @@ import {
  * changes.
  * @category Hooks
  * @param config The image embedder model configuration.
- * @param options Hook options.
- * @param options.preventLoad If true, prevents downloading and compiling the
- * model.
+ * @param options Load and caching options. See {@link ResourceOptions}.
  * @returns An object containing the model's loading state, error, download
  * progress, and embedding functions.
  */
-export function useImageEmbedder(config: ImageEmbedderModel, options?: { preventLoad?: boolean }) {
-  const { resource, downloadProgress, downloadError } = useResourceDownload(
-    config,
-    options?.preventLoad
-  );
+export function useImageEmbedder(config: ImageEmbedderModel, options?: ResourceOptions) {
+  const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);
   const { model, error } = useModel(createImageEmbedder, resource ?? null);
 
   return {

--- a/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
+++ b/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
@@ -31,7 +31,7 @@ export function useInstanceSegmenter<F extends BoxFormat, L>(
     config,
     options?.preventLoad
   );
-  const { model, error } = useModel(createInstanceSegmenter<F, L>, resource ?? null, [resource]);
+  const { model, error } = useModel(createInstanceSegmenter<F, L>, resource ?? null);
 
   return {
     isReady: !!model,

--- a/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
+++ b/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
@@ -1,5 +1,5 @@
 import { useModel } from './useModel';
-import { useResourceDownload } from './useResourceDownload';
+import { useResourceDownload, type ResourceOptions } from './useResourceDownload';
 import {
   createInstanceSegmenter,
   type InstanceSegmenterModel,
@@ -17,20 +17,15 @@ import {
  * @typeParam F The bounding box format.
  * @typeParam L The class labels type.
  * @param config The instance segmentation model configuration.
- * @param options Hook options.
- * @param options.preventLoad If true, prevents downloading and compiling the
- * model.
+ * @param options Load and caching options. See {@link ResourceOptions}.
  * @returns An object containing the model's loading state, error, download
  * progress, and segmentation functions.
  */
 export function useInstanceSegmenter<F extends BoxFormat, L>(
   config: InstanceSegmenterModel<F, L>,
-  options?: { preventLoad?: boolean }
+  options?: ResourceOptions
 ) {
-  const { resource, downloadProgress, downloadError } = useResourceDownload(
-    config,
-    options?.preventLoad
-  );
+  const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);
   const { model, error } = useModel(createInstanceSegmenter<F, L>, resource ?? null);
 
   return {

--- a/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
+++ b/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
@@ -27,21 +27,17 @@ export function useInstanceSegmenter<F extends BoxFormat, L>(
   config: InstanceSegmenterModel<F, L>,
   options?: { preventLoad?: boolean }
 ) {
-  const { localPath, downloadProgress, downloadError } = useResourceDownload(
-    config.modelPath,
+  const { resource, downloadProgress, downloadError } = useResourceDownload(
+    config,
     options?.preventLoad
   );
-  const { model, error } = useModel(
-    createInstanceSegmenter<F, L>,
-    localPath ? { ...config, modelPath: localPath } : null,
-    [localPath]
-  );
+  const { model, error } = useModel(createInstanceSegmenter<F, L>, resource ?? null, [resource]);
 
   return {
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath,
+    localPath: resource?.modelPath,
     segmentInstances: model?.segmentInstances,
     segmentInstancesWorklet: model?.segmentInstancesWorklet,
     labels: config.modelOpts.labels,

--- a/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
+++ b/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
@@ -37,7 +37,7 @@ export function useInstanceSegmenter<F extends BoxFormat, L>(
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath: resource?.modelPath,
+    resource,
     segmentInstances: model?.segmentInstances,
     segmentInstancesWorklet: model?.segmentInstancesWorklet,
     labels: config.modelOpts.labels,

--- a/packages/react-native-executorch/src/hooks/useKeypointDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useKeypointDetector.ts
@@ -37,7 +37,7 @@ export function useKeypointDetector<F extends BoxFormat, L extends PropertyKey>(
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath: resource?.modelPath,
+    resource,
     landmarks: config.modelOpts.landmarks,
     detectKeypoints: model?.detectKeypoints,
     detectKeypointsWorklet: model?.detectKeypointsWorklet,

--- a/packages/react-native-executorch/src/hooks/useKeypointDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useKeypointDetector.ts
@@ -31,7 +31,7 @@ export function useKeypointDetector<F extends BoxFormat, L extends PropertyKey>(
     config,
     options?.preventLoad
   );
-  const { model, error } = useModel(createKeypointDetector<F, L>, resource ?? null, [resource]);
+  const { model, error } = useModel(createKeypointDetector<F, L>, resource ?? null);
 
   return {
     isReady: !!model,

--- a/packages/react-native-executorch/src/hooks/useKeypointDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useKeypointDetector.ts
@@ -27,21 +27,17 @@ export function useKeypointDetector<F extends BoxFormat, L extends PropertyKey>(
   config: KeypointDetectorModel<F, L>,
   options?: { preventLoad?: boolean }
 ) {
-  const { localPath, downloadProgress, downloadError } = useResourceDownload(
-    config.modelPath,
+  const { resource, downloadProgress, downloadError } = useResourceDownload(
+    config,
     options?.preventLoad
   );
-  const { model, error } = useModel(
-    createKeypointDetector<F, L>,
-    localPath ? { ...config, modelPath: localPath } : null,
-    [localPath]
-  );
+  const { model, error } = useModel(createKeypointDetector<F, L>, resource ?? null, [resource]);
 
   return {
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath,
+    localPath: resource?.modelPath,
     landmarks: config.modelOpts.landmarks,
     detectKeypoints: model?.detectKeypoints,
     detectKeypointsWorklet: model?.detectKeypointsWorklet,

--- a/packages/react-native-executorch/src/hooks/useKeypointDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useKeypointDetector.ts
@@ -1,5 +1,5 @@
 import { useModel } from './useModel';
-import { useResourceDownload } from './useResourceDownload';
+import { useResourceDownload, type ResourceOptions } from './useResourceDownload';
 import {
   createKeypointDetector,
   type KeypointDetectorModel,
@@ -17,20 +17,15 @@ import {
  * @typeParam F The bounding box format.
  * @typeParam L The landmark labels type.
  * @param config The keypoint detection model configuration.
- * @param options Hook options.
- * @param options.preventLoad If true, prevents downloading and compiling the
- * model.
+ * @param options Load and caching options. See {@link ResourceOptions}.
  * @returns An object containing the model's loading state, error, download
  * progress, and keypoint detection functions.
  */
 export function useKeypointDetector<F extends BoxFormat, L extends PropertyKey>(
   config: KeypointDetectorModel<F, L>,
-  options?: { preventLoad?: boolean }
+  options?: ResourceOptions
 ) {
-  const { resource, downloadProgress, downloadError } = useResourceDownload(
-    config,
-    options?.preventLoad
-  );
+  const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);
   const { model, error } = useModel(createKeypointDetector<F, L>, resource ?? null);
 
   return {

--- a/packages/react-native-executorch/src/hooks/useModel.ts
+++ b/packages/react-native-executorch/src/hooks/useModel.ts
@@ -14,15 +14,15 @@ import { useEffect, useState } from 'react';
  * @param createModel An asynchronous factory function to instantiate the
  * model/task.
  * @param config The configuration to pass to `createModel`, or `null` if the
- * model shouldn't be loaded yet.
- * @param deps Dependency array specifying when to re-create the model.
+ * model shouldn't be loaded yet. The model is re-created whenever this
+ * reference changes, so pass a value that is stable across renders (for
+ * instance the `resource` returned by {@link useResourceDownload}).
  * @returns An object containing the loaded model instance and any instantiation
  * error.
  */
 export function useModel<TConfig, TModel extends { dispose: () => void }>(
   createModel: (config: TConfig) => Promise<TModel>,
-  config: TConfig | null,
-  deps: React.DependencyList
+  config: TConfig | null
 ) {
   const [model, setModel] = useState<TModel | null>(null);
   const [error, setError] = useState<Error | null>(null);
@@ -56,8 +56,10 @@ export function useModel<TConfig, TModel extends { dispose: () => void }>(
       isMounted = false;
       instance?.dispose();
     };
+    // `createModel` is a module-level factory, so `config` alone decides when
+    // the instance has to be rebuilt.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, deps);
+  }, [config]);
 
   return { model, error };
 }

--- a/packages/react-native-executorch/src/hooks/useModel.ts
+++ b/packages/react-native-executorch/src/hooks/useModel.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 /**
  * React hook to instantiate and compile a model pipeline with automatic
@@ -14,9 +14,9 @@ import { useEffect, useState } from 'react';
  * @param createModel An asynchronous factory function to instantiate the
  * model/task.
  * @param config The configuration to pass to `createModel`, or `null` if the
- * model shouldn't be loaded yet. The model is re-created whenever this
- * reference changes, so pass a value that is stable across renders (for
- * instance the `resource` returned by {@link useResourceDownload}).
+ * model shouldn't be loaded yet. It is tracked by value, so the model is
+ * re-created whenever the config's contents change and passing an inline object
+ * is safe.
  * @returns An object containing the loaded model instance and any instantiation
  * error.
  */
@@ -26,6 +26,10 @@ export function useModel<TConfig, TModel extends { dispose: () => void }>(
 ) {
   const [model, setModel] = useState<TModel | null>(null);
   const [error, setError] = useState<Error | null>(null);
+
+  // Configs are plain JSON data, so serializing is a sound structural identity
+  // and keeps an inline `config` object from rebuilding the model every render.
+  const configKey = useMemo(() => JSON.stringify(config), [config]);
 
   useEffect(() => {
     if (!config) {
@@ -56,10 +60,10 @@ export function useModel<TConfig, TModel extends { dispose: () => void }>(
       isMounted = false;
       instance?.dispose();
     };
-    // `createModel` is a module-level factory, so `config` alone decides when
-    // the instance has to be rebuilt.
+    // `createModel` is a module-level factory, so the config alone decides when
+    // the instance has to be rebuilt, and it is tracked by value via `configKey`.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [config]);
+  }, [configKey]);
 
   return { model, error };
 }

--- a/packages/react-native-executorch/src/hooks/useObjectDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useObjectDetector.ts
@@ -31,7 +31,7 @@ export function useObjectDetector<F extends BoxFormat, L>(
     config,
     options?.preventLoad
   );
-  const { model, error } = useModel(createObjectDetector<F, L>, resource ?? null, [resource]);
+  const { model, error } = useModel(createObjectDetector<F, L>, resource ?? null);
 
   return {
     isReady: !!model,

--- a/packages/react-native-executorch/src/hooks/useObjectDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useObjectDetector.ts
@@ -1,5 +1,5 @@
 import { useModel } from './useModel';
-import { useResourceDownload } from './useResourceDownload';
+import { useResourceDownload, type ResourceOptions } from './useResourceDownload';
 import {
   createObjectDetector,
   type ObjectDetectorModel,
@@ -17,20 +17,15 @@ import {
  * @typeParam L The type representing the object class labels.
  * @typeParam F The bounding box format.
  * @param config The object detection model configuration.
- * @param options Hook options.
- * @param options.preventLoad If true, prevents downloading and compiling the
- * model.
+ * @param options Load and caching options. See {@link ResourceOptions}.
  * @returns An object containing the model's loading state, error, download
  * progress, and object detection functions.
  */
 export function useObjectDetector<F extends BoxFormat, L>(
   config: ObjectDetectorModel<F, L>,
-  options?: { preventLoad?: boolean }
+  options?: ResourceOptions
 ) {
-  const { resource, downloadProgress, downloadError } = useResourceDownload(
-    config,
-    options?.preventLoad
-  );
+  const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);
   const { model, error } = useModel(createObjectDetector<F, L>, resource ?? null);
 
   return {

--- a/packages/react-native-executorch/src/hooks/useObjectDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useObjectDetector.ts
@@ -37,7 +37,7 @@ export function useObjectDetector<F extends BoxFormat, L>(
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath: resource?.modelPath,
+    resource,
     labels: config.modelOpts.labels,
     detectObjects: model?.detectObjects,
     detectObjectsWorklet: model?.detectObjectsWorklet,

--- a/packages/react-native-executorch/src/hooks/useObjectDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useObjectDetector.ts
@@ -27,21 +27,17 @@ export function useObjectDetector<F extends BoxFormat, L>(
   config: ObjectDetectorModel<F, L>,
   options?: { preventLoad?: boolean }
 ) {
-  const { localPath, downloadProgress, downloadError } = useResourceDownload(
-    config.modelPath,
+  const { resource, downloadProgress, downloadError } = useResourceDownload(
+    config,
     options?.preventLoad
   );
-  const { model, error } = useModel(
-    createObjectDetector<F, L>,
-    localPath ? { ...config, modelPath: localPath } : null,
-    [localPath]
-  );
+  const { model, error } = useModel(createObjectDetector<F, L>, resource ?? null, [resource]);
 
   return {
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath,
+    localPath: resource?.modelPath,
     labels: config.modelOpts.labels,
     detectObjects: model?.detectObjects,
     detectObjectsWorklet: model?.detectObjectsWorklet,

--- a/packages/react-native-executorch/src/hooks/useResourceDownload.ts
+++ b/packages/react-native-executorch/src/hooks/useResourceDownload.ts
@@ -1,10 +1,5 @@
-import { useState, useEffect, useMemo, useRef } from 'react';
-import {
-  download,
-  collectRemoteSources,
-  substituteRemoteSources,
-  AbortError,
-} from '../fetcher/fetcher';
+import { useState, useEffect, useMemo } from 'react';
+import { download, AbortError } from '../fetcher/fetcher';
 
 /**
  * React hook to manage downloading and local caching of the remote resources
@@ -18,9 +13,11 @@ import {
  * files, weighted by size, and interrupted downloads resume on the next attempt
  * instead of restarting.
  *
- * `resource` only changes when the set of remote URLs changes; edits to other
- * fields of `config` (labels, thresholds) don't trigger a re-download and are
- * picked up the next time those URLs are re-resolved.
+ * Work is keyed on the *value* of `config` rather than its identity, so passing
+ * an inline object is safe. Any change to the config resolves again, which is
+ * cheap for the files themselves (already-cached URLs are a no-op) but does
+ * rebuild whatever pipeline consumes `resource` — correct, since `create<Task>`
+ * factories bake their options in at construction time.
  * @category Hooks
  * @typeParam T The shape of the value being resolved.
  * @param config The value whose remote URLs should be resolved to local paths.
@@ -30,39 +27,33 @@ import {
  * percentage, and any download error.
  */
 export function useResourceDownload<T>(config: T, preventLoad?: boolean) {
-  const [resolved, setResolved] = useState<ReadonlyMap<string, string>>();
+  const [resource, setResource] = useState<T>();
   const [downloadProgress, setDownloadProgress] = useState(0);
   const [downloadError, setDownloadError] = useState<Error | null>(null);
 
-  // Downloading is keyed purely on the URLs referenced by `config`, so passing
-  // an inline config object doesn't restart the download on every render.
-  const sourcesKey = useMemo(() => [...collectRemoteSources(config)].sort().join('\n'), [config]);
-
-  // Read at substitution time only, so unrelated config edits don't re-download.
-  const configRef = useRef(config);
-  configRef.current = config;
+  // Configs are plain JSON data, so serializing is a sound structural identity
+  // and keeps an inline `config` object from re-running the effect every render.
+  const configKey = useMemo(() => JSON.stringify(config), [config]);
 
   useEffect(() => {
-    setResolved(undefined);
+    setResource(undefined);
     setDownloadProgress(0);
     setDownloadError(null);
 
     if (preventLoad) return;
 
-    const urls = sourcesKey ? sourcesKey.split('\n') : [];
-
     let isMounted = true;
     const controller = new AbortController();
 
-    download(urls, {
+    download(config, {
       signal: controller.signal,
       onProgress: (progress) => {
         if (isMounted) setDownloadProgress(progress * 100);
       },
     })
-      .then((paths) => {
+      .then((resolved) => {
         if (!isMounted) return;
-        setResolved(new Map(urls.map((url, i) => [url, paths[i]!])));
+        setResource(resolved);
         setDownloadProgress(100);
       })
       .catch((e) => {
@@ -74,12 +65,9 @@ export function useResourceDownload<T>(config: T, preventLoad?: boolean) {
       isMounted = false;
       controller.abort();
     };
-  }, [sourcesKey, preventLoad]);
-
-  const resource = useMemo(
-    () => (resolved ? substituteRemoteSources(configRef.current, resolved) : undefined),
-    [resolved]
-  );
+    // `config` is intentionally tracked by value through `configKey`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [configKey, preventLoad]);
 
   return { resource, downloadProgress, downloadError };
 }

--- a/packages/react-native-executorch/src/hooks/useResourceDownload.ts
+++ b/packages/react-native-executorch/src/hooks/useResourceDownload.ts
@@ -2,6 +2,22 @@ import { useState, useEffect, useMemo } from 'react';
 import { download, AbortError } from '../fetcher/fetcher';
 
 /**
+ * Options accepted by {@link useResourceDownload} and by every `use<Task>` hook
+ * built on top of it.
+ * @category Types
+ */
+export interface ResourceOptions {
+  /** If true, prevents checks and downloads, resetting the hook state. */
+  preventLoad?: boolean;
+  /**
+   * Re-downloads every remote source even when it is already cached, replacing
+   * the cached copy. Use to recover from a corrupted file or to pick up a model
+   * that changed behind a stable URL.
+   */
+  forceDownload?: boolean;
+}
+
+/**
  * React hook to manage downloading and local caching of the remote resources
  * (e.g. `.pte` models) referenced by a value.
  *
@@ -21,12 +37,13 @@ import { download, AbortError } from '../fetcher/fetcher';
  * @category Hooks
  * @typeParam T The shape of the value being resolved.
  * @param config The value whose remote URLs should be resolved to local paths.
- * @param preventLoad If true, prevents checks and downloads, resetting the hook
- * state.
+ * @param options Load and caching options. See {@link ResourceOptions}.
  * @returns An object containing the resolved value, the download progress
  * percentage, and any download error.
  */
-export function useResourceDownload<T>(config: T, preventLoad?: boolean) {
+export function useResourceDownload<T>(config: T, options?: ResourceOptions) {
+  const { preventLoad, forceDownload } = options ?? {};
+
   const [resource, setResource] = useState<T>();
   const [downloadProgress, setDownloadProgress] = useState(0);
   const [downloadError, setDownloadError] = useState<Error | null>(null);
@@ -47,6 +64,7 @@ export function useResourceDownload<T>(config: T, preventLoad?: boolean) {
 
     download(config, {
       signal: controller.signal,
+      forceDownload,
       onProgress: (progress) => {
         if (isMounted) setDownloadProgress(progress * 100);
       },
@@ -67,7 +85,7 @@ export function useResourceDownload<T>(config: T, preventLoad?: boolean) {
     };
     // `config` is intentionally tracked by value through `configKey`.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [configKey, preventLoad]);
+  }, [configKey, preventLoad, forceDownload]);
 
   return { resource, downloadProgress, downloadError };
 }

--- a/packages/react-native-executorch/src/hooks/useResourceDownload.ts
+++ b/packages/react-native-executorch/src/hooks/useResourceDownload.ts
@@ -1,14 +1,5 @@
-/* eslint-disable no-bitwise */
 import { useState, useEffect } from 'react';
-import RNFS from 'react-native-fs';
-
-const djb2 = (s: string): number => {
-  let h = 5381;
-  for (let i = 0; i < s.length; i++) {
-    h = (((h << 5) + h) ^ s.charCodeAt(i)) >>> 0;
-  }
-  return h;
-};
+import { download } from '../fetcher';
 
 /**
  * React hook to manage downloading and local caching of remote resources (e.g.
@@ -16,12 +7,11 @@ const djb2 = (s: string): number => {
  *
  * If the source is a remote URL starting with `http`, the hook checks the local
  * filesystem cache for a matching file. If cached, it immediately returns the
- * local file path. If not cached, it starts downloading the file to the
- * application cache directory, reporting download progress (0-100) and any
- * network/disk errors.
+ * local file path. If not cached, it downloads the file into the persistent
+ * resource cache, reporting download progress (0-100) and any network/disk
+ * errors. Interrupted downloads resume on the next attempt instead of
+ * restarting.
  * @category Hooks
- * @experimental Subject to change once the temporary react-native-fs dependency is replaced.
- * See [Issue #1253](https://github.com/software-mansion/react-native-executorch/issues/1253).
  * @param source The remote URL or local path to the resource. If it's already a
  * local path, it is returned immediately as is.
  * @param preventLoad If true, prevents checks and downloads, resetting the hook
@@ -46,63 +36,29 @@ export function useResourceDownload(source?: string, preventLoad?: boolean) {
       return;
     }
 
-    if (!source.startsWith('http')) {
-      setLocalPath(source);
-      setDownloadProgress(100);
-      return;
-    }
-
     let isMounted = true;
-    const urlWithoutQuery = source.split('?')[0]!;
-    const basename = urlWithoutQuery.split('/').pop() ?? 'model';
-    const dest = `${RNFS.CachesDirectoryPath}/${djb2(urlWithoutQuery)}_${basename}`;
-    const uid = `${Date.now()}_${Math.random().toString(36).slice(2)}`;
-    const tmp = `${dest}.${uid}.partial`;
+    const controller = new AbortController();
 
-    RNFS.exists(dest).then((exists) => {
-      if (!isMounted) return;
-
-      if (exists) {
-        setLocalPath(dest);
-        setDownloadProgress(100);
-        return;
-      }
-
-      RNFS.downloadFile({
-        fromUrl: source,
-        toFile: tmp,
-        progressInterval: 100,
-        begin: () => {
-          if (isMounted) setDownloadProgress(0);
-        },
-        progress: (r: any) => {
-          if (isMounted)
-            setDownloadProgress(r.contentLength > 0 ? (r.bytesWritten / r.contentLength) * 100 : 0);
-        },
+    download(source, {
+      signal: controller.signal,
+      onProgress: (progress) => {
+        if (isMounted) setDownloadProgress(progress * 100);
+      },
+    })
+      .then((path) => {
+        if (isMounted) {
+          setLocalPath(path);
+          setDownloadProgress(100);
+        }
       })
-        .promise.then(async (res) => {
-          if (res.statusCode && res.statusCode >= 400) {
-            throw new Error(`Download failed with HTTP status ${res.statusCode}`);
-          }
-          try {
-            await RNFS.moveFile(tmp, dest);
-          } catch (err) {
-            if (!(await RNFS.exists(dest))) throw err;
-            await RNFS.unlink(tmp).catch(() => {});
-          }
-          if (isMounted) {
-            setLocalPath(dest);
-            setDownloadProgress(100);
-          }
-        })
-        .catch((e) => {
-          RNFS.unlink(tmp).catch(() => {});
-          if (isMounted) setDownloadError(e instanceof Error ? e : new Error(String(e)));
-        });
-    });
+      .catch((e) => {
+        if (!isMounted || e?.name === 'AbortError') return;
+        setDownloadError(e instanceof Error ? e : new Error(String(e)));
+      });
 
     return () => {
       isMounted = false;
+      controller.abort();
     };
   }, [source, preventLoad]);
 

--- a/packages/react-native-executorch/src/hooks/useResourceDownload.ts
+++ b/packages/react-native-executorch/src/hooks/useResourceDownload.ts
@@ -1,55 +1,64 @@
-import { useState, useEffect } from 'react';
-import { download } from '../fetcher';
+import { useState, useEffect, useMemo, useRef } from 'react';
+import { download, collectRemoteSources, substituteRemoteSources } from '../fetcher/fetcher';
 
 /**
- * React hook to manage downloading and local caching of remote resources (e.g.
- * `.pte` models).
+ * React hook to manage downloading and local caching of the remote resources
+ * (e.g. `.pte` models) referenced by a value.
  *
- * If the source is a remote URL starting with `http`, the hook checks the local
- * filesystem cache for a matching file. If cached, it immediately returns the
- * local file path. If not cached, it downloads the file into the persistent
- * resource cache, reporting download progress (0-100) and any network/disk
- * errors. Interrupted downloads resume on the next attempt instead of
- * restarting.
+ * `config` may be a single URL or any nested object/array holding them —
+ * typically a whole model config. Every remote URL found inside is downloaded
+ * into the persistent resource cache (cache hits resolve immediately) and
+ * replaced by its local path, so `resource` mirrors `config` exactly and can be
+ * passed straight to a `create<Task>` factory. Progress is reported across all
+ * files, weighted by size, and interrupted downloads resume on the next attempt
+ * instead of restarting.
+ *
+ * `resource` only changes when the set of remote URLs changes; edits to other
+ * fields of `config` (labels, thresholds) don't trigger a re-download and are
+ * picked up the next time those URLs are re-resolved.
  * @category Hooks
- * @param source The remote URL or local path to the resource. If it's already a
- * local path, it is returned immediately as is.
+ * @typeParam T The shape of the value being resolved.
+ * @param config The value whose remote URLs should be resolved to local paths.
  * @param preventLoad If true, prevents checks and downloads, resetting the hook
  * state.
- * @returns An object containing the local file path, the download progress
+ * @returns An object containing the resolved value, the download progress
  * percentage, and any download error.
  */
-export function useResourceDownload(source?: string, preventLoad?: boolean) {
-  const [localPath, setLocalPath] = useState<string>();
+export function useResourceDownload<T>(config: T, preventLoad?: boolean) {
+  const [resolved, setResolved] = useState<ReadonlyMap<string, string>>();
   const [downloadProgress, setDownloadProgress] = useState(0);
   const [downloadError, setDownloadError] = useState<Error | null>(null);
 
+  // Downloading is keyed purely on the URLs referenced by `config`, so passing
+  // an inline config object doesn't restart the download on every render.
+  const sourcesKey = useMemo(() => [...collectRemoteSources(config)].sort().join('\n'), [config]);
+
+  // Read at substitution time only, so unrelated config edits don't re-download.
+  const configRef = useRef(config);
+  configRef.current = config;
+
   useEffect(() => {
-    setLocalPath(undefined);
+    setResolved(undefined);
     setDownloadProgress(0);
     setDownloadError(null);
 
     if (preventLoad) return;
 
-    if (!source) {
-      setDownloadProgress(100);
-      return;
-    }
+    const urls = sourcesKey ? sourcesKey.split('\n') : [];
 
     let isMounted = true;
     const controller = new AbortController();
 
-    download(source, {
+    download(urls, {
       signal: controller.signal,
       onProgress: (progress) => {
         if (isMounted) setDownloadProgress(progress * 100);
       },
     })
-      .then((path) => {
-        if (isMounted) {
-          setLocalPath(path);
-          setDownloadProgress(100);
-        }
+      .then((paths) => {
+        if (!isMounted) return;
+        setResolved(new Map(urls.map((url, i) => [url, paths[i]!])));
+        setDownloadProgress(100);
       })
       .catch((e) => {
         if (!isMounted || e?.name === 'AbortError') return;
@@ -60,7 +69,12 @@ export function useResourceDownload(source?: string, preventLoad?: boolean) {
       isMounted = false;
       controller.abort();
     };
-  }, [source, preventLoad]);
+  }, [sourcesKey, preventLoad]);
 
-  return { localPath, downloadProgress, downloadError };
+  const resource = useMemo(
+    () => (resolved ? substituteRemoteSources(configRef.current, resolved) : undefined),
+    [resolved]
+  );
+
+  return { resource, downloadProgress, downloadError };
 }

--- a/packages/react-native-executorch/src/hooks/useResourceDownload.ts
+++ b/packages/react-native-executorch/src/hooks/useResourceDownload.ts
@@ -1,5 +1,10 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { download, collectRemoteSources, substituteRemoteSources } from '../fetcher/fetcher';
+import {
+  download,
+  collectRemoteSources,
+  substituteRemoteSources,
+  AbortError,
+} from '../fetcher/fetcher';
 
 /**
  * React hook to manage downloading and local caching of the remote resources
@@ -61,7 +66,7 @@ export function useResourceDownload<T>(config: T, preventLoad?: boolean) {
         setDownloadProgress(100);
       })
       .catch((e) => {
-        if (!isMounted || e?.name === 'AbortError') return;
+        if (!isMounted || e instanceof AbortError) return;
         setDownloadError(e instanceof Error ? e : new Error(String(e)));
       });
 

--- a/packages/react-native-executorch/src/hooks/useSemanticSegmenter.ts
+++ b/packages/react-native-executorch/src/hooks/useSemanticSegmenter.ts
@@ -29,7 +29,7 @@ export function useSemanticSegmenter<L extends PropertyKey = string>(
     config,
     options?.preventLoad
   );
-  const { model, error } = useModel(createSemanticSegmenter<L>, resource ?? null, [resource]);
+  const { model, error } = useModel(createSemanticSegmenter<L>, resource ?? null);
 
   return {
     isReady: !!model,

--- a/packages/react-native-executorch/src/hooks/useSemanticSegmenter.ts
+++ b/packages/react-native-executorch/src/hooks/useSemanticSegmenter.ts
@@ -35,7 +35,7 @@ export function useSemanticSegmenter<L extends PropertyKey = string>(
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath: resource?.modelPath,
+    resource,
     segment: model?.segment,
     segmentWorklet: model?.segmentWorklet,
     labels: config.modelOpts.labels,

--- a/packages/react-native-executorch/src/hooks/useSemanticSegmenter.ts
+++ b/packages/react-native-executorch/src/hooks/useSemanticSegmenter.ts
@@ -1,5 +1,5 @@
 import { useModel } from './useModel';
-import { useResourceDownload } from './useResourceDownload';
+import { useResourceDownload, type ResourceOptions } from './useResourceDownload';
 import {
   createSemanticSegmenter,
   type SemanticSegmenterModel,
@@ -15,20 +15,15 @@ import {
  * @category Hooks
  * @typeParam L The type representing the segmentation labels.
  * @param config The semantic segmentation model configuration.
- * @param options Hook options.
- * @param options.preventLoad If true, prevents downloading and compiling the
- * model.
+ * @param options Load and caching options. See {@link ResourceOptions}.
  * @returns An object containing the model's loading state, error, download
  * progress, and segmentation functions.
  */
 export function useSemanticSegmenter<L extends PropertyKey = string>(
   config: SemanticSegmenterModel<L>,
-  options?: { preventLoad?: boolean }
+  options?: ResourceOptions
 ) {
-  const { resource, downloadProgress, downloadError } = useResourceDownload(
-    config,
-    options?.preventLoad
-  );
+  const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);
   const { model, error } = useModel(createSemanticSegmenter<L>, resource ?? null);
 
   return {

--- a/packages/react-native-executorch/src/hooks/useSemanticSegmenter.ts
+++ b/packages/react-native-executorch/src/hooks/useSemanticSegmenter.ts
@@ -25,21 +25,17 @@ export function useSemanticSegmenter<L extends PropertyKey = string>(
   config: SemanticSegmenterModel<L>,
   options?: { preventLoad?: boolean }
 ) {
-  const { localPath, downloadProgress, downloadError } = useResourceDownload(
-    config.modelPath,
+  const { resource, downloadProgress, downloadError } = useResourceDownload(
+    config,
     options?.preventLoad
   );
-  const { model, error } = useModel(
-    createSemanticSegmenter<L>,
-    localPath ? { ...config, modelPath: localPath } : null,
-    [localPath]
-  );
+  const { model, error } = useModel(createSemanticSegmenter<L>, resource ?? null, [resource]);
 
   return {
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath,
+    localPath: resource?.modelPath,
     segment: model?.segment,
     segmentWorklet: model?.segmentWorklet,
     labels: config.modelOpts.labels,

--- a/packages/react-native-executorch/src/hooks/useSpeechToText.ts
+++ b/packages/react-native-executorch/src/hooks/useSpeechToText.ts
@@ -25,42 +25,19 @@ export function useSpeechToText<L extends WhisperLanguage = WhisperLanguage>(
   config: WhisperSttModel<L>,
   options?: { preventLoad?: boolean }
 ) {
-  const vadModelPath = config.vadModel.modelPath;
-  const vadResource = useResourceDownload(vadModelPath, options?.preventLoad);
-  const modelResource = useResourceDownload(config.modelPath, options?.preventLoad);
-  const tokenizerResource = useResourceDownload(config.tokenizerPath, options?.preventLoad);
-
-  const localVadPath = vadResource.localPath;
-  const localModelPath = modelResource.localPath;
-  const localTokenizerPath = tokenizerResource.localPath;
-
-  const isResourcesReady = !!(localModelPath && localTokenizerPath && localVadPath);
-  const whisperConfig = isResourcesReady
-    ? {
-        ...config,
-        modelPath: localModelPath!,
-        tokenizerPath: localTokenizerPath!,
-        vadModel: { ...config.vadModel, modelPath: localVadPath! },
-      }
-    : null;
-
-  const { model, error: modelError } = useModel(createWhisperSpeechToText, whisperConfig, [
-    localVadPath,
-    localModelPath,
-    localTokenizerPath,
-  ]);
-
-  const error =
-    vadResource.downloadError ||
-    modelResource.downloadError ||
-    tokenizerResource.downloadError ||
-    modelError;
+  // Resolves the model, the tokenizer and the nested VAD model in one pass,
+  // with progress weighted across all three.
+  const { resource, downloadProgress, downloadError } = useResourceDownload(
+    config,
+    options?.preventLoad
+  );
+  const { model, error } = useModel(createWhisperSpeechToText, resource ?? null, [resource]);
 
   return {
     isReady: !!model,
-    error,
-    downloadProgress: modelResource.downloadProgress,
-    localPath: modelResource.localPath,
+    error: downloadError || error,
+    downloadProgress,
+    localPath: resource?.modelPath,
     transcribe: model?.transcribe,
     transcribeWorklet: model?.transcribeWorklet,
     transcribeStop: model?.transcribeStop,

--- a/packages/react-native-executorch/src/hooks/useSpeechToText.ts
+++ b/packages/react-native-executorch/src/hooks/useSpeechToText.ts
@@ -31,7 +31,7 @@ export function useSpeechToText<L extends WhisperLanguage = WhisperLanguage>(
     config,
     options?.preventLoad
   );
-  const { model, error } = useModel(createWhisperSpeechToText, resource ?? null, [resource]);
+  const { model, error } = useModel(createWhisperSpeechToText, resource ?? null);
 
   return {
     isReady: !!model,

--- a/packages/react-native-executorch/src/hooks/useSpeechToText.ts
+++ b/packages/react-native-executorch/src/hooks/useSpeechToText.ts
@@ -37,7 +37,7 @@ export function useSpeechToText<L extends WhisperLanguage = WhisperLanguage>(
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath: resource?.modelPath,
+    resource,
     transcribe: model?.transcribe,
     transcribeWorklet: model?.transcribeWorklet,
     transcribeStop: model?.transcribeStop,

--- a/packages/react-native-executorch/src/hooks/useSpeechToText.ts
+++ b/packages/react-native-executorch/src/hooks/useSpeechToText.ts
@@ -1,5 +1,5 @@
 import { useModel } from './useModel';
-import { useResourceDownload } from './useResourceDownload';
+import { useResourceDownload, type ResourceOptions } from './useResourceDownload';
 import {
   createWhisperSpeechToText,
   type WhisperSttModel,
@@ -15,22 +15,17 @@ import {
  * unmounts or configuration changes.
  * @category Hooks
  * @param config The Whisper speech-to-text model configuration.
- * @param options Hook options.
- * @param options.preventLoad If true, prevents downloading and compiling the
- * model.
+ * @param options Load and caching options. See {@link ResourceOptions}.
  * @returns An object containing the model's loading state, error, download
  * progress, and transcription functions.
  */
 export function useSpeechToText<L extends WhisperLanguage = WhisperLanguage>(
   config: WhisperSttModel<L>,
-  options?: { preventLoad?: boolean }
+  options?: ResourceOptions
 ) {
   // Resolves the model, the tokenizer and the nested VAD model in one pass,
   // with progress weighted across all three.
-  const { resource, downloadProgress, downloadError } = useResourceDownload(
-    config,
-    options?.preventLoad
-  );
+  const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);
   const { model, error } = useModel(createWhisperSpeechToText, resource ?? null);
 
   return {

--- a/packages/react-native-executorch/src/hooks/useStyleTransfer.ts
+++ b/packages/react-native-executorch/src/hooks/useStyleTransfer.ts
@@ -18,21 +18,17 @@ import { createStyleTransfer, type StyleTransferModel } from '../extensions/cv/t
  * progress, and style transfer functions.
  */
 export function useStyleTransfer(config: StyleTransferModel, options?: { preventLoad?: boolean }) {
-  const { localPath, downloadProgress, downloadError } = useResourceDownload(
-    config.modelPath,
+  const { resource, downloadProgress, downloadError } = useResourceDownload(
+    config,
     options?.preventLoad
   );
-  const { model, error } = useModel(
-    createStyleTransfer,
-    localPath ? { ...config, modelPath: localPath } : null,
-    [localPath]
-  );
+  const { model, error } = useModel(createStyleTransfer, resource ?? null, [resource]);
 
   return {
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath,
+    localPath: resource?.modelPath,
     transferStyle: model?.transferStyle,
     transferStyleWorklet: model?.transferStyleWorklet,
   };

--- a/packages/react-native-executorch/src/hooks/useStyleTransfer.ts
+++ b/packages/react-native-executorch/src/hooks/useStyleTransfer.ts
@@ -28,7 +28,7 @@ export function useStyleTransfer(config: StyleTransferModel, options?: { prevent
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath: resource?.modelPath,
+    resource,
     transferStyle: model?.transferStyle,
     transferStyleWorklet: model?.transferStyleWorklet,
   };

--- a/packages/react-native-executorch/src/hooks/useStyleTransfer.ts
+++ b/packages/react-native-executorch/src/hooks/useStyleTransfer.ts
@@ -1,5 +1,5 @@
 import { useModel } from './useModel';
-import { useResourceDownload } from './useResourceDownload';
+import { useResourceDownload, type ResourceOptions } from './useResourceDownload';
 import { createStyleTransfer, type StyleTransferModel } from '../extensions/cv/tasks/styleTransfer';
 
 /**
@@ -11,17 +11,12 @@ import { createStyleTransfer, type StyleTransferModel } from '../extensions/cv/t
  * changes.
  * @category Hooks
  * @param config The style transfer model configuration.
- * @param options Hook options.
- * @param options.preventLoad If true, prevents downloading and compiling the
- * model.
+ * @param options Load and caching options. See {@link ResourceOptions}.
  * @returns An object containing the model's loading state, error, download
  * progress, and style transfer functions.
  */
-export function useStyleTransfer(config: StyleTransferModel, options?: { preventLoad?: boolean }) {
-  const { resource, downloadProgress, downloadError } = useResourceDownload(
-    config,
-    options?.preventLoad
-  );
+export function useStyleTransfer(config: StyleTransferModel, options?: ResourceOptions) {
+  const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);
   const { model, error } = useModel(createStyleTransfer, resource ?? null);
 
   return {

--- a/packages/react-native-executorch/src/hooks/useStyleTransfer.ts
+++ b/packages/react-native-executorch/src/hooks/useStyleTransfer.ts
@@ -22,7 +22,7 @@ export function useStyleTransfer(config: StyleTransferModel, options?: { prevent
     config,
     options?.preventLoad
   );
-  const { model, error } = useModel(createStyleTransfer, resource ?? null, [resource]);
+  const { model, error } = useModel(createStyleTransfer, resource ?? null);
 
   return {
     isReady: !!model,

--- a/packages/react-native-executorch/src/hooks/useTextEmbedder.ts
+++ b/packages/react-native-executorch/src/hooks/useTextEmbedder.ts
@@ -1,5 +1,5 @@
 import { useModel } from './useModel';
-import { useResourceDownload } from './useResourceDownload';
+import { useResourceDownload, type ResourceOptions } from './useResourceDownload';
 import { createTextEmbedder, type TextEmbedderModel } from '../extensions/nlp/tasks/textEmbedding';
 
 /**
@@ -12,17 +12,12 @@ import { createTextEmbedder, type TextEmbedderModel } from '../extensions/nlp/ta
  * @category Hooks
  * @param config The text embedder model configuration (model and tokenizer
  * paths).
- * @param options Hook options.
- * @param options.preventLoad If true, prevents downloading and compiling the
- * model.
+ * @param options Load and caching options. See {@link ResourceOptions}.
  * @returns An object containing the model's loading state, error, download
  * progress, and embedding functions.
  */
-export function useTextEmbedder(config: TextEmbedderModel, options?: { preventLoad?: boolean }) {
-  const { resource, downloadProgress, downloadError } = useResourceDownload(
-    config,
-    options?.preventLoad
-  );
+export function useTextEmbedder(config: TextEmbedderModel, options?: ResourceOptions) {
+  const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);
   const { model, error } = useModel(createTextEmbedder, resource ?? null);
 
   return {

--- a/packages/react-native-executorch/src/hooks/useTextEmbedder.ts
+++ b/packages/react-native-executorch/src/hooks/useTextEmbedder.ts
@@ -23,7 +23,7 @@ export function useTextEmbedder(config: TextEmbedderModel, options?: { preventLo
     config,
     options?.preventLoad
   );
-  const { model, error } = useModel(createTextEmbedder, resource ?? null, [resource]);
+  const { model, error } = useModel(createTextEmbedder, resource ?? null);
 
   return {
     isReady: !!model,

--- a/packages/react-native-executorch/src/hooks/useTextEmbedder.ts
+++ b/packages/react-native-executorch/src/hooks/useTextEmbedder.ts
@@ -29,8 +29,7 @@ export function useTextEmbedder(config: TextEmbedderModel, options?: { preventLo
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath: resource?.modelPath,
-    tokenizerPath: resource?.tokenizerPath,
+    resource,
     embed: model?.embed,
     embedWorklet: model?.embedWorklet,
   };

--- a/packages/react-native-executorch/src/hooks/useTextEmbedder.ts
+++ b/packages/react-native-executorch/src/hooks/useTextEmbedder.ts
@@ -19,26 +19,18 @@ import { createTextEmbedder, type TextEmbedderModel } from '../extensions/nlp/ta
  * progress, and embedding functions.
  */
 export function useTextEmbedder(config: TextEmbedderModel, options?: { preventLoad?: boolean }) {
-  const modelResource = useResourceDownload(config.modelPath, options?.preventLoad);
-  const tokenizerResource = useResourceDownload(config.tokenizerPath, options?.preventLoad);
-
-  const localModelPath = modelResource.localPath;
-  const localTokenizerPath = tokenizerResource.localPath;
-
-  const { model, error } = useModel(
-    createTextEmbedder,
-    localModelPath && localTokenizerPath
-      ? { modelPath: localModelPath, tokenizerPath: localTokenizerPath }
-      : null,
-    [localModelPath, localTokenizerPath]
+  const { resource, downloadProgress, downloadError } = useResourceDownload(
+    config,
+    options?.preventLoad
   );
+  const { model, error } = useModel(createTextEmbedder, resource ?? null, [resource]);
 
   return {
     isReady: !!model,
-    error: modelResource.downloadError || tokenizerResource.downloadError || error,
-    downloadProgress: modelResource.downloadProgress,
-    localPath: localModelPath,
-    tokenizerPath: localTokenizerPath,
+    error: downloadError || error,
+    downloadProgress,
+    localPath: resource?.modelPath,
+    tokenizerPath: resource?.tokenizerPath,
     embed: model?.embed,
     embedWorklet: model?.embedWorklet,
   };

--- a/packages/react-native-executorch/src/hooks/useTextToImage.ts
+++ b/packages/react-native-executorch/src/hooks/useTextToImage.ts
@@ -24,7 +24,7 @@ export function useTextToImage(config: SdxsTextToImageModel, options?: { prevent
     config,
     options?.preventLoad
   );
-  const { model, error } = useModel(createSdxsTextToImage, resource ?? null, [resource]);
+  const { model, error } = useModel(createSdxsTextToImage, resource ?? null);
 
   return {
     isReady: !!model,

--- a/packages/react-native-executorch/src/hooks/useTextToImage.ts
+++ b/packages/react-native-executorch/src/hooks/useTextToImage.ts
@@ -20,25 +20,16 @@ import {
  * progress, and generation functions.
  */
 export function useTextToImage(config: SdxsTextToImageModel, options?: { preventLoad?: boolean }) {
-  const modelResource = useResourceDownload(config.modelPath, options?.preventLoad);
-  const tokenizerResource = useResourceDownload(config.tokenizerPath, options?.preventLoad);
-
-  const localModelPath = modelResource.localPath;
-  const localTokenizerPath = tokenizerResource.localPath;
-  const isResourcesReady = !!(localModelPath && localTokenizerPath);
-
-  const { model, error } = useModel(
-    createSdxsTextToImage,
-    isResourcesReady
-      ? { ...config, modelPath: localModelPath!, tokenizerPath: localTokenizerPath! }
-      : null,
-    [localModelPath, localTokenizerPath]
+  const { resource, downloadProgress, downloadError } = useResourceDownload(
+    config,
+    options?.preventLoad
   );
+  const { model, error } = useModel(createSdxsTextToImage, resource ?? null, [resource]);
 
   return {
     isReady: !!model,
-    error: modelResource.downloadError || tokenizerResource.downloadError || error,
-    downloadProgress: modelResource.downloadProgress,
+    error: downloadError || error,
+    downloadProgress,
     generate: model?.generate,
     generateWorklet: model?.generateWorklet,
   };

--- a/packages/react-native-executorch/src/hooks/useTextToImage.ts
+++ b/packages/react-native-executorch/src/hooks/useTextToImage.ts
@@ -1,5 +1,5 @@
 import { useModel } from './useModel';
-import { useResourceDownload } from './useResourceDownload';
+import { useResourceDownload, type ResourceOptions } from './useResourceDownload';
 import {
   createSdxsTextToImage,
   type SdxsTextToImageModel,
@@ -14,22 +14,19 @@ import {
  * configuration changes.
  * @category Hooks
  * @param config The SDXS model configuration.
- * @param options Hook options.
- * @param options.preventLoad If true, prevents downloading and compiling the model.
+ * @param options Load and caching options. See {@link ResourceOptions}.
  * @returns An object containing the model's loading state, error, download
  * progress, and generation functions.
  */
-export function useTextToImage(config: SdxsTextToImageModel, options?: { preventLoad?: boolean }) {
-  const { resource, downloadProgress, downloadError } = useResourceDownload(
-    config,
-    options?.preventLoad
-  );
+export function useTextToImage(config: SdxsTextToImageModel, options?: ResourceOptions) {
+  const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);
   const { model, error } = useModel(createSdxsTextToImage, resource ?? null);
 
   return {
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
+    resource,
     generate: model?.generate,
     generateWorklet: model?.generateWorklet,
   };

--- a/packages/react-native-executorch/src/hooks/useTokenizer.ts
+++ b/packages/react-native-executorch/src/hooks/useTokenizer.ts
@@ -21,7 +21,7 @@ export function useTokenizer(tokenizerPath: string, options?: { preventLoad?: bo
     tokenizerPath,
     options?.preventLoad
   );
-  const { model, error } = useModel(createTokenizer, resource ?? null, [resource]);
+  const { model, error } = useModel(createTokenizer, resource ?? null);
 
   return {
     isReady: !!model,

--- a/packages/react-native-executorch/src/hooks/useTokenizer.ts
+++ b/packages/react-native-executorch/src/hooks/useTokenizer.ts
@@ -17,17 +17,17 @@ import { createTokenizer } from '../extensions/nlp/tasks/tokenization';
  * progress, and tokenization functions.
  */
 export function useTokenizer(tokenizerPath: string, options?: { preventLoad?: boolean }) {
-  const { localPath, downloadProgress, downloadError } = useResourceDownload(
+  const { resource, downloadProgress, downloadError } = useResourceDownload(
     tokenizerPath,
     options?.preventLoad
   );
-  const { model, error } = useModel(createTokenizer, localPath ?? null, [localPath]);
+  const { model, error } = useModel(createTokenizer, resource ?? null, [resource]);
 
   return {
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath,
+    localPath: resource,
     encode: model?.encode,
     decode: model?.decode,
     getVocabSize: model?.getVocabSize,

--- a/packages/react-native-executorch/src/hooks/useTokenizer.ts
+++ b/packages/react-native-executorch/src/hooks/useTokenizer.ts
@@ -1,5 +1,5 @@
 import { useModel } from './useModel';
-import { useResourceDownload } from './useResourceDownload';
+import { useResourceDownload, type ResourceOptions } from './useResourceDownload';
 import { createTokenizer } from '../extensions/nlp/tasks/tokenization';
 
 /**
@@ -10,17 +10,12 @@ import { createTokenizer } from '../extensions/nlp/tasks/tokenization';
  * cleaning up native memory when the component unmounts or the source changes.
  * @category Hooks
  * @param tokenizerPath A remote URL or local path to a `tokenizer.json` file.
- * @param options Hook options.
- * @param options.preventLoad If true, prevents downloading and loading the
- * tokenizer.
+ * @param options Load and caching options. See {@link ResourceOptions}.
  * @returns An object containing the tokenizer's loading state, error, download
  * progress, and tokenization functions.
  */
-export function useTokenizer(tokenizerPath: string, options?: { preventLoad?: boolean }) {
-  const { resource, downloadProgress, downloadError } = useResourceDownload(
-    tokenizerPath,
-    options?.preventLoad
-  );
+export function useTokenizer(tokenizerPath: string, options?: ResourceOptions) {
+  const { resource, downloadProgress, downloadError } = useResourceDownload(tokenizerPath, options);
   const { model, error } = useModel(createTokenizer, resource ?? null);
 
   return {

--- a/packages/react-native-executorch/src/hooks/useTokenizer.ts
+++ b/packages/react-native-executorch/src/hooks/useTokenizer.ts
@@ -27,7 +27,7 @@ export function useTokenizer(tokenizerPath: string, options?: { preventLoad?: bo
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath: resource,
+    resource,
     encode: model?.encode,
     decode: model?.decode,
     getVocabSize: model?.getVocabSize,

--- a/packages/react-native-executorch/src/hooks/useVoiceActivityDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useVoiceActivityDetector.ts
@@ -1,5 +1,5 @@
 import { useModel } from './useModel';
-import { useResourceDownload } from './useResourceDownload';
+import { useResourceDownload, type ResourceOptions } from './useResourceDownload';
 import {
   createFsmnVoiceActivityDetector,
   type FsmnVadModel,
@@ -14,20 +14,12 @@ import {
  * changes.
  * @category Hooks
  * @param config The VAD model configuration.
- * @param options Hook options.
- * @param options.preventLoad If true, prevents downloading and compiling the
- * model.
+ * @param options Load and caching options. See {@link ResourceOptions}.
  * @returns An object containing the model's loading state, error, download
  * progress, one-shot detection functions, and live detection controls.
  */
-export function useVoiceActivityDetector(
-  config: FsmnVadModel,
-  options?: { preventLoad?: boolean }
-) {
-  const { resource, downloadProgress, downloadError } = useResourceDownload(
-    config,
-    options?.preventLoad
-  );
+export function useVoiceActivityDetector(config: FsmnVadModel, options?: ResourceOptions) {
+  const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);
   const { model, error } = useModel(createFsmnVoiceActivityDetector, resource ?? null);
 
   return {

--- a/packages/react-native-executorch/src/hooks/useVoiceActivityDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useVoiceActivityDetector.ts
@@ -34,7 +34,7 @@ export function useVoiceActivityDetector(
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath: resource?.modelPath,
+    resource,
     detectVoice: model?.detectVoice,
     detectVoiceWorklet: model?.detectVoiceWorklet,
     detectVoiceOnStream: model?.detectVoiceOnStream,

--- a/packages/react-native-executorch/src/hooks/useVoiceActivityDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useVoiceActivityDetector.ts
@@ -24,21 +24,17 @@ export function useVoiceActivityDetector(
   config: FsmnVadModel,
   options?: { preventLoad?: boolean }
 ) {
-  const { localPath, downloadProgress, downloadError } = useResourceDownload(
-    config.modelPath,
+  const { resource, downloadProgress, downloadError } = useResourceDownload(
+    config,
     options?.preventLoad
   );
-  const { model, error } = useModel(
-    createFsmnVoiceActivityDetector,
-    localPath ? { ...config, modelPath: localPath } : null,
-    [localPath]
-  );
+  const { model, error } = useModel(createFsmnVoiceActivityDetector, resource ?? null, [resource]);
 
   return {
     isReady: !!model,
     error: downloadError || error,
     downloadProgress,
-    localPath,
+    localPath: resource?.modelPath,
     detectVoice: model?.detectVoice,
     detectVoiceWorklet: model?.detectVoiceWorklet,
     detectVoiceOnStream: model?.detectVoiceOnStream,

--- a/packages/react-native-executorch/src/hooks/useVoiceActivityDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useVoiceActivityDetector.ts
@@ -28,7 +28,7 @@ export function useVoiceActivityDetector(
     config,
     options?.preventLoad
   );
-  const { model, error } = useModel(createFsmnVoiceActivityDetector, resource ?? null, [resource]);
+  const { model, error } = useModel(createFsmnVoiceActivityDetector, resource ?? null);
 
   return {
     isReady: !!model,

--- a/packages/react-native-executorch/src/index.ts
+++ b/packages/react-native-executorch/src/index.ts
@@ -14,6 +14,9 @@ export * from './hooks/useTextToImage';
 export * from './hooks/useResourceDownload';
 export * from './hooks/useModel';
 
+// Resource fetching — imperative download API
+export * from './fetcher';
+
 // Constants
 export { models } from './models';
 export * as constants from './constants';

--- a/packages/react-native-executorch/src/utils.ts
+++ b/packages/react-native-executorch/src/utils.ts
@@ -22,6 +22,12 @@ export function getRegisteredBackends(): string[] {
  * temporary local file, reads its configuration and method signatures
  * (inputs/outputs shapes, types, and tags), and deletes the temporary file
  * before returning.
+ *
+ * That download is deliberately throwaway: it does not go through
+ * {@link download}, so the file never enters the persistent resource cache and
+ * is not reused. Inspecting a remote model therefore re-downloads it on every
+ * call and leaves nothing behind — call {@link download} first and inspect the
+ * returned local path if you also intend to run the model.
  * @category Utils
  * @param source The remote HTTP URL or local path to the `.pte` model file.
  * @returns A promise resolving to an object containing the model source,

--- a/packages/react-native-executorch/src/utils.ts
+++ b/packages/react-native-executorch/src/utils.ts
@@ -1,7 +1,7 @@
 import { rnexecutorchJsi } from './native/bridge';
 import { loadModel } from './core/model';
 import type { ModelSpec, ConcreteDim } from './core/schema';
-import RNFS from 'react-native-fs';
+import RNBlobUtil from 'react-native-blob-util';
 
 /**
  * Retrieves the names of all ExecuTorch backends compiled and registered in the
@@ -23,7 +23,6 @@ export function getRegisteredBackends(): string[] {
  * (inputs/outputs shapes, types, and tags), and deletes the temporary file
  * before returning.
  * @category Utils
- * @experimental Subject to change once the temporary react-native-fs dependency is replaced. See [Issue #1253](https://github.com/software-mansion/react-native-executorch/issues/1253).
  * @param source The remote HTTP URL or local path to the `.pte` model file.
  * @returns A promise resolving to an object containing the model source,
  * method signature metadata, and per-method backend usage.
@@ -37,8 +36,10 @@ export async function inspectModel(source: string): Promise<{
   let downloaded = false;
 
   if (source.startsWith('http')) {
-    localPath = `${RNFS.TemporaryDirectoryPath}/inspect_model_${Date.now()}.pte`;
-    await RNFS.downloadFile({ fromUrl: source, toFile: localPath }).promise;
+    // Throwaway download to a temp path — inspection shouldn't populate the
+    // persistent resource cache, so we don't go through `download()`.
+    localPath = `${RNBlobUtil.fs.dirs.CacheDir}/inspect_model_${Date.now()}.pte`;
+    await RNBlobUtil.config({ path: localPath }).fetch('GET', source);
     downloaded = true;
   }
 
@@ -52,7 +53,7 @@ export async function inspectModel(source: string): Promise<{
       model.dispose();
     }
     if (downloaded) {
-      await RNFS.unlink(localPath).catch(() => {});
+      await RNBlobUtil.fs.unlink(localPath).catch(() => {});
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6234,10 +6234,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-64@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "base-64@npm:0.1.0"
-  checksum: 10/5a42938f82372ab5392cbacc85a5a78115cbbd9dbef9f7540fa47d78763a3a8bd7d598475f0d92341f66285afd377509851a9bb5c67bbecb89686e9255d5b3eb
+"base-64@npm:1.0.0":
+  version: 1.0.0
+  resolution: "base-64@npm:1.0.0"
+  checksum: 10/d10b64a1fc9b2c5a5f39f1ce1e6c9d1c5b249222bbfa3a0604c592d90623caf74419983feadd8a170f27dc0c3389704f72faafa3e645aeb56bfc030c93ff074a
   languageName: node
   linkType: hard
 
@@ -6806,6 +6806,7 @@ __metadata:
     expo-router: "npm:~56.2.9"
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"
+    react-native-blob-util: "npm:^0.24.0"
     react-native-drawer-layout: "npm:^4.2.2"
     react-native-executorch: "workspace:*"
     react-native-gesture-handler: "npm:~2.31.1"
@@ -9036,6 +9037,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:13.0.6, glob@npm:^13.0.0":
+  version: 13.0.6
+  resolution: "glob@npm:13.0.6"
+  dependencies:
+    minimatch: "npm:^10.2.2"
+    minipass: "npm:^7.1.3"
+    path-scurry: "npm:^2.0.2"
+  checksum: 10/201ad69e5f0aa74e1d8c00a481581f8b8c804b6a4fbfabeeb8541f5d756932800331daeba99b58fb9e4cd67e12ba5a7eba5b82fb476691588418060b84353214
+  languageName: node
+  linkType: hard
+
 "glob@npm:^10.5.0":
   version: 10.5.0
   resolution: "glob@npm:10.5.0"
@@ -9049,17 +9061,6 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 10/ab3bccfefcc0afaedbd1f480cd0c4a2c0e322eb3f0aa7ceaa31b3f00b825069f17cf0f1fc8b6f256795074b903f37c0ade37ddda6a176aa57f1c2bbfe7240653
-  languageName: node
-  linkType: hard
-
-"glob@npm:^13.0.0":
-  version: 13.0.6
-  resolution: "glob@npm:13.0.6"
-  dependencies:
-    minimatch: "npm:^10.2.2"
-    minipass: "npm:^7.1.3"
-    path-scurry: "npm:^2.0.2"
-  checksum: 10/201ad69e5f0aa74e1d8c00a481581f8b8c804b6a4fbfabeeb8541f5d756932800331daeba99b58fb9e4cd67e12ba5a7eba5b82fb476691588418060b84353214
   languageName: node
   linkType: hard
 
@@ -11921,6 +11922,7 @@ __metadata:
     expo-router: "npm:~56.2.9"
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"
+    react-native-blob-util: "npm:^0.24.0"
     react-native-drawer-layout: "npm:^4.2.2"
     react-native-executorch: "workspace:*"
     react-native-gesture-handler: "npm:~2.31.1"
@@ -12794,6 +12796,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-blob-util@npm:^0.24.0":
+  version: 0.24.10
+  resolution: "react-native-blob-util@npm:0.24.10"
+  dependencies:
+    base-64: "npm:1.0.0"
+    glob: "npm:13.0.6"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/3999fbe4c856fd45f09248a80c324c5cd464d9774c705138e864e06d8dab826d2be1ccba25beea09ce1352b66922094eef35435612d5b5e9bde5443803f0269a
+  languageName: node
+  linkType: hard
+
 "react-native-builder-bob@npm:^0.40.18":
   version: 0.40.18
   resolution: "react-native-builder-bob@npm:0.40.18"
@@ -12943,33 +12958,17 @@ __metadata:
     del-cli: "npm:^6.0.0"
     react: "npm:19.2.0"
     react-native: "npm:0.83.6"
+    react-native-blob-util: "npm:^0.24.0"
     react-native-builder-bob: "npm:^0.40.18"
-    react-native-fs: "npm:^2.20.0"
     react-native-worklets: "npm:0.9.1"
     typescript: "npm:~5.9.2"
   peerDependencies:
     react: "*"
     react-native: "*"
-    react-native-fs: ^2.20.0
+    react-native-blob-util: ^0.24.0
     react-native-worklets: "*"
   languageName: unknown
   linkType: soft
-
-"react-native-fs@npm:^2.20.0":
-  version: 2.20.0
-  resolution: "react-native-fs@npm:2.20.0"
-  dependencies:
-    base-64: "npm:^0.1.0"
-    utf8: "npm:^3.0.0"
-  peerDependencies:
-    react-native: "*"
-    react-native-windows: "*"
-  peerDependenciesMeta:
-    react-native-windows:
-      optional: true
-  checksum: 10/372e59f55d5e544e87093d832896fa3d56ba9802ca140c17b4b8903afe047714e022d3b1a2ddf18d744cb7f4f973593c8083641db9ae0768688b1390078d67a2
-  languageName: node
-  linkType: hard
 
 "react-native-gesture-handler@npm:~2.31.1":
   version: 2.31.2
@@ -14093,6 +14092,7 @@ __metadata:
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"
     react-native-audio-api: "npm:0.13.1"
+    react-native-blob-util: "npm:^0.24.0"
     react-native-device-info: "npm:^15.0.2"
     react-native-drawer-layout: "npm:^4.2.2"
     react-native-executorch: "workspace:*"
@@ -14904,13 +14904,6 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 10/b40ad2847ba220695bff2d4ba4f4d60391c0fb4fb012faa7a4c18eb38b69181936f5edc55a522c4d20a788d1a879b73c3810952c9d0fd128d01cb3f22042c09e
-  languageName: node
-  linkType: hard
-
-"utf8@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "utf8@npm:3.0.0"
-  checksum: 10/31d19c4faacbb65b09ebc1c21c32b20bdb0919c6f6773cee5001b99bb83f8e503e7233c08fc71ebb34f7cfebd95cec3243b81d90176097aa2f286cccb4ce866e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Adds resource fetching to the rewrite as a single `react-native-blob-util`-backed fetcher inside `react-native-executorch`. Replaces the temporary `react-native-fs` hook.

`download(source, { onProgress, signal })` is a single generic entry point: it takes any nested structure of plain objects and arrays, downloads every string leaf that is an `http(s)` URL, and returns the value with those URLs replaced by local paths. Everything else passes through untouched, so the result is structurally identical to the input. `download<T>(source: T): Promise<T>` types correctly for every task config without per-task overloads:

```ts
const model = await download(models.classification.EFFICIENTNET_V2_S.XNNPACK_FP32);
const { classify, dispose } = await createClassifier(model);
```

Backend is split by platform: Android uses the system DownloadManager (reliable for files >2 GB, background), iOS streams via NSURLSession with `.partial`/HTTP-Range resume.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

1. Run the `computer-vision` example app.
2. Open Classification, pick an XNNPACK model — it downloads with progress, then loads and runs.
3. Reopen the screen — the model is served from cache instantly (no re-download).
4. Open Speech-to-Text — model, tokenizer and the nested VAD model resolve in one pass, with progress weighted across all three.
5. Imperative: `createClassifier(await download(models.classification.EFFICIENTNET_V2_S.XNNPACK_FP32))`.

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

Closes #1253

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

- Swaps the `react-native-fs` peer dependency for `react-native-blob-util`.
- Android must use DownloadManager.
- `isEmulator` is now installed on the `__rnexecutorch_jsi__` module by the native layer.
- File management (list/delete downloaded models) is intentionally out of scope; the fetcher only downloads and returns paths.
