### PR TITLE
[RNE Rewrite] refactor: use skImageToBuffer helper across CV demo screens

### DIFF
--- a/apps/computer-vision/app/classification/index.tsx
+++ b/apps/computer-vision/app/classification/index.tsx
@@ -5,7 +5,7 @@ import { commonStyles, ColorPalette, theme } from '../../theme';
 import { useImage } from '@shopify/react-native-skia';
 import { useClassifier, models } from 'react-native-executorch';
 import ScreenWrapper from '../../components/ScreenWrapper';
-import { getImage } from '../../utils';
+import { getImage, skImageToBuffer } from '../../utils';
 import { ModelPicker, type ModelOption } from '../../components/ModelPicker';
 import { ImageViewport } from '../../components/ImageViewport';
 import { ModelStatus } from '../../components/ModelStatus';
@@ -66,20 +66,7 @@ function ClassificationContent() {
     if (!sync) setIsProcessing(true);
     setError(null);
     try {
-      const pixels = skiaImage.readPixels();
-      if (!pixels) {
-        throw new Error('Failed to read pixels from image');
-      }
-      if (!(pixels instanceof Uint8Array)) {
-        throw new Error('Expected Uint8Array from readPixels');
-      }
-      const buffer = {
-        data: pixels,
-        width: skiaImage.width(),
-        height: skiaImage.height(),
-        format: 'rgba' as const,
-        layout: 'hwc' as const,
-      };
+      const buffer = skImageToBuffer(skiaImage);
       const start = Date.now();
       const output = sync
         ? classifyWorklet(buffer, { topk: 5 })

--- a/apps/computer-vision/app/detection/index.tsx
+++ b/apps/computer-vision/app/detection/index.tsx
@@ -5,7 +5,7 @@ import { commonStyles, theme } from '../../theme';
 import { useImage } from '@shopify/react-native-skia';
 import { useObjectDetector, models, type ObjectDetection } from 'react-native-executorch';
 import ScreenWrapper from '../../components/ScreenWrapper';
-import { getImage } from '../../utils';
+import { getImage, skImageToBuffer } from '../../utils';
 import { ModelPicker, type ModelOption } from '../../components/ModelPicker';
 import { ImageViewport } from '../../components/ImageViewport';
 import { ModelStatus } from '../../components/ModelStatus';
@@ -94,20 +94,7 @@ function DetectionContent() {
     if (!sync) setIsProcessing(true);
     setError(null);
     try {
-      const pixels = skiaImage.readPixels();
-      if (!pixels) {
-        throw new Error('Failed to read pixels from image');
-      }
-      if (!(pixels instanceof Uint8Array)) {
-        throw new Error('Expected Uint8Array from readPixels');
-      }
-      const buffer = {
-        data: pixels,
-        width: skiaImage.width(),
-        height: skiaImage.height(),
-        format: 'rgba' as const,
-        layout: 'hwc' as const,
-      };
+      const buffer = skImageToBuffer(skiaImage);
       const start = Date.now();
       const output = (
         sync ? detectObjectsWorklet(buffer) : await detectObjects(buffer)

--- a/apps/computer-vision/app/instanceSegmentation/index.tsx
+++ b/apps/computer-vision/app/instanceSegmentation/index.tsx
@@ -15,7 +15,7 @@ import {
   type InstanceSegmentationResult,
 } from 'react-native-executorch';
 import ScreenWrapper from '../../components/ScreenWrapper';
-import { getImage } from '../../utils';
+import { getImage, skImageToBuffer } from '../../utils';
 import { ModelPicker, type ModelOption } from '../../components/ModelPicker';
 import { ImageViewport } from '../../components/ImageViewport';
 import { ModelStatus } from '../../components/ModelStatus';
@@ -128,20 +128,7 @@ function InstanceSegmentationContent() {
     setError(null);
 
     try {
-      const pixels = skiaImage.readPixels();
-      if (!pixels) {
-        throw new Error('Failed to read pixels from image');
-      }
-      if (!(pixels instanceof Uint8Array)) {
-        throw new Error('Expected Uint8Array from readPixels');
-      }
-      const buffer = {
-        data: pixels,
-        width: skiaImage.width(),
-        height: skiaImage.height(),
-        format: 'rgba' as const,
-        layout: 'hwc' as const,
-      };
+      const buffer = skImageToBuffer(skiaImage);
 
       const start = Date.now();
       const output = (

--- a/apps/computer-vision/app/keypoint/index.tsx
+++ b/apps/computer-vision/app/keypoint/index.tsx
@@ -5,7 +5,7 @@ import { commonStyles, theme } from '../../theme';
 import { useImage } from '@shopify/react-native-skia';
 import { useKeypointDetector, models, type KeypointDetection } from 'react-native-executorch';
 import ScreenWrapper from '../../components/ScreenWrapper';
-import { getImage } from '../../utils';
+import { getImage, skImageToBuffer } from '../../utils';
 import { ModelPicker, type ModelOption } from '../../components/ModelPicker';
 import { ImageViewport } from '../../components/ImageViewport';
 import { ModelStatus } from '../../components/ModelStatus';
@@ -79,20 +79,7 @@ function KeypointContent() {
     if (!sync) setIsProcessing(true);
     setError(null);
     try {
-      const pixels = skiaImage.readPixels();
-      if (!pixels) {
-        throw new Error('Failed to read pixels from image');
-      }
-      if (!(pixels instanceof Uint8Array)) {
-        throw new Error('Expected Uint8Array from readPixels');
-      }
-      const buffer = {
-        data: pixels,
-        width: skiaImage.width(),
-        height: skiaImage.height(),
-        format: 'rgba' as const,
-        layout: 'hwc' as const,
-      };
+      const buffer = skImageToBuffer(skiaImage);
       const start = Date.now();
       const output = (
         sync ? detectKeypointsWorklet(buffer) : await detectKeypoints(buffer)

--- a/apps/computer-vision/app/segmentation/index.tsx
+++ b/apps/computer-vision/app/segmentation/index.tsx
@@ -12,7 +12,7 @@ import {
 import { useSemanticSegmenter, models } from 'react-native-executorch';
 import ScreenWrapper from '../../components/ScreenWrapper';
 import { ModelPicker, type ModelOption } from '../../components/ModelPicker';
-import { getImage } from '../../utils';
+import { getImage, skImageToBuffer } from '../../utils';
 import { ImageViewport } from '../../components/ImageViewport';
 import { ModelStatus } from '../../components/ModelStatus';
 import { LatencyIndicator } from '../../components/LatencyIndicator';
@@ -93,20 +93,7 @@ function SegmentationContent() {
     setError(null);
 
     try {
-      const pixels = skiaImage.readPixels();
-      if (!pixels) {
-        throw new Error('Failed to read pixels from image');
-      }
-      if (!(pixels instanceof Uint8Array)) {
-        throw new Error('Expected Uint8Array from readPixels');
-      }
-      const buffer = {
-        data: pixels,
-        width: skiaImage.width(),
-        height: skiaImage.height(),
-        format: 'rgba' as const,
-        layout: 'hwc' as const,
-      };
+      const buffer = skImageToBuffer(skiaImage);
 
       const start = Date.now();
       const { buffer: outBuffer } = sync ? segmentWorklet(buffer) : await segment(buffer);

--- a/apps/computer-vision/app/styleTransfer/index.tsx
+++ b/apps/computer-vision/app/styleTransfer/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@shopify/react-native-skia';
 import { useStyleTransfer, models } from 'react-native-executorch';
 import ScreenWrapper from '../../components/ScreenWrapper';
-import { getImage } from '../../utils';
+import { getImage, skImageToBuffer } from '../../utils';
 import { ModelPicker, type ModelOption } from '../../components/ModelPicker';
 import { ImageViewport } from '../../components/ImageViewport';
 import { ModelStatus } from '../../components/ModelStatus';
@@ -97,20 +97,7 @@ function StyleTransferContent() {
     if (!sync) setIsProcessing(true);
     setError(null);
     try {
-      const pixels = skiaImage.readPixels();
-      if (!pixels) {
-        throw new Error('Failed to read pixels from image');
-      }
-      if (!(pixels instanceof Uint8Array)) {
-        throw new Error('Expected Uint8Array from readPixels');
-      }
-      const buffer = {
-        data: pixels,
-        width: skiaImage.width(),
-        height: skiaImage.height(),
-        format: 'rgba' as const,
-        layout: 'hwc' as const,
-      };
+      const buffer = skImageToBuffer(skiaImage);
 
       const start = Date.now();
       const output = sync ? transferStyleWorklet(buffer) : await transferStyle(buffer);


### PR DESCRIPTION
## Description

Replaces the duplicated inline Skia pixel-reading boilerplate with the shared `skImageToBuffer()` helper (`apps/computer-vision/utils.ts`) across the remaining computer-vision demo screens: classification, detection, segmentation, instance segmentation, keypoint, and style transfer. The helper was introduced in #1292 for the image-embeddings screen; this consolidates the pattern. Behavior-preserving; padding logic (`useSafeAreaInsets`/`insets.bottom`) untouched.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

Open each affected screen in the computer-vision demo app, pick an image, and run the task — output is unchanged.

### Related issues

Closes #1304

### Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings