### PR TITLE
[RNE Rewrite] Extract tokenizer try-lock helper

### DIFF
--- a/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
+++ b/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
@@ -67,6 +67,18 @@ TokenizerHostObject::TokenizerHostObject(std::string tokenizerPath)
     }
 }
 
+std::unique_lock<std::mutex> TokenizerHostObject::tryLockUnique(jsi::Runtime &rt,
+                                                               std::string_view context) {
+    std::unique_lock<std::mutex> lock(mutex_, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        throw jsi::JSError(rt, std::format("{} is currently in use", context));
+    }
+    if (!tokenizer_) {
+        throw jsi::JSError(rt, std::format("{} has been disposed", context));
+    }
+    return lock;
+}
+
 jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &name) {
     auto nameStr = name.utf8(rt);
 
@@ -81,14 +93,7 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
                 throw jsi::JSError(rt, "encode: Usage: encode(text)");
             }
 
-            std::unique_lock<std::mutex> lock(self->mutex_, std::try_to_lock);
-            if (!lock.owns_lock()) {
-                throw jsi::JSError(rt, "encode: Tokenizer is currently in use");
-            }
-
-            if (!self->tokenizer_) {
-                throw jsi::JSError(rt, "encode: Tokenizer has been disposed");
-            }
+            auto lock = self->tryLockUnique(rt, "encode: Tokenizer");
 
             auto text = conversions::asType<std::string>(rt, "encode: text", args[0]);
             auto tokens = unwrap(rt, "encode: Failed to encode input",
@@ -112,14 +117,7 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
                 skipSpecialTokens = conversions::asType<bool>(rt, "decode: skipSpecialTokens", args[1]);
             }
 
-            std::unique_lock<std::mutex> lock(self->mutex_, std::try_to_lock);
-            if (!lock.owns_lock()) {
-                throw jsi::JSError(rt, "decode: Tokenizer is currently in use");
-            }
-
-            if (!self->tokenizer_) {
-                throw jsi::JSError(rt, "decode: Tokenizer has been disposed");
-            }
+            auto lock = self->tryLockUnique(rt, "decode: Tokenizer");
 
             auto tokens = conversions::asVector<uint64_t>(rt, "decode: tokens", args[0]);
 
@@ -142,14 +140,7 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
                 throw jsi::JSError(rt, "getVocabSize: Usage: getVocabSize()");
             }
 
-            std::unique_lock<std::mutex> lock(self->mutex_, std::try_to_lock);
-            if (!lock.owns_lock()) {
-                throw jsi::JSError(rt, "getVocabSize: Tokenizer is currently in use");
-            }
-
-            if (!self->tokenizer_) {
-                throw jsi::JSError(rt, "getVocabSize: Tokenizer has been disposed");
-            }
+            auto lock = self->tryLockUnique(rt, "getVocabSize: Tokenizer");
 
             return static_cast<double>(self->tokenizer_->vocab_size());
         };
@@ -163,14 +154,7 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
                 throw jsi::JSError(rt, "idToToken: Usage: idToToken(id)");
             }
 
-            std::unique_lock<std::mutex> lock(self->mutex_, std::try_to_lock);
-            if (!lock.owns_lock()) {
-                throw jsi::JSError(rt, "idToToken: Tokenizer is currently in use");
-            }
-
-            if (!self->tokenizer_) {
-                throw jsi::JSError(rt, "idToToken: Tokenizer has been disposed");
-            }
+            auto lock = self->tryLockUnique(rt, "idToToken: Tokenizer");
 
             auto tokenId = conversions::asType<uint64_t>(rt, "idToToken: id", args[0]);
             auto token = unwrap(rt, "idToToken: Failed to convert id to token",
@@ -188,14 +172,7 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
                 throw jsi::JSError(rt, "tokenToId: Usage: tokenToId(token)");
             }
 
-            std::unique_lock<std::mutex> lock(self->mutex_, std::try_to_lock);
-            if (!lock.owns_lock()) {
-                throw jsi::JSError(rt, "tokenToId: Tokenizer is currently in use");
-            }
-
-            if (!self->tokenizer_) {
-                throw jsi::JSError(rt, "tokenToId: Tokenizer has been disposed");
-            }
+            auto lock = self->tryLockUnique(rt, "tokenToId: Tokenizer");
 
             auto token = conversions::asType<std::string>(rt, "tokenToId: token", args[0]);
             auto tokenId = unwrap(rt, "tokenToId: Failed to convert token to id",

--- a/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.h
+++ b/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <jsi/jsi.h>
@@ -20,6 +21,13 @@ public:
     std::vector<facebook::jsi::PropNameID> getPropertyNames(facebook::jsi::Runtime &rt) override;
 
 private:
+    // Non-blocking try-lock on mutex_ that also checks the tokenizer is still
+    // alive, throwing a facebook::jsi::JSError prefixed with `context` on
+    // contention ("... is currently in use") or after dispose ("... has been
+    // disposed").
+    [[nodiscard]] std::unique_lock<std::mutex> tryLockUnique(facebook::jsi::Runtime &rt,
+                                                             std::string_view context);
+
     std::string tokenizerPath_;
     std::unique_ptr<tokenizers::HFTokenizer> tokenizer_;
     std::mutex mutex_;

--- a/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.h
+++ b/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.h
@@ -21,10 +21,6 @@ public:
     std::vector<facebook::jsi::PropNameID> getPropertyNames(facebook::jsi::Runtime &rt) override;
 
 private:
-    // Non-blocking try-lock on mutex_ that also checks the tokenizer is still
-    // alive, throwing a facebook::jsi::JSError prefixed with `context` on
-    // contention ("... is currently in use") or after dispose ("... has been
-    // disposed").
     [[nodiscard]] std::unique_lock<std::mutex> tryLockUnique(facebook::jsi::Runtime &rt,
                                                              std::string_view context);
 


### PR DESCRIPTION
## Description

Resolves the locking + boilerplate items of #1316. Extracts the try-lock + liveness-check block that was duplicated across the five `TokenizerHostObject` ops into a single class-scoped `tryLockUnique` member, so callsites read `self->tryLockUnique(rt, ctx)` — no lambdas or template parameters. Error messages are preserved verbatim. The helper is scoped to the tokenizer rather than shared across host objects, to keep callsites simple and avoid coupling unrelated types.

`TokenizerHostObject` keeps its exclusive `std::mutex`.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

Pure refactor with no behavior change: the extracted helper reproduces the exact same lock discipline and error strings as the inlined code.

### Screenshots

### Related issues

Resolves the locking/deduplication parts of #1316.

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes