### PR TITLE
[RNE Rewrite] perf(nlp): return tokenizer ids as Int32Array instead of number[]

### DIFF
--- a/apps/nlp/app/tokenizer/index.tsx
+++ b/apps/nlp/app/tokenizer/index.tsx
@@ -15,7 +15,7 @@ function TokenizerContent() {
   const [text, setText] = useState('Hello world');
   const [running, setRunning] = useState(false);
   const [runError, setRunError] = useState<string | null>(null);
-  const [ids, setIds] = useState<number[] | null>(null);
+  const [ids, setIds] = useState<Int32Array | null>(null);
   const [roundTrip, setRoundTrip] = useState<string | null>(null);
   const [vocabSize, setVocabSize] = useState<number | null>(null);
   const [checks, setChecks] = useState<Check[]>([]);
@@ -71,7 +71,7 @@ function TokenizerContent() {
         JSON.stringify({
           allPass: nextChecks.every((c) => c.pass),
           input: text,
-          ids: tokenIds,
+          ids: Array.from(tokenIds),
           decoded,
           vocab,
           checks: nextChecks.map((c) => ({ label: c.label, pass: c.pass, detail: c.detail })),

--- a/packages/react-native-executorch/cpp/core/conversions.h
+++ b/packages/react-native-executorch/cpp/core/conversions.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <format>
 #include <optional>
 #include <string>
@@ -113,45 +114,38 @@ std::vector<T> asVector(jsi::Runtime &rt, const std::string &ctx, const jsi::Val
 }
 
 /**
- * Reads a JS TypedArray into a std::vector by copying its backing ArrayBuffer
- * in a single pass. Unlike asVector, elements are not boxed through JSI one by
- * one. Pairs with toJsiTypedArray so that numeric arrays can cross worklet
- * runtime boundaries as a cheap ArrayBuffer clone rather than an element-by-
- * element serialization.
+ * Reads a JS TypedArray into a std::vector<T> by copying its backing
+ * ArrayBuffer in a single memcpy. Unlike asVector, elements are not boxed
+ * through JSI one by one. The bytes are interpreted as-is, so T must match the
+ * TypedArray's element type (e.g. int32_t for an Int32Array); if the caller
+ * needs a different element type it should reinterpret the result explicitly,
+ * e.g. std::vector<uint64_t>(v.begin(), v.end()).
  *
- * @tparam Storage The element type of the TypedArray's storage (e.g. int32_t
- * for an Int32Array). Determines how the backing buffer bytes are interpreted.
- * @tparam T The target vector element type; each storage element is cast to it.
- * Defaults to Storage.
+ * @tparam T The element type; the buffer's bytes are read directly as T.
  * @param rt The JSI runtime instance.
  * @param ctx Context description used for error messages.
- * @param val The JSI value (must be a TypedArray whose element size is
- * sizeof(Storage)).
- * @return A std::vector containing the converted elements.
+ * @param val The JSI value (must be a TypedArray / have a `buffer`).
+ * @return A std::vector containing the elements.
  */
-template <typename Storage, typename T = Storage>
+template <typename T>
 std::vector<T> fromJsiTypedArray(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
-    static_assert(std::is_arithmetic_v<Storage>, "fromJsiTypedArray requires an arithmetic storage type");
+    static_assert(std::is_arithmetic_v<T>, "fromJsiTypedArray requires an arithmetic type");
+
     auto obj = asType<jsi::Object>(rt, ctx, val);
-    if (!obj.hasProperty(rt, "buffer")) {
-        throw jsi::JSError(rt, ctx + " must be a TypedArray");
+    auto buffer = getRequiredProperty<jsi::ArrayBuffer>(rt, ctx, obj, "buffer");
+
+    const size_t byteOffset = getOptionalProperty<uint64_t>(rt, ctx, obj, "byteOffset").value_or(0);
+    const size_t byteLength = getOptionalProperty<uint64_t>(rt, ctx, obj, "byteLength").value_or(buffer.size(rt));
+
+    if (byteOffset > buffer.size(rt) || byteLength > buffer.size(rt) - byteOffset) {
+        throw jsi::JSError(rt, ctx + " has out-of-bounds byteOffset/byteLength for its ArrayBuffer");
     }
-    if (getRequiredProperty<uint64_t>(rt, ctx, obj, "BYTES_PER_ELEMENT") != sizeof(Storage)) {
-        throw jsi::JSError(rt, ctx + " has an unexpected element size");
+    if (byteLength % sizeof(T) != 0) {
+        throw jsi::JSError(rt, std::format("{}: byteLength is not a multiple of sizeof(T)={}", ctx, sizeof(T)));
     }
-    auto buffer = asType<jsi::ArrayBuffer>(rt, ctx, obj.getProperty(rt, "buffer"));
-    const auto byteOffset = static_cast<size_t>(getOptionalProperty<uint64_t>(rt, ctx, obj, "byteOffset").value_or(0));
-    const auto length = static_cast<size_t>(getRequiredProperty<uint64_t>(rt, ctx, obj, "length"));
-    if (byteOffset + length * sizeof(Storage) > buffer.size(rt)) {
-        throw jsi::JSError(rt, ctx + " is out of bounds for its backing ArrayBuffer");
-    }
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): reading the typed array's raw storage
-    const auto *src = reinterpret_cast<const Storage *>(buffer.data(rt) + byteOffset);
-    std::vector<T> vec;
-    vec.reserve(length);
-    for (size_t i = 0; i < length; ++i) {
-        vec.push_back(static_cast<T>(src[i]));
-    }
+
+    std::vector<T> vec(byteLength / sizeof(T));
+    std::memcpy(vec.data(), buffer.data(rt) + byteOffset, byteLength);
     return vec;
 }
 
@@ -212,35 +206,33 @@ constexpr const char *jsiTypedArrayName() {
 }
 
 /**
- * Converts a std::vector to a JS TypedArray backed by an ArrayBuffer. This is
- * far cheaper to move across worklet runtime boundaries than toJsiArray:
+ * Converts a std::vector<T> to a JS TypedArray backed by an ArrayBuffer. This
+ * is far cheaper to move across worklet runtime boundaries than toJsiArray:
  * react-native-worklets clones the underlying ArrayBuffer with a single memcpy
  * instead of serializing each element individually, which matters for long
  * sequences (e.g. token ids). Read it back with fromJsiTypedArray.
  *
- * @tparam Storage The element type of the resulting TypedArray's storage, which
- * also selects the JS view (e.g. int32_t -> Int32Array).
- * @tparam T The source vector element type; each value is cast to Storage.
- * Defaults to Storage.
+ * @tparam T The vector element type, which also selects the JS view
+ * (e.g. int32_t -> Int32Array).
  * @param rt The JSI runtime instance.
  * @param vec The source vector to convert.
  * @return A new JS TypedArray containing the elements from the vector.
  */
-template <typename Storage, typename T = Storage>
+template <typename T>
 jsi::Object toJsiTypedArray(jsi::Runtime &rt, const std::vector<T> &vec) {
-    static_assert(std::is_arithmetic_v<Storage>, "toJsiTypedArray requires an arithmetic storage type");
-    const size_t byteLength = vec.size() * sizeof(Storage);
+    static_assert(std::is_arithmetic_v<T>, "toJsiTypedArray requires an arithmetic type");
+    const size_t byteLength = vec.size() * sizeof(T);
     auto arrayBuffer = rt.global()
                            .getPropertyAsFunction(rt, "ArrayBuffer")
                            .callAsConstructor(rt, static_cast<double>(byteLength))
                            .asObject(rt);
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): writing directly into the typed array's storage
-    auto *dst = reinterpret_cast<Storage *>(arrayBuffer.getArrayBuffer(rt).data(rt));
-    for (size_t i = 0; i < vec.size(); ++i) {
-        dst[i] = static_cast<Storage>(vec[i]);
+
+    if (!vec.empty()) {
+        std::memcpy(arrayBuffer.getArrayBuffer(rt).data(rt), vec.data(), byteLength);
     }
+
     return rt.global()
-        .getPropertyAsFunction(rt, jsiTypedArrayName<Storage>())
+        .getPropertyAsFunction(rt, jsiTypedArrayName<T>())
         .callAsConstructor(rt, arrayBuffer)
         .asObject(rt);
 }

--- a/packages/react-native-executorch/cpp/core/conversions.h
+++ b/packages/react-native-executorch/cpp/core/conversions.h
@@ -113,6 +113,49 @@ std::vector<T> asVector(jsi::Runtime &rt, const std::string &ctx, const jsi::Val
 }
 
 /**
+ * Reads a JS TypedArray into a std::vector by copying its backing ArrayBuffer
+ * in a single pass. Unlike asVector, elements are not boxed through JSI one by
+ * one. Pairs with toJsiTypedArray so that numeric arrays can cross worklet
+ * runtime boundaries as a cheap ArrayBuffer clone rather than an element-by-
+ * element serialization.
+ *
+ * @tparam Storage The element type of the TypedArray's storage (e.g. int32_t
+ * for an Int32Array). Determines how the backing buffer bytes are interpreted.
+ * @tparam T The target vector element type; each storage element is cast to it.
+ * Defaults to Storage.
+ * @param rt The JSI runtime instance.
+ * @param ctx Context description used for error messages.
+ * @param val The JSI value (must be a TypedArray whose element size is
+ * sizeof(Storage)).
+ * @return A std::vector containing the converted elements.
+ */
+template <typename Storage, typename T = Storage>
+std::vector<T> fromJsiTypedArray(jsi::Runtime &rt, const std::string &ctx, const jsi::Value &val) {
+    static_assert(std::is_arithmetic_v<Storage>, "fromJsiTypedArray requires an arithmetic storage type");
+    auto obj = asType<jsi::Object>(rt, ctx, val);
+    if (!obj.hasProperty(rt, "buffer")) {
+        throw jsi::JSError(rt, ctx + " must be a TypedArray");
+    }
+    if (getRequiredProperty<uint64_t>(rt, ctx, obj, "BYTES_PER_ELEMENT") != sizeof(Storage)) {
+        throw jsi::JSError(rt, ctx + " has an unexpected element size");
+    }
+    auto buffer = asType<jsi::ArrayBuffer>(rt, ctx, obj.getProperty(rt, "buffer"));
+    const auto byteOffset = static_cast<size_t>(getOptionalProperty<uint64_t>(rt, ctx, obj, "byteOffset").value_or(0));
+    const auto length = static_cast<size_t>(getRequiredProperty<uint64_t>(rt, ctx, obj, "length"));
+    if (byteOffset + length * sizeof(Storage) > buffer.size(rt)) {
+        throw jsi::JSError(rt, ctx + " is out of bounds for its backing ArrayBuffer");
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): reading the typed array's raw storage
+    const auto *src = reinterpret_cast<const Storage *>(buffer.data(rt) + byteOffset);
+    std::vector<T> vec;
+    vec.reserve(length);
+    for (size_t i = 0; i < length; ++i) {
+        vec.push_back(static_cast<T>(src[i]));
+    }
+    return vec;
+}
+
+/**
  * Converts a std::vector of values to a new facebook::jsi::Array.
  * Handles strings, booleans, and numeric types appropriately.
  *
@@ -134,6 +177,72 @@ jsi::Array toJsiArray(jsi::Runtime &rt, const std::vector<T> &vec) {
         }
     }
     return arr;
+}
+
+template <typename>
+inline constexpr bool kAlwaysFalse = false;
+
+/**
+ * Maps an arithmetic C++ type to the name of the JS TypedArray constructor whose
+ * elements have the same layout (e.g. int32_t -> "Int32Array"). 64-bit integers
+ * are intentionally unsupported: their JS counterparts (BigInt64Array) hold
+ * bigints rather than numbers.
+ */
+template <typename Storage>
+constexpr const char *jsiTypedArrayName() {
+    if constexpr (std::is_same_v<Storage, int8_t>) {
+        return "Int8Array";
+    } else if constexpr (std::is_same_v<Storage, uint8_t>) {
+        return "Uint8Array";
+    } else if constexpr (std::is_same_v<Storage, int16_t>) {
+        return "Int16Array";
+    } else if constexpr (std::is_same_v<Storage, uint16_t>) {
+        return "Uint16Array";
+    } else if constexpr (std::is_same_v<Storage, int32_t>) {
+        return "Int32Array";
+    } else if constexpr (std::is_same_v<Storage, uint32_t>) {
+        return "Uint32Array";
+    } else if constexpr (std::is_same_v<Storage, float>) {
+        return "Float32Array";
+    } else if constexpr (std::is_same_v<Storage, double>) {
+        return "Float64Array";
+    } else {
+        static_assert(kAlwaysFalse<Storage>, "Unsupported TypedArray element type");
+    }
+}
+
+/**
+ * Converts a std::vector to a JS TypedArray backed by an ArrayBuffer. This is
+ * far cheaper to move across worklet runtime boundaries than toJsiArray:
+ * react-native-worklets clones the underlying ArrayBuffer with a single memcpy
+ * instead of serializing each element individually, which matters for long
+ * sequences (e.g. token ids). Read it back with fromJsiTypedArray.
+ *
+ * @tparam Storage The element type of the resulting TypedArray's storage, which
+ * also selects the JS view (e.g. int32_t -> Int32Array).
+ * @tparam T The source vector element type; each value is cast to Storage.
+ * Defaults to Storage.
+ * @param rt The JSI runtime instance.
+ * @param vec The source vector to convert.
+ * @return A new JS TypedArray containing the elements from the vector.
+ */
+template <typename Storage, typename T = Storage>
+jsi::Object toJsiTypedArray(jsi::Runtime &rt, const std::vector<T> &vec) {
+    static_assert(std::is_arithmetic_v<Storage>, "toJsiTypedArray requires an arithmetic storage type");
+    const size_t byteLength = vec.size() * sizeof(Storage);
+    auto arrayBuffer = rt.global()
+                           .getPropertyAsFunction(rt, "ArrayBuffer")
+                           .callAsConstructor(rt, static_cast<double>(byteLength))
+                           .asObject(rt);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): writing directly into the typed array's storage
+    auto *dst = reinterpret_cast<Storage *>(arrayBuffer.getArrayBuffer(rt).data(rt));
+    for (size_t i = 0; i < vec.size(); ++i) {
+        dst[i] = static_cast<Storage>(vec[i]);
+    }
+    return rt.global()
+        .getPropertyAsFunction(rt, jsiTypedArrayName<Storage>())
+        .callAsConstructor(rt, arrayBuffer)
+        .asObject(rt);
 }
 
 } // namespace rnexecutorch::core::conversions

--- a/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
+++ b/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
@@ -94,7 +94,8 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
             auto tokens = unwrap(rt, "encode: Failed to encode input",
                                  self->tokenizer_->encode(text, kNumAddedBosTokens, kNumAddedEosTokens));
 
-            return conversions::toJsiTypedArray<int32_t>(rt, tokens);
+            // Token ids are non-negative and well below 2^31, so int32 is lossless.
+            return conversions::toJsiTypedArray(rt, std::vector<int32_t>(tokens.begin(), tokens.end()));
         };
         return jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "encode"), 1, fnBody);
     }
@@ -121,7 +122,8 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
                 throw jsi::JSError(rt, "decode: Tokenizer has been disposed");
             }
 
-            auto tokens = conversions::fromJsiTypedArray<int32_t, uint64_t>(rt, "decode: tokens", args[0]);
+            auto ids = conversions::fromJsiTypedArray<int32_t>(rt, "decode: tokens", args[0]);
+            std::vector<uint64_t> tokens(ids.begin(), ids.end());
 
             if (tokens.empty()) {
                 return jsi::String::createFromUtf8(rt, "");

--- a/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
+++ b/packages/react-native-executorch/cpp/extensions/nlp/tokenizer.cpp
@@ -94,7 +94,7 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
             auto tokens = unwrap(rt, "encode: Failed to encode input",
                                  self->tokenizer_->encode(text, kNumAddedBosTokens, kNumAddedEosTokens));
 
-            return conversions::toJsiArray(rt, tokens);
+            return conversions::toJsiTypedArray<int32_t>(rt, tokens);
         };
         return jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, "encode"), 1, fnBody);
     }
@@ -121,7 +121,7 @@ jsi::Value TokenizerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
                 throw jsi::JSError(rt, "decode: Tokenizer has been disposed");
             }
 
-            auto tokens = conversions::asVector<uint64_t>(rt, "decode: tokens", args[0]);
+            auto tokens = conversions::fromJsiTypedArray<int32_t, uint64_t>(rt, "decode: tokens", args[0]);
 
             if (tokens.empty()) {
                 return jsi::String::createFromUtf8(rt, "");

--- a/packages/react-native-executorch/src/extensions/nlp/tokenizer.ts
+++ b/packages/react-native-executorch/src/extensions/nlp/tokenizer.ts
@@ -13,12 +13,9 @@ export type Tokenizer = {
 
   /**
    * Encodes a string into token ids (special tokens are added according to the
-   * tokenizer.json post_processor). Token ids are returned as an `Int32Array`
-   * so that, when the tokenizer runs on a background worklet runtime, the
-   * result is transferred to the caller thread as a single ArrayBuffer copy
-   * rather than serialized element by element (which is costly for long texts).
+   * tokenizer.json post_processor).
    * @param text The input text to tokenize.
-   * @returns The encoded token ids.
+   * @returns The encoded token ids as an `Int32Array`.
    */
   encode(text: string): Int32Array;
 

--- a/packages/react-native-executorch/src/extensions/nlp/tokenizer.ts
+++ b/packages/react-native-executorch/src/extensions/nlp/tokenizer.ts
@@ -13,19 +13,22 @@ export type Tokenizer = {
 
   /**
    * Encodes a string into token ids (special tokens are added according to the
-   * tokenizer.json post_processor).
+   * tokenizer.json post_processor). Token ids are returned as an `Int32Array`
+   * so that, when the tokenizer runs on a background worklet runtime, the
+   * result is transferred to the caller thread as a single ArrayBuffer copy
+   * rather than serialized element by element (which is costly for long texts).
    * @param text The input text to tokenize.
    * @returns The encoded token ids.
    */
-  encode(text: string): number[];
+  encode(text: string): Int32Array;
 
   /**
    * Decodes token ids back into a string.
-   * @param tokens The token ids to decode.
+   * @param tokens The token ids to decode, as returned by {@link encode}.
    * @param skipSpecialTokens Whether to omit special tokens. Defaults to `true`.
    * @returns The decoded text.
    */
-  decode(tokens: number[], skipSpecialTokens?: boolean): string;
+  decode(tokens: Int32Array, skipSpecialTokens?: boolean): string;
 
   /**
    * @returns The size of the tokenizer's vocabulary.

--- a/packages/react-native-executorch/src/extensions/speech/tasks/whisperSpeechToText.ts
+++ b/packages/react-native-executorch/src/extensions/speech/tasks/whisperSpeechToText.ts
@@ -258,12 +258,12 @@ export async function createWhisperSpeechToText<L extends WhisperLanguage = Whis
         if (isCancelled.getBlocking()) break;
 
         generated.push(nextToken);
-        if (onToken) scheduleOnRN(onToken, tokenizer.decode([nextToken]));
+        if (onToken) scheduleOnRN(onToken, tokenizer.decode(Int32Array.of(nextToken)));
         nextToken = decode(nextToken, position);
         position++;
       }
 
-      text += tokenizer.decode(generated);
+      text += tokenizer.decode(Int32Array.from(generated));
       offset += BUFFER_SIZE;
     }
 


### PR DESCRIPTION
## Description

`encode()` now returns an ArrayBuffer-backed `Int32Array` (and `decode()` takes one) instead of `number[]`. When the tokenizer runs on a background worklet runtime, react-native-worklets clones the result to the caller thread with a single `ArrayBuffer` memcpy rather than serializing each token individually — the per-element cost flagged in the review of #1274, which is significant for long texts.

Adds `conversions::toJsiInt32Array` / `fromJsiInt32Array` and migrates the internal consumers (whisper decode call sites; the text-embedding and SDXS paths already use array-like access).

### Introduces a breaking change?

- [x] Yes
- [ ] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

Run the `tokenizer` screen in `apps/nlp` — it auto-runs an encode/decode round-trip and asserts the results (logged under `[TokenizerTest]`).

### Related issues

Part of #1208; follows up review feedback on #1274.

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings