### PR TITLE
chore: Release v0.8.5

### DIFF
--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-executorch",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "An easy way to run AI models in React Native with ExecuTorch",
   "source": "./src/index.ts",
   "main": "./lib/module/index.js",


### PR DESCRIPTION
## Description

Patch release **v0.8.5**. The bundleId/system telemetry change (#1312) is already merged into `release/0.8`; this PR only bumps the core package version.

- Bump `packages/react-native-executorch/package.json` to `0.8.5`.
- Adapter packages (`bare-resource-fetcher`, `expo-resource-fetcher`) untouched — versions not bumped.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Related issues

#1312

### Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings