### PR TITLE
chore: Release v0.9.3

### DIFF
--- a/packages/react-native-executorch/android/build.gradle
+++ b/packages/react-native-executorch/android/build.gradle
@@ -115,6 +115,7 @@ android {
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
+    consumerProguardFiles "consumer-proguard-rules.pro"
     externalNativeBuild {
         cmake {
           abiFilters (*reactNativeArchitectures())

--- a/packages/react-native-executorch/android/consumer-proguard-rules.pro
+++ b/packages/react-native-executorch/android/consumer-proguard-rules.pro
@@ -1,0 +1,51 @@
+# Ported from ExecuTorch's official Android consumer rules:
+# https://github.com/pytorch/executorch/blob/904c667007aed15e9a3bb8278aa271b479450c85/extension/android/executorch_android/consumer-proguard-rules.pro
+
+# ExecuTorch Android AAR — Consumer ProGuard/R8 Rules
+#
+# These rules are automatically applied to any app that depends on the
+# ExecuTorch AAR. They prevent R8/ProGuard from stripping classes and
+# methods that are called from native (JNI) code.
+
+# Keep ExecuTorch classes and members annotated with @DoNotStrip.
+# Scoped to org.pytorch.executorch to avoid affecting unrelated libraries.
+-keep @com.facebook.jni.annotations.DoNotStrip class org.pytorch.executorch.** { *; }
+-keepclassmembers class org.pytorch.executorch.** {
+    @com.facebook.jni.annotations.DoNotStrip *;
+}
+
+# Keep all native methods across ExecuTorch packages.
+# Use -keepclasseswithmembers (not -keepclasseswithmembernames) to prevent
+# both shrinking and obfuscation of JNI entry points.
+-keepclasseswithmembers class org.pytorch.executorch.** {
+    native <methods>;
+}
+
+# Keep HybridData fields (accessed by fbjni via reflection).
+-keepclassmembers class org.pytorch.executorch.** {
+    com.facebook.jni.HybridData *;
+}
+
+# Keep ExecutorchRuntimeException and its factory/subclasses.
+# These are instantiated from JNI via jni_helper.cpp.
+-keep class org.pytorch.executorch.ExecutorchRuntimeException { *; }
+-keep class org.pytorch.executorch.ExecutorchRuntimeException$* { *; }
+
+# Keep EValue (fields and type codes accessed from native code).
+-keep class org.pytorch.executorch.EValue { *; }
+
+# Keep Tensor and its inner classes. The Tensor class has methods and fields
+# accessed from JNI (dtypeJniCode, shape, getRawDataBuffer, nativeNewTensor).
+-keep class org.pytorch.executorch.Tensor { *; }
+-keep class org.pytorch.executorch.Tensor$* { *; }
+
+# Keep LlmCallback interface methods (invoked from native code).
+-keep interface org.pytorch.executorch.extension.llm.LlmCallback { *; }
+
+# Keep AsrCallback interface methods (invoked from native code).
+-keep interface org.pytorch.executorch.extension.asr.AsrCallback { *; }
+
+# --- react-native-executorch rules (not from upstream) ---
+
+# RNE's own JNI entry point, resolved by literal descriptor from C++.
+-keep class com.swmansion.rnexecutorch.ETInstaller { *; }

--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-executorch",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "An easy way to run AI models in React Native with ExecuTorch",
   "source": "./src/index.ts",
   "main": "./lib/module/index.js",

--- a/packages/react-native-executorch/src/utils/ResourceFetcher.ts
+++ b/packages/react-native-executorch/src/utils/ResourceFetcher.ts
@@ -138,8 +138,10 @@ export class ResourceFetcher {
      * @remarks
      * **REQUIRED**: Used internally for reading configuration files (e.g., tokenizer configs).
      */
+    // Reference the class by name: `this` inside a static-field arrow gets
+    // rebound to module scope by Babel under RN's hermes transform profiles.
     readAsString: async (path: string) => {
-      return this.getAdapter().readAsString(path);
+      return ResourceFetcher.getAdapter().readAsString(path);
     },
   };
 }


### PR DESCRIPTION
## Description

Patch release **v0.9.3**. The bundleId/system telemetry change (#1311) is already merged into `release/0.9`. This PR cherry-picks the following bug fixes from `main` (chronological order, with `-x`) and bumps the core package version:

- fix(resource-fetcher): avoid `this` in static `fs` field initializer (#1310)
- fix(android): forward ExecuTorch consumer ProGuard rules (#1325)

Bump `packages/react-native-executorch/package.json` to `0.9.3`. Adapter packages (`bare-resource-fetcher`, `expo-resource-fetcher`) untouched by the cherry-picks — versions not bumped.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)

### Tested on

- [ ] iOS
- [ ] Android

### Related issues

#1310 #1325

### Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings