### PR TITLE
[RNE Rewrite] build(rewrite): decouple native lib artifacts from core versioning

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -43,11 +43,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RNET_HEADERS_ONLY: '1'
           RNET_TARGET: android-arm64-v8a
-          # TODO(#1291, @msluszniak): drop this override once a real versioned
-          # release exists. download-libs.js resolves the tag from the package
-          # version (v${PACKAGE_VERSION} == v0.0.0), but the placeholder 0.0.0 has
-          # no release; headers.tar.gz currently lives only on the test pre-release.
-          RNET_BASE_URL: https://github.com/software-mansion/react-native-executorch/releases/download/v0.0.0-rewrite-libs-test
         run: node scripts/download-libs.js
 
       - name: Run clang-tidy

--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react-native-executorch",
   "version": "0.0.0",
+  "nativeLibsVersion": "0.10.0",
   "description": "An easy way to run AI models in React Native with ExecuTorch",
   "main": "./lib/module/index.js",
   "module": "./lib/module/index.js",

--- a/packages/react-native-executorch/scripts/download-libs.js
+++ b/packages/react-native-executorch/scripts/download-libs.js
@@ -5,7 +5,9 @@
  * and extracts them into third-party/ so the existing CMakeLists.txt / podspec
  * can find them at build time without any other changes.
  *
- * Artifact layout on GitHub Releases (per version tag, e.g. v0.9.0):
+ * Artifacts are versioned independently of the npm package and live on their own
+ * GitHub Release tagged `v${nativeLibsVersion}-libs` (pinned via `nativeLibsVersion`
+ * in package.json). Artifact layout on that release (e.g. tag v0.10.0-libs):
  *
  *   headers.tar.gz                   -- ExecuTorch + c10 + torch + tokenizers + opencv
  *                                       headers (platform-independent; always downloaded)
@@ -76,11 +78,23 @@ const { execSync } = require('child_process');
 
 // ---- Config ----------------------------------------------------------------
 
-const PACKAGE_VERSION = require('../package.json').version;
+// The native artifacts are versioned independently of the npm package: they
+// live on their own GitHub Release tagged `v${LIBS_VERSION}-libs` and are pinned
+// here via `nativeLibsVersion` in package.json. The two lines coincide on a minor
+// cut (core v0.10.0 <-> libs v0.10.0-libs) but drift on patches — a core-only fix
+// keeps the pin (no re-upload), an assets-only fix bumps the pin in a core
+// release. The `-libs` suffix keeps the tags distinct when the numbers match.
+const LIBS_VERSION = require('../package.json').nativeLibsVersion;
+if (!process.env.RNET_BASE_URL && !LIBS_VERSION) {
+  throw new Error(
+    '[react-native-executorch] Missing "nativeLibsVersion" in package.json — cannot resolve the ' +
+      'native artifacts release. Set it to the libs version to pin, or set RNET_BASE_URL to override.'
+  );
+}
 const GITHUB_REPO = 'software-mansion/react-native-executorch';
 const BASE_URL =
   process.env.RNET_BASE_URL ||
-  `https://github.com/${GITHUB_REPO}/releases/download/v${PACKAGE_VERSION}`;
+  `https://github.com/${GITHUB_REPO}/releases/download/v${LIBS_VERSION}-libs`;
 
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
 const THIRD_PARTY_DIR = path.join(PACKAGE_ROOT, 'third-party');
@@ -89,7 +103,7 @@ const DEFAULT_CACHE_DIR = path.join(
   require('os').homedir(),
   '.cache',
   'react-native-executorch',
-  PACKAGE_VERSION
+  LIBS_VERSION
 );
 const CACHE_DIR = process.env.RNET_LIBS_CACHE_DIR || DEFAULT_CACHE_DIR;
 

--- a/packages/react-native-executorch/scripts/package-release-artifacts.sh
+++ b/packages/react-native-executorch/scripts/package-release-artifacts.sh
@@ -35,16 +35,17 @@
 #   cd dist-artifacts && python3 -m http.server 8080
 #   RNET_BASE_URL=http://localhost:8080 INIT_CWD=<repo-root> node scripts/download-libs.js
 #
-# Option B — GitHub pre-release:
-#   gh release create v0.9.0-libs-test --prerelease --title "libs test" \
+# Option B — throwaway GitHub pre-release (uses a -test suffix so it never
+# collides with the real v${nativeLibsVersion}-libs assets release):
+#   gh release create v0.10.0-libs-test --prerelease --title "libs test" \
 #     --notes "Test release, will be deleted." \
 #     --repo software-mansion/react-native-executorch
-#   gh release upload v0.9.0-libs-test dist-artifacts/* \
+#   gh release upload v0.10.0-libs-test dist-artifacts/* \
 #     --repo software-mansion/react-native-executorch
-#   RNET_BASE_URL=https://github.com/software-mansion/react-native-executorch/releases/download/v0.9.0-libs-test \
+#   RNET_BASE_URL=https://github.com/software-mansion/react-native-executorch/releases/download/v0.10.0-libs-test \
 #     INIT_CWD=<repo-root> node scripts/download-libs.js
 #   # cleanup:
-#   gh release delete v0.9.0-libs-test --repo software-mansion/react-native-executorch --yes
+#   gh release delete v0.10.0-libs-test --repo software-mansion/react-native-executorch --yes
 
 set -euo pipefail
 
@@ -55,9 +56,14 @@ IOS_DIR="$PACKAGE_ROOT/third-party/ios"
 OUT="$PACKAGE_ROOT/dist-artifacts"
 
 INCLUDE_DIR="$PACKAGE_ROOT/third-party/include"
-VERSION=$(node -p "require('$PACKAGE_ROOT/package.json').version")
+# Artifacts are versioned independently of the npm package (see download-libs.js).
+# The pin lives in package.json:nativeLibsVersion and the release is tagged
+# v${nativeLibsVersion}-libs — the `-libs` suffix keeps it distinct from the core
+# release tag (v${version}) when the two numbers coincide.
+LIBS_VERSION=$(node -p "require('$PACKAGE_ROOT/package.json').nativeLibsVersion")
+TAG="v$LIBS_VERSION-libs"
 
-echo "Packaging release artifacts for v$VERSION"
+echo "Packaging release artifacts for $TAG"
 mkdir -p "$OUT"
 
 # ---- Helpers ----------------------------------------------------------------
@@ -255,5 +261,11 @@ echo ""
 echo "Done. Artifacts written to dist-artifacts/:"
 ls -lh "$OUT"
 echo ""
-echo "Upload these files to the GitHub Release for v$VERSION:"
-echo "  https://github.com/software-mansion/react-native-executorch/releases/tag/v$VERSION"
+echo "Publish these to the $TAG assets release:"
+echo "  # first cut (pre-release while the native surface is still settling):"
+echo "  gh release create $TAG dist-artifacts/* --prerelease \\"
+echo "    --title '$TAG' --notes 'Native lib artifacts for react-native-executorch $LIBS_VERSION.' \\"
+echo "    --repo software-mansion/react-native-executorch"
+echo "  # when the surface is final, promote it to a full release:"
+echo "  gh release edit $TAG --prerelease=false --repo software-mansion/react-native-executorch"
+echo "  https://github.com/software-mansion/react-native-executorch/releases/tag/$TAG"


### PR DESCRIPTION
## Description

Version the prebuilt native artifacts independently of the npm package. They now live on their own GitHub Release tagged `v${nativeLibsVersion}-libs`, pinned via a new `nativeLibsVersion` field in `package.json`.

- `download-libs.js`: resolve `v${nativeLibsVersion}-libs`, key the cache on it, fail loudly if the pin is missing.
- `package-release-artifacts.sh`: publish against the `v*-libs` tag with a prerelease-now → promote-later recipe.
- `clang-tidy.yml`: drop the `RNET_BASE_URL` test-release override + TODO.

The `v0.10.0-libs` pre-release carrying the artifacts is published, so the resolution works with no override.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

From `packages/react-native-executorch`, with no `RNET_BASE_URL` override:

```
RNET_HEADERS_ONLY=1 RNET_TARGET=android-arm64-v8a INIT_CWD=<repo-root> node scripts/download-libs.js
```

Resolves `.../releases/download/v0.10.0-libs/headers.tar.gz` correctly.

### Screenshots

### Related issues

Closes #1291

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

The `v0.10.0-libs` release is a pre-release while the native surface for 0.10.0 settles; promote it with `gh release edit v0.10.0-libs --prerelease=false` once final.
