### PR TITLE
[RNE Rewrite] style(ts): standardize task naming, preprocessor options, and TSDoc conventions

### DIFF
--- a/packages/react-native-executorch/src/extensions/cv/ops/boxes.ts
+++ b/packages/react-native-executorch/src/extensions/cv/ops/boxes.ts
@@ -8,9 +8,24 @@ import { scalePoint } from './points';
  * @category Types
  */
 export type BoxMap = {
-  xyxy: { xmin: number; ymin: number; xmax: number; ymax: number };
-  xywh: { xmin: number; ymin: number; w: number; h: number };
-  cxcywh: { cx: number; cy: number; w: number; h: number };
+  xyxy: {
+    readonly xmin: number;
+    readonly ymin: number;
+    readonly xmax: number;
+    readonly ymax: number;
+  };
+  xywh: {
+    readonly xmin: number;
+    readonly ymin: number;
+    readonly w: number;
+    readonly h: number;
+  };
+  cxcywh: {
+    readonly cx: number;
+    readonly cy: number;
+    readonly w: number;
+    readonly h: number;
+  };
 };
 
 /**

--- a/packages/react-native-executorch/src/extensions/cv/ops/boxes.ts
+++ b/packages/react-native-executorch/src/extensions/cv/ops/boxes.ts
@@ -145,7 +145,7 @@ export function scaleBox<F extends BoxFormat>(
  * @category Types
  */
 export type NmsOptions = {
-  /** Bounding box format {@link BoxFormat}. */
+  /** How bounding box coordinates are interpreted {@link BoxFormat}. */
   readonly boxFormat: BoxFormat;
   /** Intersection over Union (IoU) threshold for suppressing overlapping boxes. */
   readonly iouThreshold: number;

--- a/packages/react-native-executorch/src/extensions/cv/ops/boxes.ts
+++ b/packages/react-native-executorch/src/extensions/cv/ops/boxes.ts
@@ -130,9 +130,16 @@ export function scaleBox<F extends BoxFormat>(
  * @category Types
  */
 export type NmsOptions = {
+  /** Bounding box format (`xyxy`, `cxcywh`, etc.). */
   readonly boxFormat: BoxFormat;
+  /** IoU threshold for suppressing overlapping boxes. */
   readonly iouThreshold: number;
+  /** Minimum confidence score threshold for filtering candidate boxes. */
   readonly confidenceThreshold: number;
+  /**
+   * NMS algorithm variant (`standard` for hard suppression, `weighted` for soft
+   * coordinate averaging).
+   */
   readonly nmsType: 'standard' | 'weighted';
 };
 
@@ -142,7 +149,13 @@ export type NmsOptions = {
  * @category Utils
  * @param boxes Bounding boxes coordinate tensor.
  * @param scores Bounding boxes confidence scores tensor.
- * @param opts Options configure NMS thresholds and execution mode.
+ * @param opts Options configuring NMS thresholds and execution mode.
+ * @param opts.boxFormat Bounding box format (`xyxy`, `cxcywh`, etc.).
+ * @param opts.iouThreshold Intersection over Union (IoU) threshold for
+ * suppression.
+ * @param opts.confidenceThreshold Minimum confidence score for candidate
+ * selection.
+ * @param opts.nmsType Suppression algorithm mode (`standard` or `weighted`).
  * @returns The resulting indices of the non-suppressed boxes:
  * - For `standard` NMS: A 1D array of indices (`number[]`) representing the
  *   selected boxes.

--- a/packages/react-native-executorch/src/extensions/cv/ops/boxes.ts
+++ b/packages/react-native-executorch/src/extensions/cv/ops/boxes.ts
@@ -75,8 +75,8 @@ export function decodeBox<F extends BoxFormat>(
  * @param opts Options defining dimensions and resize modes.
  * @param opts.from The source bounds (e.g. model input dimensions).
  * @param opts.to The destination bounds (e.g. original image dimensions).
- * @param opts.resizeMode The mode used to resize the image ('letterbox' or
- * 'stretch').
+ * @param opts.resizeMode The mode used to resize the image {@link ResizeMode}
+ * (excluding `'crop'`).
  * @returns The scaled BoundingBox object.
  */
 export function scaleBox<F extends BoxFormat>(
@@ -145,9 +145,9 @@ export function scaleBox<F extends BoxFormat>(
  * @category Types
  */
 export type NmsOptions = {
-  /** Bounding box format (`xyxy`, `cxcywh`, etc.). */
+  /** Bounding box format {@link BoxFormat}. */
   readonly boxFormat: BoxFormat;
-  /** IoU threshold for suppressing overlapping boxes. */
+  /** Intersection over Union (IoU) threshold for suppressing overlapping boxes. */
   readonly iouThreshold: number;
   /** Minimum confidence score threshold for filtering candidate boxes. */
   readonly confidenceThreshold: number;
@@ -165,12 +165,12 @@ export type NmsOptions = {
  * @param boxes Bounding boxes coordinate tensor.
  * @param scores Bounding boxes confidence scores tensor.
  * @param opts Options configuring NMS thresholds and execution mode.
- * @param opts.boxFormat Bounding box format (`xyxy`, `cxcywh`, etc.).
+ * @param opts.boxFormat The bounding box format {@link BoxFormat}.
  * @param opts.iouThreshold Intersection over Union (IoU) threshold for
  * suppression.
  * @param opts.confidenceThreshold Minimum confidence score for candidate
  * selection.
- * @param opts.nmsType Suppression algorithm mode (`standard` or `weighted`).
+ * @param opts.nmsType The NMS algorithm variant {@link NmsOptions.nmsType}.
  * @returns The resulting indices of the non-suppressed boxes:
  * - For `standard` NMS: A 1D array of indices (`number[]`) representing the
  *   selected boxes.

--- a/packages/react-native-executorch/src/extensions/cv/ops/image.ts
+++ b/packages/react-native-executorch/src/extensions/cv/ops/image.ts
@@ -74,7 +74,7 @@ export type InterpolationMethod = 'nearest' | 'area' | 'cubic' | 'lanczos' | 'li
  * @category Types
  */
 export type ResizeOptions = {
-  /** Resize algorithm mode {@link ResizeMode}. */
+  /** How the image is resized {@link ResizeMode}. */
   readonly mode?: ResizeMode;
   /** Background fill value used when letterboxing. */
   readonly padValue?: number;
@@ -87,9 +87,12 @@ export type ResizeOptions = {
  * @category Types
  */
 export type NormalizeOptions = {
-  /** Multiplicative scaling coefficient(s). */
+  /**
+   * Multiplicative coefficient applied as `pixel * alpha`. Single value for
+   * uniform scaling, array for per-channel.
+   */
   readonly alpha?: number | readonly number[];
-  /** Additive offset coefficient(s). */
+  /** Additive offset applied as `pixel * alpha + beta`. Single value or per-channel array. */
   readonly beta?: number | readonly number[];
 };
 

--- a/packages/react-native-executorch/src/extensions/cv/ops/image.ts
+++ b/packages/react-native-executorch/src/extensions/cv/ops/image.ts
@@ -74,8 +74,11 @@ export type InterpolationMethod = 'nearest' | 'area' | 'cubic' | 'lanczos' | 'li
  * @category Types
  */
 export type ResizeOptions = {
+  /** Resize algorithm mode (`stretch`, `letterbox`, `crop`). */
   readonly mode?: ResizeMode;
+  /** Background fill value used when letterboxing. */
   readonly padValue?: number;
+  /** Pixel interpolation method. */
   readonly interpolation?: InterpolationMethod;
 };
 
@@ -84,7 +87,9 @@ export type ResizeOptions = {
  * @category Types
  */
 export type NormalizeOptions = {
+  /** Multiplicative scaling coefficient(s). */
   readonly alpha?: number | readonly number[];
+  /** Additive offset coefficient(s). */
   readonly beta?: number | readonly number[];
 };
 
@@ -99,6 +104,11 @@ export type NormalizeOptions = {
  * to. `dst` must be in HWC layout and its number of channels must match `src`.
  * Shape [H',W',C].
  * @param opts Configuration options for resizing.
+ * @param opts.mode Resize algorithm mode (`stretch`, `letterbox`, `crop`).
+ * Defaults to `'stretch'`.
+ * @param opts.interpolation Pixel interpolation method (`linear`, `lanczos`,
+ * etc.). Defaults to `'lanczos'`.
+ * @param opts.padValue Fill value for letterboxing. Defaults to `0`.
  * @returns The destination tensor containing the resized image.
  */
 export function resize(src: Tensor, dst: Tensor, opts?: ResizeOptions): Tensor {
@@ -173,6 +183,9 @@ export function toChannelsLast(src: Tensor, dst: Tensor): Tensor {
  * @param dst The pre-allocated destination tensor to write the normalized
  * values to. `dst` must have the same shape as `src`. Shape [C,H,W].
  * @param opts Normalization scaling coefficients.
+ * @param opts.alpha Multiplicative scaling coefficient(s). Defaults to
+ * `1 / 255.0`.
+ * @param opts.beta Additive offset coefficient(s). Defaults to `0.0`.
  * @returns The destination tensor containing the normalized image.
  */
 export function normalize(src: Tensor, dst: Tensor, opts?: NormalizeOptions): Tensor {

--- a/packages/react-native-executorch/src/extensions/cv/ops/image.ts
+++ b/packages/react-native-executorch/src/extensions/cv/ops/image.ts
@@ -74,11 +74,11 @@ export type InterpolationMethod = 'nearest' | 'area' | 'cubic' | 'lanczos' | 'li
  * @category Types
  */
 export type ResizeOptions = {
-  /** Resize algorithm mode (`stretch`, `letterbox`, `crop`). */
+  /** Resize algorithm mode {@link ResizeMode}. */
   readonly mode?: ResizeMode;
   /** Background fill value used when letterboxing. */
   readonly padValue?: number;
-  /** Pixel interpolation method. */
+  /** Pixel interpolation method {@link InterpolationMethod}. */
   readonly interpolation?: InterpolationMethod;
 };
 
@@ -96,18 +96,17 @@ export type NormalizeOptions = {
 /**
  * Resizes an image tensor from a source dimension to a destination dimension.
  *
- * Supports various resize modes (`stretch`, `letterbox`, `crop`) and
- * interpolation algorithms (`linear`, `lanczos`, etc.).
+ * Supports various {@link ResizeMode} and {@link InterpolationMethod} options.
  * @category Typescript API
  * @param src The source image tensor in HWC layout. Shape [H,W,C].
  * @param dst The pre-allocated destination tensor to write the resized image
  * to. `dst` must be in HWC layout and its number of channels must match `src`.
  * Shape [H',W',C].
  * @param opts Configuration options for resizing.
- * @param opts.mode Resize algorithm mode (`stretch`, `letterbox`, `crop`).
- * Defaults to `'stretch'`.
- * @param opts.interpolation Pixel interpolation method (`linear`, `lanczos`,
- * etc.). Defaults to `'lanczos'`.
+ * @param opts.mode The resize algorithm mode {@link ResizeMode}. Defaults to
+ * `'stretch'`.
+ * @param opts.interpolation The pixel interpolation method
+ * {@link InterpolationMethod}. Defaults to `'lanczos'`.
  * @param opts.padValue Fill value for letterboxing. Defaults to `0`.
  * @returns The destination tensor containing the resized image.
  */

--- a/packages/react-native-executorch/src/extensions/cv/ops/points.ts
+++ b/packages/react-native-executorch/src/extensions/cv/ops/points.ts
@@ -17,8 +17,8 @@ export type Point = {
  * @param opts Options detailing the scaling factors and resize mode.
  * @param opts.from The source bounds (e.g. model input dimensions).
  * @param opts.to The destination bounds (e.g. original image dimensions).
- * @param opts.resizeMode The mode used to resize the image ('letterbox' or
- * 'stretch').
+ * @param opts.resizeMode The mode used to resize the image {@link ResizeMode}
+ * (excluding `'crop'`).
  * @returns The scaled coordinate point.
  */
 export function scalePoint(

--- a/packages/react-native-executorch/src/extensions/cv/tasks/classification.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/classification.ts
@@ -26,7 +26,11 @@ export type ClassifierOptions<L> = ImagePreprocessorOptions & {
 export type ClassifierModel<L> = {
   /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
-  /** Image preprocessor and vocabulary options. */
+  /**
+   * Image preprocessing and label vocabulary
+   * {@link ClassifierOptions}. The `labels` array length must
+   * match the model's output dimension.
+   */
   readonly modelOpts: ClassifierOptions<L>;
 };
 

--- a/packages/react-native-executorch/src/extensions/cv/tasks/classification.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/classification.ts
@@ -27,7 +27,7 @@ export type ClassifierModel<L> = {
   /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
   /** Image preprocessor and vocabulary options. */
-  readonly opts: ClassifierOptions<L>;
+  readonly modelOpts: ClassifierOptions<L>;
 };
 
 /**
@@ -81,7 +81,7 @@ export async function createClassifier<L>(
    */
   classifyWorklet: (input: ImageBuffer, options?: { topk?: number }) => Classification<L>[];
 }> {
-  const { modelPath, opts } = config;
+  const { modelPath, modelOpts } = config;
   const model = await wrapAsync(loadModel, runtime)(modelPath);
 
   const meta = validateModelSchema(
@@ -94,9 +94,9 @@ export async function createClassifier<L>(
   const outShape = meta.outputTensorMeta[0]!.shape;
 
   const numLabels = outShape[outShape.length - 1]!;
-  if (opts.labels.length !== numLabels) {
+  if (modelOpts.labels.length !== numLabels) {
     throw new Error(
-      `Classifier labels length (${opts.labels.length}) must match model output dimension (${numLabels}).`
+      `Classifier labels length (${modelOpts.labels.length}) must match model output dimension (${numLabels}).`
     );
   }
 
@@ -107,7 +107,7 @@ export async function createClassifier<L>(
   ] as const;
 
   const [tLogits, tProbas] = tensors;
-  const preprocessor = createImagePreprocessor(opts, inpShape);
+  const preprocessor = createImagePreprocessor(modelOpts, inpShape);
 
   const dispose = () => {
     preprocessor.dispose();
@@ -132,7 +132,7 @@ export async function createClassifier<L>(
       .getData(new Float32Array(tProbas.numel));
 
     return Array.from(probas)
-      .map((confidence, index) => ({ confidence, label: opts.labels[index]! }))
+      .map((confidence, index) => ({ confidence, label: modelOpts.labels[index]! }))
       .sort((a, b) => b.confidence - a.confidence)
       .slice(0, options?.topk);
   };

--- a/packages/react-native-executorch/src/extensions/cv/tasks/classification.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/classification.ts
@@ -14,14 +14,19 @@ import { createImagePreprocessor, type ImagePreprocessorOptions } from './prepro
  * vocabulary.
  * @category Types
  */
-export type ClassifierOptions<L> = ImagePreprocessorOptions & { readonly labels: readonly L[] };
+export type ClassifierOptions<L> = ImagePreprocessorOptions & {
+  /** Array of class labels matching the model's output vocabulary. */
+  readonly labels: readonly L[];
+};
 
 /**
  * Model configuration required to instantiate a classifier task runner.
  * @category Types
  */
 export type ClassifierModel<L> = {
+  /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
+  /** Image preprocessor and vocabulary options. */
   readonly opts: ClassifierOptions<L>;
 };
 
@@ -30,7 +35,9 @@ export type ClassifierModel<L> = {
  * @category Types
  */
 export type Classification<L> = {
+  /** Predicted class label. */
   readonly label: L;
+  /** Confidence score of the prediction (between 0.0 and 1.0). */
   readonly confidence: number;
 };
 

--- a/packages/react-native-executorch/src/extensions/cv/tasks/classification.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/classification.ts
@@ -22,7 +22,7 @@ export type ClassifierOptions<L> = ImagePreprocessorOptions & { readonly labels:
  */
 export type ClassifierModel<L> = {
   readonly modelPath: string;
-  readonly classifierOpts: ClassifierOptions<L>;
+  readonly opts: ClassifierOptions<L>;
 };
 
 /**
@@ -74,7 +74,7 @@ export async function createClassifier<L>(
    */
   classifyWorklet: (input: ImageBuffer, options?: { topk?: number }) => Classification<L>[];
 }> {
-  const { modelPath, classifierOpts } = config;
+  const { modelPath, opts } = config;
   const model = await wrapAsync(loadModel, runtime)(modelPath);
 
   const meta = validateModelSchema(
@@ -87,9 +87,9 @@ export async function createClassifier<L>(
   const outShape = meta.outputTensorMeta[0]!.shape;
 
   const numLabels = outShape[outShape.length - 1]!;
-  if (classifierOpts.labels.length !== numLabels) {
+  if (opts.labels.length !== numLabels) {
     throw new Error(
-      `Classifier labels length (${classifierOpts.labels.length}) must match model output dimension (${numLabels}).`
+      `Classifier labels length (${opts.labels.length}) must match model output dimension (${numLabels}).`
     );
   }
 
@@ -100,7 +100,7 @@ export async function createClassifier<L>(
   ] as const;
 
   const [tLogits, tProbas] = tensors;
-  const preprocessor = createImagePreprocessor(classifierOpts, inpShape);
+  const preprocessor = createImagePreprocessor(opts, inpShape);
 
   const dispose = () => {
     preprocessor.dispose();
@@ -125,7 +125,7 @@ export async function createClassifier<L>(
       .getData(new Float32Array(tProbas.numel));
 
     return Array.from(probas)
-      .map((confidence, index) => ({ confidence, label: classifierOpts.labels[index]! }))
+      .map((confidence, index) => ({ confidence, label: opts.labels[index]! }))
       .sort((a, b) => b.confidence - a.confidence)
       .slice(0, options?.topk);
   };

--- a/packages/react-native-executorch/src/extensions/cv/tasks/imageEmbedding.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/imageEmbedding.ts
@@ -13,7 +13,9 @@ import { createImagePreprocessor, type ImagePreprocessorOptions } from './prepro
  * @category Types
  */
 export type ImageEmbedderModel = {
+  /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
+  /** Image preprocessor options. */
   readonly opts: ImagePreprocessorOptions;
 };
 

--- a/packages/react-native-executorch/src/extensions/cv/tasks/imageEmbedding.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/imageEmbedding.ts
@@ -16,7 +16,7 @@ export type ImageEmbedderModel = {
   /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
   /** Image preprocessor options. */
-  readonly opts: ImagePreprocessorOptions;
+  readonly modelOpts: ImagePreprocessorOptions;
 };
 
 /**
@@ -55,7 +55,7 @@ export async function createImageEmbedder(
    */
   embedWorklet: (input: ImageBuffer) => Float32Array;
 }> {
-  const { modelPath, opts } = config;
+  const { modelPath, modelOpts } = config;
   const model = await wrapAsync(loadModel, runtime)(modelPath);
 
   const meta = validateModelSchema(
@@ -69,7 +69,7 @@ export async function createImageEmbedder(
 
   const tensors = [tensor('float32', outShape)] as const;
   const [tEmbedding] = tensors;
-  const preprocessor = createImagePreprocessor(opts, inpShape);
+  const preprocessor = createImagePreprocessor(modelOpts, inpShape);
 
   const dispose = () => {
     preprocessor.dispose();

--- a/packages/react-native-executorch/src/extensions/cv/tasks/imageEmbedding.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/imageEmbedding.ts
@@ -15,7 +15,10 @@ import { createImagePreprocessor, type ImagePreprocessorOptions } from './prepro
 export type ImageEmbedderModel = {
   /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
-  /** Image preprocessor options. */
+  /**
+   * Image preprocessing (resize, color conversion, normalization)
+   * for embedding models {@link ImagePreprocessorOptions}.
+   */
   readonly modelOpts: ImagePreprocessorOptions;
 };
 

--- a/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
@@ -31,13 +31,13 @@ export type InstanceSegmenterOptions<F extends BoxFormat, L> = Omit<
   ImagePreprocessorOptions,
   'resizeMode'
 > & {
-  /** Resize mode for input images. */
+  /** Resize mode for input images. Must be `'stretch'`. */
   readonly resizeMode: 'stretch';
   /** Array of class labels matching the model's output vocabulary. */
   readonly labels: readonly L[];
-  /** Bounding box format exported by the model (`xyxy`, `cxcywh`, etc.). */
+  /** Bounding box format {@link BoxFormat}. */
   readonly boxFormat: F;
-  /** Default IoU threshold for Non-Maximum Suppression (NMS). */
+  /** Default Intersection over Union (IoU) threshold for Non-Maximum Suppression (NMS). */
   readonly defaultIouThreshold: number;
   /** Default probability threshold for mask values. */
   readonly defaultMaskThreshold: number;
@@ -107,7 +107,7 @@ export async function createInstanceSegmenter<F extends BoxFormat, L>(
    * @param options Execution override options.
    * @param options.confidenceThreshold Minimum confidence threshold. If
    * omitted, uses `modelOpts.defaultConfidenceThreshold`.
-   * @param options.iouThreshold IoU threshold in NMS. If omitted, uses
+   * @param options.iouThreshold Intersection over Union (IoU) threshold in NMS. If omitted, uses
    * `modelOpts.defaultIouThreshold`.
    * @param options.maskThreshold Mask binarization threshold. If omitted,
    * uses `modelOpts.defaultMaskThreshold`.

--- a/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
@@ -55,7 +55,7 @@ export type InstanceSegmenterModel<F extends BoxFormat, L> = {
   /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
   /** Instance segmenter options. */
-  readonly opts: InstanceSegmenterOptions<F, L>;
+  readonly modelOpts: InstanceSegmenterOptions<F, L>;
 };
 
 /**
@@ -106,11 +106,11 @@ export async function createInstanceSegmenter<F extends BoxFormat, L>(
    * @param input The input image buffer.
    * @param options Execution override options.
    * @param options.confidenceThreshold Minimum confidence threshold. If
-   * omitted, uses `opts.defaultConfidenceThreshold`.
+   * omitted, uses `modelOpts.defaultConfidenceThreshold`.
    * @param options.iouThreshold IoU threshold in NMS. If omitted, uses
-   * `opts.defaultIouThreshold`.
+   * `modelOpts.defaultIouThreshold`.
    * @param options.maskThreshold Mask binarization threshold. If omitted,
-   * uses `opts.defaultMaskThreshold`.
+   * uses `modelOpts.defaultMaskThreshold`.
    * @returns A promise resolving to a list of detected instances.
    */
   segmentInstances: (
@@ -127,7 +127,7 @@ export async function createInstanceSegmenter<F extends BoxFormat, L>(
     options?: { confidenceThreshold?: number; iouThreshold?: number; maskThreshold?: number }
   ) => InstanceSegmentationResult<F, L>[];
 }> {
-  const { modelPath, opts } = config;
+  const { modelPath, modelOpts } = config;
   const model = await wrapAsync(loadModel, runtime)(modelPath);
   const meta = validateModelSchema(
     model,
@@ -163,7 +163,7 @@ export async function createInstanceSegmenter<F extends BoxFormat, L>(
 
   const [tBoxes, tScores, tClasses, tAllMasks, tMask] = tensors;
 
-  const preprocessor = createImagePreprocessor(opts, inpShape);
+  const preprocessor = createImagePreprocessor(modelOpts, inpShape);
 
   const dispose = () => {
     preprocessor.dispose();
@@ -179,16 +179,17 @@ export async function createInstanceSegmenter<F extends BoxFormat, L>(
     const tInput = preprocessor.process(input);
     model.execute('forward', [tInput], [tBoxes, tScores, tClasses, tAllMasks]);
 
-    const iouThreshold = options?.iouThreshold ?? opts.defaultIouThreshold;
-    const maskThreshold = options?.maskThreshold ?? opts.defaultMaskThreshold;
-    const confidenceThreshold = options?.confidenceThreshold ?? opts.defaultConfidenceThreshold;
+    const iouThreshold = options?.iouThreshold ?? modelOpts.defaultIouThreshold;
+    const maskThreshold = options?.maskThreshold ?? modelOpts.defaultMaskThreshold;
+    const confidenceThreshold =
+      options?.confidenceThreshold ?? modelOpts.defaultConfidenceThreshold;
 
     const eps = 1e-7;
     const clampedMaskThreshold = Math.max(eps, Math.min(1 - eps, maskThreshold));
     const logitMaskThreshold = Math.log(clampedMaskThreshold / (1 - clampedMaskThreshold));
 
     const indices = nms(tBoxes, tScores, {
-      boxFormat: opts.boxFormat,
+      boxFormat: modelOpts.boxFormat,
       iouThreshold,
       confidenceThreshold,
       nmsType: 'standard',
@@ -213,12 +214,12 @@ export async function createInstanceSegmenter<F extends BoxFormat, L>(
       for (const idx of indices) {
         const confidence = scores[idx]!;
         const classIdx = Math.round(classes[idx]!);
-        const label = opts.labels[classIdx];
+        const label = modelOpts.labels[classIdx];
 
         if (label === undefined) {
           throw new Error(
             `InstanceSegmenter: Predicted class index ${classIdx} is ` +
-              `out of bounds for labels array of size ${opts.labels.length}.`
+              `out of bounds for labels array of size ${modelOpts.labels.length}.`
           );
         }
 
@@ -227,7 +228,7 @@ export async function createInstanceSegmenter<F extends BoxFormat, L>(
         const c = boxes[idx * 4 + 2]!;
         const d = boxes[idx * 4 + 3]!;
 
-        const box = scaleBox(decodeBox([a, b, c, d], opts.boxFormat), {
+        const box = scaleBox(decodeBox([a, b, c, d], modelOpts.boxFormat), {
           from: { width: targetW, height: targetH },
           to: { width: input.width, height: input.height },
           resizeMode: 'stretch',

--- a/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
@@ -31,11 +31,17 @@ export type InstanceSegmenterOptions<F extends BoxFormat, L> = Omit<
   ImagePreprocessorOptions,
   'resizeMode'
 > & {
+  /** Resize mode for input images. */
   readonly resizeMode: 'stretch';
+  /** Array of class labels matching the model's output vocabulary. */
   readonly labels: readonly L[];
+  /** Bounding box format exported by the model (`xyxy`, `cxcywh`, etc.). */
   readonly boxFormat: F;
+  /** Default IoU threshold for Non-Maximum Suppression (NMS). */
   readonly defaultIouThreshold: number;
+  /** Default probability threshold for mask values. */
   readonly defaultMaskThreshold: number;
+  /** Default minimum confidence score threshold for detected instances. */
   readonly defaultConfidenceThreshold: number;
 };
 
@@ -46,7 +52,9 @@ export type InstanceSegmenterOptions<F extends BoxFormat, L> = Omit<
  * @typeParam L The label type.
  */
 export type InstanceSegmenterModel<F extends BoxFormat, L> = {
+  /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
+  /** Instance segmenter options. */
   readonly opts: InstanceSegmenterOptions<F, L>;
 };
 
@@ -58,9 +66,13 @@ export type InstanceSegmenterModel<F extends BoxFormat, L> = {
  * @typeParam L The label type.
  */
 export type InstanceSegmentationResult<F extends BoxFormat, L> = {
+  /** Scaled bounding box coordinates matching the input image resolution. */
   readonly box: BoundingBox<F>;
+  /** Binary segmentation mask buffer cropped to the instance bounding box. */
   readonly mask: ImageBuffer;
+  /** Predicted instance class label. */
   readonly label: L;
+  /** Confidence score of the instance detection (between 0.0 and 1.0). */
   readonly confidence: number;
 };
 
@@ -93,10 +105,12 @@ export async function createInstanceSegmenter<F extends BoxFormat, L>(
    * Performs asynchronous instance segmentation on the given input image.
    * @param input The input image buffer.
    * @param options Execution override options.
-   * @param options.confidenceThreshold Override for the minimum confidence
-   * threshold.
-   * @param options.iouThreshold Override for the IoU threshold in NMS.
-   * @param options.maskThreshold Override for the mask binarization threshold.
+   * @param options.confidenceThreshold Minimum confidence threshold. If
+   * omitted, uses `opts.defaultConfidenceThreshold`.
+   * @param options.iouThreshold IoU threshold in NMS. If omitted, uses
+   * `opts.defaultIouThreshold`.
+   * @param options.maskThreshold Mask binarization threshold. If omitted,
+   * uses `opts.defaultMaskThreshold`.
    * @returns A promise resolving to a list of detected instances.
    */
   segmentInstances: (

--- a/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
@@ -35,7 +35,7 @@ export type InstanceSegmenterOptions<F extends BoxFormat, L> = Omit<
   readonly resizeMode: 'stretch';
   /** Array of class labels matching the model's output vocabulary. */
   readonly labels: readonly L[];
-  /** Bounding box format {@link BoxFormat}. */
+  /** How bounding box coordinates are interpreted {@link BoxFormat}. */
   readonly boxFormat: F;
   /** Default Intersection over Union (IoU) threshold for Non-Maximum Suppression (NMS). */
   readonly defaultIouThreshold: number;
@@ -54,7 +54,11 @@ export type InstanceSegmenterOptions<F extends BoxFormat, L> = Omit<
 export type InstanceSegmenterModel<F extends BoxFormat, L> = {
   /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
-  /** Instance segmenter options. */
+  /**
+   * Image preprocessing, label vocabulary, bounding box format,
+   * and default NMS/mask/confidence thresholds
+   * {@link InstanceSegmenterOptions}.
+   */
   readonly modelOpts: InstanceSegmenterOptions<F, L>;
 };
 

--- a/packages/react-native-executorch/src/extensions/cv/tasks/keypointDetection.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/keypointDetection.ts
@@ -22,10 +22,15 @@ export type KeypointDetectorOptions<F extends BoxFormat, L extends PropertyKey> 
   ImagePreprocessorOptions,
   'resizeMode'
 > & {
+  /** Resize mode for preprocessing input images (`stretch` or `letterbox`). */
   readonly resizeMode: Exclude<ResizeMode, 'crop'>;
+  /** Bounding box format exported by the model (`xyxy`, `cxcywh`, etc.). */
   readonly boxFormat: F;
+  /** Array of landmark names matching the model output keypoint locations. */
   readonly landmarks: readonly L[];
+  /** Default IoU threshold for Non-Maximum Suppression (NMS). */
   readonly defaultIouThreshold: number;
+  /** Default minimum confidence score threshold for keypoint detections. */
   readonly defaultConfidenceThreshold: number;
 };
 
@@ -34,7 +39,9 @@ export type KeypointDetectorOptions<F extends BoxFormat, L extends PropertyKey> 
  * @category Types
  */
 export type KeypointDetectorModel<F extends BoxFormat, L extends PropertyKey> = {
+  /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
+  /** Keypoint detector options. */
   readonly opts: KeypointDetectorOptions<F, L>;
 };
 
@@ -51,8 +58,11 @@ export type Landmarks<L extends PropertyKey> = Record<L, Point & { readonly conf
  * @category Types
  */
 export type KeypointDetection<F extends BoxFormat, L extends PropertyKey> = {
+  /** Scaled bounding box coordinates matching the input image resolution. */
   readonly box: BoundingBox<F>;
+  /** Overall confidence score of the detection (between 0.0 and 1.0). */
   readonly confidence: number;
+  /** Map of landmark names to their scaled pixel coordinates and individual confidence scores. */
   readonly landmarks: Landmarks<L>;
 };
 
@@ -160,9 +170,9 @@ export async function createKeypointDetector<F extends BoxFormat, L extends Prop
    * @param input The input image buffer.
    * @param options Configuration options for keypoint detection.
    * @param options.confidenceThreshold Minimum confidence score for a
-   * detection. If omitted, uses the model default.
+   * detection. If omitted, uses `opts.defaultConfidenceThreshold`.
    * @param options.iouThreshold Intersection over Union (IoU) threshold for
-   * NMS. If omitted, uses the model default.
+   * NMS. If omitted, uses `opts.defaultIouThreshold`.
    * @returns A promise resolving to the list of keypoint detections.
    */
   detectKeypoints: (

--- a/packages/react-native-executorch/src/extensions/cv/tasks/keypointDetection.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/keypointDetection.ts
@@ -42,7 +42,7 @@ export type KeypointDetectorModel<F extends BoxFormat, L extends PropertyKey> = 
   /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
   /** Keypoint detector options. */
-  readonly opts: KeypointDetectorOptions<F, L>;
+  readonly modelOpts: KeypointDetectorOptions<F, L>;
 };
 
 /**
@@ -170,9 +170,9 @@ export async function createKeypointDetector<F extends BoxFormat, L extends Prop
    * @param input The input image buffer.
    * @param options Configuration options for keypoint detection.
    * @param options.confidenceThreshold Minimum confidence score for a
-   * detection. If omitted, uses `opts.defaultConfidenceThreshold`.
+   * detection. If omitted, uses `modelOpts.defaultConfidenceThreshold`.
    * @param options.iouThreshold Intersection over Union (IoU) threshold for
-   * NMS. If omitted, uses `opts.defaultIouThreshold`.
+   * NMS. If omitted, uses `modelOpts.defaultIouThreshold`.
    * @returns A promise resolving to the list of keypoint detections.
    */
   detectKeypoints: (
@@ -188,8 +188,8 @@ export async function createKeypointDetector<F extends BoxFormat, L extends Prop
     options?: { confidenceThreshold?: number; iouThreshold?: number }
   ) => KeypointDetection<F, L>[];
 }> {
-  const { modelPath, opts } = config;
-  const { landmarks } = opts;
+  const { modelPath, modelOpts } = config;
+  const { landmarks } = modelOpts;
   const model = await wrapAsync(loadModel, runtime)(modelPath);
   const meta = validateModelSchema(
     model,
@@ -215,7 +215,7 @@ export async function createKeypointDetector<F extends BoxFormat, L extends Prop
   ] as const;
 
   const [tBoxes, tScores, tKeypoints] = tensors;
-  const preprocessor = createImagePreprocessor(opts, inpShape);
+  const preprocessor = createImagePreprocessor(modelOpts, inpShape);
 
   const dispose = () => {
     preprocessor.dispose();
@@ -231,11 +231,12 @@ export async function createKeypointDetector<F extends BoxFormat, L extends Prop
     const tInput = preprocessor.process(input);
     model.execute('forward', [tInput], [tBoxes, tScores, tKeypoints]);
 
-    const iouThreshold = options?.iouThreshold ?? opts.defaultIouThreshold;
-    const confidenceThreshold = options?.confidenceThreshold ?? opts.defaultConfidenceThreshold;
+    const iouThreshold = options?.iouThreshold ?? modelOpts.defaultIouThreshold;
+    const confidenceThreshold =
+      options?.confidenceThreshold ?? modelOpts.defaultConfidenceThreshold;
 
     return postprocess(tBoxes, tScores, tKeypoints, {
-      ...opts,
+      ...modelOpts,
       iouThreshold,
       confidenceThreshold,
       from: { width: targetW, height: targetH },

--- a/packages/react-native-executorch/src/extensions/cv/tasks/keypointDetection.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/keypointDetection.ts
@@ -24,7 +24,7 @@ export type KeypointDetectorOptions<F extends BoxFormat, L extends PropertyKey> 
 > & {
   /** Resize mode for preprocessing input images {@link ResizeMode} (excluding `'crop'`). */
   readonly resizeMode: Exclude<ResizeMode, 'crop'>;
-  /** Bounding box format {@link BoxFormat}. */
+  /** How bounding box coordinates are interpreted {@link BoxFormat}. */
   readonly boxFormat: F;
   /** Array of landmark names matching the model output keypoint locations. */
   readonly landmarks: readonly L[];
@@ -41,7 +41,11 @@ export type KeypointDetectorOptions<F extends BoxFormat, L extends PropertyKey> 
 export type KeypointDetectorModel<F extends BoxFormat, L extends PropertyKey> = {
   /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
-  /** Keypoint detector options. */
+  /**
+   * Image preprocessing, landmark names, bounding box format,
+   * and default NMS/confidence thresholds
+   * {@link KeypointDetectorOptions}.
+   */
   readonly modelOpts: KeypointDetectorOptions<F, L>;
 };
 

--- a/packages/react-native-executorch/src/extensions/cv/tasks/keypointDetection.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/keypointDetection.ts
@@ -22,13 +22,13 @@ export type KeypointDetectorOptions<F extends BoxFormat, L extends PropertyKey> 
   ImagePreprocessorOptions,
   'resizeMode'
 > & {
-  /** Resize mode for preprocessing input images (`stretch` or `letterbox`). */
+  /** Resize mode for preprocessing input images {@link ResizeMode} (excluding `'crop'`). */
   readonly resizeMode: Exclude<ResizeMode, 'crop'>;
-  /** Bounding box format exported by the model (`xyxy`, `cxcywh`, etc.). */
+  /** Bounding box format {@link BoxFormat}. */
   readonly boxFormat: F;
   /** Array of landmark names matching the model output keypoint locations. */
   readonly landmarks: readonly L[];
-  /** Default IoU threshold for Non-Maximum Suppression (NMS). */
+  /** Default Intersection over Union (IoU) threshold for Non-Maximum Suppression (NMS). */
   readonly defaultIouThreshold: number;
   /** Default minimum confidence score threshold for keypoint detections. */
   readonly defaultConfidenceThreshold: number;

--- a/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts
@@ -25,7 +25,7 @@ export type ObjectDetectorOptions<F extends BoxFormat, L> = Omit<
   readonly resizeMode: Exclude<ResizeMode, 'crop'>;
   /** Array of class labels matching the model's output vocabulary. */
   readonly labels: readonly L[];
-  /** Bounding box format {@link BoxFormat}. */
+  /** How bounding box coordinates are interpreted {@link BoxFormat}. */
   readonly boxFormat: F;
   /** Default Intersection over Union (IoU) threshold for Non-Maximum Suppression (NMS). */
   readonly defaultIouThreshold: number;
@@ -40,7 +40,11 @@ export type ObjectDetectorOptions<F extends BoxFormat, L> = Omit<
 export type ObjectDetectorModel<F extends BoxFormat, L> = {
   /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
-  /** Object detector preprocessor and threshold options. */
+  /**
+   * Image preprocessing, label vocabulary, and default
+   * NMS/confidence thresholds {@link ObjectDetectorOptions}.
+   * Used as fallbacks when per-call overrides are omitted.
+   */
   readonly modelOpts: ObjectDetectorOptions<F, L>;
 };
 

--- a/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts
@@ -21,13 +21,13 @@ export type ObjectDetectorOptions<F extends BoxFormat, L> = Omit<
   ImagePreprocessorOptions,
   'resizeMode'
 > & {
-  /** Resize mode for preprocessing input images (`stretch` or `letterbox`). */
+  /** Resize mode for preprocessing input images {@link ResizeMode} (excluding `'crop'`). */
   readonly resizeMode: Exclude<ResizeMode, 'crop'>;
   /** Array of class labels matching the model's output vocabulary. */
   readonly labels: readonly L[];
-  /** Bounding box format exported by the model (`xyxy`, `cxcywh`, etc.). */
+  /** Bounding box format {@link BoxFormat}. */
   readonly boxFormat: F;
-  /** Default IoU threshold for Non-Maximum Suppression (NMS). */
+  /** Default Intersection over Union (IoU) threshold for Non-Maximum Suppression (NMS). */
   readonly defaultIouThreshold: number;
   /** Default minimum confidence score threshold for detections. */
   readonly defaultConfidenceThreshold: number;
@@ -86,7 +86,7 @@ export async function createObjectDetector<F extends BoxFormat, L>(
    * @param options Configuration options for object detection.
    * @param options.confidenceThreshold Minimum confidence score threshold. If
    * omitted, uses `modelOpts.defaultConfidenceThreshold`.
-   * @param options.iouThreshold Non-maximum suppression IoU threshold. If
+   * @param options.iouThreshold Intersection over Union (IoU) threshold. If
    * omitted, uses `modelOpts.defaultIouThreshold`.
    * @returns A promise resolving to the list of object detections.
    */

--- a/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts
@@ -21,10 +21,15 @@ export type ObjectDetectorOptions<F extends BoxFormat, L> = Omit<
   ImagePreprocessorOptions,
   'resizeMode'
 > & {
+  /** Resize mode for preprocessing input images (`stretch` or `letterbox`). */
   readonly resizeMode: Exclude<ResizeMode, 'crop'>;
+  /** Array of class labels matching the model's output vocabulary. */
   readonly labels: readonly L[];
+  /** Bounding box format exported by the model (`xyxy`, `cxcywh`, etc.). */
   readonly boxFormat: F;
+  /** Default IoU threshold for Non-Maximum Suppression (NMS). */
   readonly defaultIouThreshold: number;
+  /** Default minimum confidence score threshold for detections. */
   readonly defaultConfidenceThreshold: number;
 };
 
@@ -33,7 +38,9 @@ export type ObjectDetectorOptions<F extends BoxFormat, L> = Omit<
  * @category Types
  */
 export type ObjectDetectorModel<F extends BoxFormat, L> = {
+  /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
+  /** Object detector preprocessor and threshold options. */
   readonly opts: ObjectDetectorOptions<F, L>;
 };
 
@@ -42,8 +49,11 @@ export type ObjectDetectorModel<F extends BoxFormat, L> = {
  * @category Types
  */
 export type ObjectDetection<F extends BoxFormat, L> = {
+  /** Scaled bounding box coordinates matching the input image resolution. */
   readonly box: BoundingBox<F>;
+  /** Predicted object class label. */
   readonly label: L;
+  /** Confidence score of the detection (between 0.0 and 1.0). */
   readonly confidence: number;
 };
 
@@ -72,12 +82,12 @@ export async function createObjectDetector<F extends BoxFormat, L>(
    */
   dispose: () => void;
   /**
-   * Performs asynchronous object detection on the given input image.
    * @param input The input image buffer.
    * @param options Configuration options for object detection.
-   * @param options.confidenceThreshold Minimum confidence score for returned
-   * detections.
-   * @param options.iouThreshold Non-maximum suppression IoU threshold.
+   * @param options.confidenceThreshold Minimum confidence score threshold. If
+   * omitted, uses `opts.defaultConfidenceThreshold`.
+   * @param options.iouThreshold Non-maximum suppression IoU threshold. If
+   * omitted, uses `opts.defaultIouThreshold`.
    * @returns A promise resolving to the list of object detections.
    */
   detectObjects: (

--- a/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts
@@ -41,7 +41,7 @@ export type ObjectDetectorModel<F extends BoxFormat, L> = {
   /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
   /** Object detector preprocessor and threshold options. */
-  readonly opts: ObjectDetectorOptions<F, L>;
+  readonly modelOpts: ObjectDetectorOptions<F, L>;
 };
 
 /**
@@ -85,9 +85,9 @@ export async function createObjectDetector<F extends BoxFormat, L>(
    * @param input The input image buffer.
    * @param options Configuration options for object detection.
    * @param options.confidenceThreshold Minimum confidence score threshold. If
-   * omitted, uses `opts.defaultConfidenceThreshold`.
+   * omitted, uses `modelOpts.defaultConfidenceThreshold`.
    * @param options.iouThreshold Non-maximum suppression IoU threshold. If
-   * omitted, uses `opts.defaultIouThreshold`.
+   * omitted, uses `modelOpts.defaultIouThreshold`.
    * @returns A promise resolving to the list of object detections.
    */
   detectObjects: (
@@ -103,7 +103,7 @@ export async function createObjectDetector<F extends BoxFormat, L>(
     options?: { confidenceThreshold?: number; iouThreshold?: number }
   ) => ObjectDetection<F, L>[];
 }> {
-  const { modelPath, opts } = config;
+  const { modelPath, modelOpts } = config;
   const model = await wrapAsync(loadModel, runtime)(modelPath);
 
   const meta = validateModelSchema(
@@ -132,9 +132,9 @@ export async function createObjectDetector<F extends BoxFormat, L>(
   ] as const;
 
   const [tBoxes, tScores, tClasses] = tensors;
-  const preprocessor = createImagePreprocessor(opts, inpShape);
+  const preprocessor = createImagePreprocessor(modelOpts, inpShape);
 
-  const { boxFormat } = opts;
+  const { boxFormat } = modelOpts;
 
   const dispose = () => {
     preprocessor.dispose();
@@ -154,8 +154,9 @@ export async function createObjectDetector<F extends BoxFormat, L>(
     const scores = tScores.getData(new Float32Array(tScores.numel));
     const classes = tClasses.getData(new Float32Array(tClasses.numel));
 
-    const iouThreshold = options?.iouThreshold ?? opts.defaultIouThreshold;
-    const confidenceThreshold = options?.confidenceThreshold ?? opts.defaultConfidenceThreshold;
+    const iouThreshold = options?.iouThreshold ?? modelOpts.defaultIouThreshold;
+    const confidenceThreshold =
+      options?.confidenceThreshold ?? modelOpts.defaultConfidenceThreshold;
 
     const results: ObjectDetection<F, L>[] = [];
     const indices = nms(tBoxes, tScores, {
@@ -168,12 +169,12 @@ export async function createObjectDetector<F extends BoxFormat, L>(
     for (const index of indices) {
       const confidence = scores[index]!;
       const classIdx = Math.round(classes[index]!);
-      const label = opts.labels[classIdx];
+      const label = modelOpts.labels[classIdx];
 
       if (label === undefined) {
         throw new Error(
           `ObjectDetector: Predicted class index ${classIdx} is out of bounds for` +
-            `labels array of size ${opts.labels.length}.`
+            `labels array of size ${modelOpts.labels.length}.`
         );
       }
 
@@ -188,7 +189,7 @@ export async function createObjectDetector<F extends BoxFormat, L>(
         box: scaleBox(decodeBox([a, b, c, d], boxFormat), {
           from: { width: targetW, height: targetH },
           to: { width: input.width, height: input.height },
-          ...opts,
+          ...modelOpts,
         }),
       });
     }

--- a/packages/react-native-executorch/src/extensions/cv/tasks/preprocessing.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/preprocessing.ts
@@ -19,9 +19,13 @@ import {
  * @category Types
  */
 export type ImagePreprocessorOptions = {
+  /** Resize algorithm mode (`stretch`, `letterbox`, `crop`). */
   readonly resizeMode: ResizeMode;
+  /** Pixel interpolation method (`linear`, `lanczos`, etc.). */
   readonly interpolation: InterpolationMethod;
+  /** Normalization scaling coefficients. */
   readonly normalizeOpts: NormalizeOptions;
+  /** Optional background fill value used when letterboxing. */
   readonly padValue?: number;
 };
 

--- a/packages/react-native-executorch/src/extensions/cv/tasks/preprocessing.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/preprocessing.ts
@@ -19,9 +19,12 @@ import {
  * @category Types
  */
 export type ImagePreprocessorOptions = {
-  /** Resize algorithm mode {@link ResizeMode}. */
+  /**
+   * How the input image is resized to match the model's expected
+   * dimensions {@link ResizeMode}.
+   */
   readonly resizeMode: ResizeMode;
-  /** Pixel interpolation method {@link InterpolationMethod}. */
+  /** Algorithm used when resizing {@link InterpolationMethod}. `'linear'` is a good default. */
   readonly interpolation: InterpolationMethod;
   /** Normalization scaling coefficients. */
   readonly normalizeOpts: NormalizeOptions;

--- a/packages/react-native-executorch/src/extensions/cv/tasks/preprocessing.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/preprocessing.ts
@@ -19,9 +19,9 @@ import {
  * @category Types
  */
 export type ImagePreprocessorOptions = {
-  /** Resize algorithm mode (`stretch`, `letterbox`, `crop`). */
+  /** Resize algorithm mode {@link ResizeMode}. */
   readonly resizeMode: ResizeMode;
-  /** Pixel interpolation method (`linear`, `lanczos`, etc.). */
+  /** Pixel interpolation method {@link InterpolationMethod}. */
   readonly interpolation: InterpolationMethod;
   /** Normalization scaling coefficients. */
   readonly normalizeOpts: NormalizeOptions;

--- a/packages/react-native-executorch/src/extensions/cv/tasks/preprocessing.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/preprocessing.ts
@@ -5,6 +5,7 @@ import type { ImageBuffer } from '../image';
 import {
   type ResizeMode,
   type InterpolationMethod,
+  type NormalizeOptions,
   FORMAT_CONVERSION,
   FORMAT_CHANNELS,
   resize,
@@ -20,8 +21,7 @@ import {
 export type ImagePreprocessorOptions = {
   readonly resizeMode: ResizeMode;
   readonly interpolation: InterpolationMethod;
-  readonly alpha: number | readonly number[];
-  readonly beta: number | readonly number[];
+  readonly normalizeOpts: NormalizeOptions;
   readonly padValue?: number;
 };
 
@@ -84,7 +84,7 @@ export function createImagePreprocessor(
   ] as const;
 
   const [tColor, tChanFirst, tNorm, tOutput] = tensors;
-  const { resizeMode, interpolation, alpha, beta, padValue } = opts;
+  const { resizeMode, interpolation, normalizeOpts, padValue } = opts;
 
   const dispose = () => tensors.forEach((t) => t.dispose());
   const process = (input: ImageBuffer): Tensor => {
@@ -105,7 +105,7 @@ export function createImagePreprocessor(
         })
         .throughIf(colorCode !== null, cvtColor, tColor, colorCode!)
         .through(toChannelsFirst, tChanFirst)
-        .through(normalize, tNorm, { alpha, beta })
+        .through(normalize, tNorm, normalizeOpts)
         .copyTo(tOutput);
     } finally {
       tInput.dispose();

--- a/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
@@ -23,8 +23,11 @@ import { sigmoid, argmax } from '../../math';
  * @category Types
  */
 export type SemanticSegmenterOptions<L> = Omit<ImagePreprocessorOptions, 'resizeMode'> & {
+  /** Resize mode for input images. */
   readonly resizeMode: 'stretch';
+  /** Interpolation method used when resizing output masks back to input image dimensions. */
   readonly outInterpolation: InterpolationMethod;
+  /** Array of class labels matching the model's output vocabulary. */
   readonly labels: readonly L[];
 };
 
@@ -33,7 +36,9 @@ export type SemanticSegmenterOptions<L> = Omit<ImagePreprocessorOptions, 'resize
  * @category Types
  */
 export type SemanticSegmenterModel<L> = {
+  /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
+  /** Semantic segmenter options. */
   readonly opts: SemanticSegmenterOptions<L>;
 };
 
@@ -48,7 +53,9 @@ export type ColorMap<L extends PropertyKey> = Record<L, [number, number, number,
  * @category Types
  */
 export type SemanticSegmentationResult<L extends PropertyKey> = {
+  /** Generated output RGBA image buffer containing the colored segmentation mask. */
   buffer: ImageBuffer;
+  /** Applied color map mapping each class label to its RGBA tuple. */
   colormap?: ColorMap<L>;
 };
 

--- a/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
@@ -38,7 +38,11 @@ export type SemanticSegmenterOptions<L> = Omit<ImagePreprocessorOptions, 'resize
 export type SemanticSegmenterModel<L> = {
   /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
-  /** Semantic segmenter options. */
+  /**
+   * Image preprocessing, output mask interpolation, and label
+   * vocabulary {@link SemanticSegmenterOptions}. `resizeMode`
+   * is fixed to `'stretch'`.
+   */
   readonly modelOpts: SemanticSegmenterOptions<L>;
 };
 

--- a/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
@@ -23,7 +23,7 @@ import { sigmoid, argmax } from '../../math';
  * @category Types
  */
 export type SemanticSegmenterOptions<L> = Omit<ImagePreprocessorOptions, 'resizeMode'> & {
-  /** Resize mode for input images. */
+  /** Resize mode for input images. Must be `'stretch'`. */
   readonly resizeMode: 'stretch';
   /** Interpolation method used when resizing output masks back to input image dimensions. */
   readonly outInterpolation: InterpolationMethod;

--- a/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
@@ -54,9 +54,9 @@ export type ColorMap<L extends PropertyKey> = Record<L, [number, number, number,
  */
 export type SemanticSegmentationResult<L extends PropertyKey> = {
   /** Generated output RGBA image buffer containing the colored segmentation mask. */
-  buffer: ImageBuffer;
+  readonly buffer: ImageBuffer;
   /** Applied color map mapping each class label to its RGBA tuple. */
-  colormap?: ColorMap<L>;
+  readonly colormap?: ColorMap<L>;
 };
 
 function hslToRgb(h: number, s: number, l: number): [number, number, number] {

--- a/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
@@ -39,7 +39,7 @@ export type SemanticSegmenterModel<L> = {
   /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
   /** Semantic segmenter options. */
-  readonly opts: SemanticSegmenterOptions<L>;
+  readonly modelOpts: SemanticSegmenterOptions<L>;
 };
 
 /**
@@ -125,7 +125,7 @@ export async function createSemanticSegmenter<L extends PropertyKey = string>(
     colormap?: Partial<ColorMap<L>>
   ) => SemanticSegmentationResult<L>;
 }> {
-  const { modelPath, opts } = config;
+  const { modelPath, modelOpts } = config;
   const model = await wrapAsync(loadModel, runtime)(modelPath);
 
   const meta = validateModelSchema(
@@ -143,14 +143,14 @@ export async function createSemanticSegmenter<L extends PropertyKey = string>(
 
   // Generate highly distinct, high-contrast colors, see:
   // https://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically/
-  const defaultColormap = opts.labels.map((_, i) => {
+  const defaultColormap = modelOpts.labels.map((_, i) => {
     if (i === 0) return [0, 0, 0, 0] as const;
     return [...hslToRgb((i * 137.5) % 360, 95, 50), 255] as const;
   });
 
-  if (nClasses > 1 && opts.labels.length !== nClasses) {
+  if (nClasses > 1 && modelOpts.labels.length !== nClasses) {
     throw new Error(
-      `Model outputs ${nClasses} classes, but ${opts.labels.length} labels were provided in the configuration.`
+      `Model outputs ${nClasses} classes, but ${modelOpts.labels.length} labels were provided in the configuration.`
     );
   }
 
@@ -164,7 +164,7 @@ export async function createSemanticSegmenter<L extends PropertyKey = string>(
   ] as const;
 
   const [tOutput, tReshape, tSigmoid, tChanLast, tMask, tRgba] = tensors;
-  const preprocessor = createImagePreprocessor(opts, inpShape);
+  const preprocessor = createImagePreprocessor(modelOpts, inpShape);
 
   const dispose = () => {
     tensors.forEach((t) => t.dispose());
@@ -184,15 +184,15 @@ export async function createSemanticSegmenter<L extends PropertyKey = string>(
     if (nClasses > 1) {
       if (colormap) {
         returnColormap = Object.fromEntries(
-          opts.labels.map((l) => [l, colormap[l] ?? [0, 0, 0, 0]])
+          modelOpts.labels.map((l) => [l, colormap[l] ?? [0, 0, 0, 0]])
         ) as ColorMap<L>;
       } else {
         returnColormap = Object.fromEntries(
-          opts.labels.map((l, i) => [l, defaultColormap[i]!])
+          modelOpts.labels.map((l, i) => [l, defaultColormap[i]!])
         ) as ColorMap<L>;
       }
 
-      const colormapData = opts.labels.map((l) => returnColormap![l]);
+      const colormapData = modelOpts.labels.map((l) => returnColormap![l]);
 
       tOutput
         .copyTo(tReshape)
@@ -212,7 +212,7 @@ export async function createSemanticSegmenter<L extends PropertyKey = string>(
     const tResize = tensor('uint8', [input.height, input.width, 4]);
     try {
       tRgba
-        .through(resize, tResize, { mode: 'stretch', interpolation: opts.outInterpolation })
+        .through(resize, tResize, { mode: 'stretch', interpolation: modelOpts.outInterpolation })
         .getData(data);
     } finally {
       tResize.dispose();

--- a/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
@@ -22,7 +22,7 @@ import { sigmoid, argmax } from '../../math';
  * vocabulary.
  * @category Types
  */
-export type SemanticSegmentationOptions<L> = Omit<ImagePreprocessorOptions, 'resizeMode'> & {
+export type SemanticSegmenterOptions<L> = Omit<ImagePreprocessorOptions, 'resizeMode'> & {
   readonly resizeMode: 'stretch';
   readonly outInterpolation: InterpolationMethod;
   readonly labels: readonly L[];
@@ -32,9 +32,9 @@ export type SemanticSegmentationOptions<L> = Omit<ImagePreprocessorOptions, 'res
  * Model configuration required to instantiate a segmenter task runner.
  * @category Types
  */
-export type SemanticSegmentationModel<L> = {
+export type SemanticSegmenterModel<L> = {
   readonly modelPath: string;
-  readonly opts: SemanticSegmentationOptions<L>;
+  readonly opts: SemanticSegmenterOptions<L>;
 };
 
 /**
@@ -77,7 +77,7 @@ function hslToRgb(h: number, s: number, l: number): [number, number, number] {
  * disposal controls.
  */
 export async function createSemanticSegmenter<L extends PropertyKey = string>(
-  config: SemanticSegmentationModel<L>,
+  config: SemanticSegmenterModel<L>,
   runtime?: WorkletRuntime
 ): Promise<{
   /**

--- a/packages/react-native-executorch/src/extensions/cv/tasks/styleTransfer.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/styleTransfer.ts
@@ -21,8 +21,11 @@ import {
  * @category Types
  */
 export type StyleTransferOptions = Omit<ImagePreprocessorOptions, 'resizeMode'> & {
+  /** Resize mode for input images. */
   readonly resizeMode: 'stretch';
+  /** Normalization options for postprocessing output tensors back to uint8 pixel values. */
   readonly outNormalizeOpts: NormalizeOptions;
+  /** Interpolation method used when resizing output styled images to input dimensions. */
   readonly outInterpolation: InterpolationMethod;
 };
 
@@ -31,7 +34,9 @@ export type StyleTransferOptions = Omit<ImagePreprocessorOptions, 'resizeMode'> 
  * @category Types
  */
 export type StyleTransferModel = {
+  /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
+  /** Style transfer preprocessor and postprocessor options. */
   readonly opts: StyleTransferOptions;
 };
 

--- a/packages/react-native-executorch/src/extensions/cv/tasks/styleTransfer.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/styleTransfer.ts
@@ -36,7 +36,11 @@ export type StyleTransferOptions = Omit<ImagePreprocessorOptions, 'resizeMode'> 
 export type StyleTransferModel = {
   /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
-  /** Style transfer preprocessor and postprocessor options. */
+  /**
+   * Input preprocessing and output postprocessing
+   * {@link StyleTransferOptions} (normalization back to uint8,
+   * interpolation). `resizeMode` is fixed to `'stretch'`.
+   */
   readonly modelOpts: StyleTransferOptions;
 };
 

--- a/packages/react-native-executorch/src/extensions/cv/tasks/styleTransfer.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/styleTransfer.ts
@@ -37,7 +37,7 @@ export type StyleTransferModel = {
   /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
   /** Style transfer preprocessor and postprocessor options. */
-  readonly opts: StyleTransferOptions;
+  readonly modelOpts: StyleTransferOptions;
 };
 
 /**
@@ -71,7 +71,7 @@ export async function createStyleTransfer(
    */
   transferStyleWorklet: (input: ImageBuffer) => ImageBuffer;
 }> {
-  const { modelPath, opts } = config;
+  const { modelPath, modelOpts } = config;
   const model = await wrapAsync(loadModel, runtime)(modelPath);
 
   const meta = validateModelSchema(
@@ -95,7 +95,7 @@ export async function createStyleTransfer(
   ] as const;
 
   const [tOutput, tReshape, tUint8, tChanLast, tRgba] = tensors;
-  const preprocessor = createImagePreprocessor(opts, inpShape);
+  const preprocessor = createImagePreprocessor(modelOpts, inpShape);
 
   const dispose = () => {
     tensors.forEach((t) => t.dispose());
@@ -113,10 +113,10 @@ export async function createStyleTransfer(
     try {
       tOutput
         .copyTo(tReshape)
-        .through(normalize, tUint8, opts.outNormalizeOpts)
+        .through(normalize, tUint8, modelOpts.outNormalizeOpts)
         .through(toChannelsLast, tChanLast)
         .through(cvtColor, tRgba, 'RGB2RGBA')
-        .through(resize, tResize, { mode: 'stretch', interpolation: opts.outInterpolation })
+        .through(resize, tResize, { mode: 'stretch', interpolation: modelOpts.outInterpolation })
         .getData(data);
     } finally {
       tResize.dispose();

--- a/packages/react-native-executorch/src/extensions/cv/tasks/styleTransfer.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/styleTransfer.ts
@@ -13,6 +13,7 @@ import {
   cvtColor,
   resize,
   type InterpolationMethod,
+  type NormalizeOptions,
 } from '../ops/image';
 
 /**
@@ -21,8 +22,7 @@ import {
  */
 export type StyleTransferOptions = Omit<ImagePreprocessorOptions, 'resizeMode'> & {
   readonly resizeMode: 'stretch';
-  readonly outAlpha: number | number[];
-  readonly outBeta: number | number[];
+  readonly outNormalizeOpts: NormalizeOptions;
   readonly outInterpolation: InterpolationMethod;
 };
 
@@ -108,7 +108,7 @@ export async function createStyleTransfer(
     try {
       tOutput
         .copyTo(tReshape)
-        .through(normalize, tUint8, { alpha: opts.outAlpha, beta: opts.outBeta })
+        .through(normalize, tUint8, opts.outNormalizeOpts)
         .through(toChannelsLast, tChanLast)
         .through(cvtColor, tRgba, 'RGB2RGBA')
         .through(resize, tResize, { mode: 'stretch', interpolation: opts.outInterpolation })

--- a/packages/react-native-executorch/src/extensions/cv/tasks/styleTransfer.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/styleTransfer.ts
@@ -21,7 +21,7 @@ import {
  * @category Types
  */
 export type StyleTransferOptions = Omit<ImagePreprocessorOptions, 'resizeMode'> & {
-  /** Resize mode for input images. */
+  /** Resize mode for input images. Must be `'stretch'`. */
   readonly resizeMode: 'stretch';
   /** Normalization options for postprocessing output tensors back to uint8 pixel values. */
   readonly outNormalizeOpts: NormalizeOptions;

--- a/packages/react-native-executorch/src/extensions/nlp/tasks/textEmbedding.ts
+++ b/packages/react-native-executorch/src/extensions/nlp/tasks/textEmbedding.ts
@@ -12,8 +12,11 @@ import { loadTokenizer } from '../tokenizer';
  * @category Types
  */
 export type TextEmbedderModel = {
+  /** Local path or remote URL of the `.pte` model file. */
   readonly modelPath: string;
+  /** Local path or remote URL of the tokenizer file. */
   readonly tokenizerPath: string;
+  /** Optional default prompt prefix added to input text before embedding. */
   readonly defaultPrompt?: string;
 };
 

--- a/packages/react-native-executorch/src/extensions/speech/tasks/fsmnVoiceActivityDetection.ts
+++ b/packages/react-native-executorch/src/extensions/speech/tasks/fsmnVoiceActivityDetection.ts
@@ -33,35 +33,35 @@ const DEFAULT_DETECTION_MARGIN_MS = 100;
  * Tunable thresholds controlling how per-frame speech probabilities are turned
  * into speech {@link Segment}s.
  * @category Types
- * @property {number} [speechThreshold] - Minimum speech probability (0-1) for a
- * frame to count as speech. Defaults to `0.6`.
- * @property {number} [minSpeechDurationMs] - Minimum duration a region must stay
- * above the threshold to open a segment. Defaults to `250`.
- * @property {number} [minSilenceDurationMs] - Minimum duration below the
- * threshold required to close a segment. Defaults to `100`.
- * @property {number} [speechPadMs] - Padding added to both ends of every
- * detected segment. Defaults to `30`.
- * @property {number} [mergeGapMs] - Segments closer than this gap are merged
- * into one. Defaults to `0`.
  */
 export type VadOptions = {
+  /** Minimum speech probability (0-1) for a frame to count as speech. */
   readonly speechThreshold?: number;
+  /**
+   * Minimum duration a region must stay above the threshold to open a
+   * segment.
+   */
   readonly minSpeechDurationMs?: number;
+  /** Minimum duration below threshold required to close a segment. */
   readonly minSilenceDurationMs?: number;
+  /** Padding added to both ends of every detected segment. */
   readonly speechPadMs?: number;
+  /** Segments closer than this gap are merged into one. */
   readonly mergeGapMs?: number;
 };
 
 /**
  * Model configuration required to instantiate an FSMN-VAD task runner.
  * @category Types
- * @property {string} modelPath - Local path or remote URL of the `.pte` model.
- * @property {Required<VadOptions>} defaultOptions - Detection thresholds tuned
- * for this model, overridable per `detectVoice` call. Defined alongside the
- * model in the `models` registry so the defaults are discoverable there.
  */
 export type FsmnVadModel = {
+  /** Local path or remote URL of the `.pte` model. */
   readonly modelPath: string;
+  /**
+   * Detection thresholds tuned for this model, overridable per `detectVoice`
+   * call. Defined alongside the model in the `models` registry so defaults
+   * are discoverable there.
+   */
   readonly defaultOptions: Required<VadOptions>;
 };
 
@@ -70,7 +70,9 @@ export type FsmnVadModel = {
  * @category Types
  */
 export type Segment = {
+  /** Start time of the speech segment in seconds. */
   readonly start: number;
+  /** End time of the speech segment in seconds. */
   readonly end: number;
 };
 
@@ -78,11 +80,12 @@ export type Segment = {
  * Options controlling live detection via `detectVoiceOnStream`. Extends the
  * per-call detection thresholds ({@link VadOptions}).
  * @category Types
- * @property {number} [detectionMargin] - How recent (in milliseconds) the last
- * detected speech segment must reach toward the end of the window for speech to
- * still be considered ongoing. Defaults to `100`.
  */
 export type VadStreamOptions = VadOptions & {
+  /**
+   * How recent (in milliseconds) the last detected speech segment must reach
+   * toward the end of the window for speech to still be considered ongoing.
+   */
   readonly detectionMargin?: number;
 };
 

--- a/packages/react-native-executorch/src/extensions/speech/tasks/whisperSpeechToText.ts
+++ b/packages/react-native-executorch/src/extensions/speech/tasks/whisperSpeechToText.ts
@@ -55,11 +55,13 @@ export type WhisperLanguage = (typeof WHISPER_LANGUAGES)[number];
 /**
  * Options passed to a single transcription call.
  * @category Types
- * @property language - Whisper language code of the spoken audio. Must be one of
- * the {@link WhisperLanguage} values declared in the model's
- * `supportedLanguages` list.
  */
 export type WhisperSttOptions<L extends WhisperLanguage = WhisperLanguage> = {
+  /**
+   * Whisper language code of the spoken audio. Must be one of
+   * the {@link WhisperLanguage} values declared in the model's
+   * `supportedLanguages` list.
+   */
   readonly language: L;
 };
 
@@ -67,20 +69,28 @@ export type WhisperSttOptions<L extends WhisperLanguage = WhisperLanguage> = {
  * Options for the live-streaming transcription API.
  * Extends {@link WhisperSttOptions} with optional VAD tuning.
  * @category Types
- * @property vadOptions - Fine-tuning knobs forwarded to the voice-activity
- * detector. Omit to use the detector's built-in defaults.
  */
 export type WhisperStreamOptions<L extends WhisperLanguage = WhisperLanguage> =
-  WhisperSttOptions<L> & { readonly vadOptions?: VadStreamOptions };
+  WhisperSttOptions<L> & {
+    /**
+     * Fine-tuning knobs forwarded to the voice-activity detector. Omit to use
+     * built-in defaults.
+     */
+    readonly vadOptions?: VadStreamOptions;
+  };
 
 /**
  * Paths and metadata required to instantiate a Whisper speech-to-text model.
  * @category Types
  */
 export type WhisperSttModel<L extends WhisperLanguage = WhisperLanguage> = {
+  /** Local path or remote URL of the `.pte` model. */
   readonly modelPath: string;
+  /** Local path or remote URL of the tokenizer file. */
   readonly tokenizerPath: string;
+  /** List of supported language codes for this model. */
   readonly supportedLanguages: readonly L[];
+  /** VAD model configuration used for speech segmentation. */
   readonly vadModel: FsmnVadModel;
 };
 

--- a/packages/react-native-executorch/src/extensions/speech/utils/vadUtils.ts
+++ b/packages/react-native-executorch/src/extensions/speech/utils/vadUtils.ts
@@ -8,7 +8,7 @@ import { type Tensor } from '../../../core/tensor';
 export type ExtractFramesOptions = {
   /** Number of audio frames to extract and write into the destination tensor. */
   readonly numFrames: number;
-  /** Samples between consecutive frames. */
+  /** Number of samples between consecutive frames. */
   readonly hopLength: number;
   /** Pre-emphasis filter coefficient. */
   readonly preemphasis: number;

--- a/packages/react-native-executorch/src/extensions/speech/utils/vadUtils.ts
+++ b/packages/react-native-executorch/src/extensions/speech/utils/vadUtils.ts
@@ -4,13 +4,13 @@ import { type Tensor } from '../../../core/tensor';
 /**
  * Options controlling how {@link extractFrames} slices and filters the waveform.
  * @category Types
- * @property {number} numFrames - Number of frames to write (must be `<= dst.shape[0]`).
- * @property {number} hopLength - Samples between consecutive frames.
- * @property {number} preemphasis - Pre-emphasis filter coefficient.
  */
 export type ExtractFramesOptions = {
+  /** Number of audio frames to extract and write into the destination tensor. */
   readonly numFrames: number;
+  /** Samples between consecutive frames. */
   readonly hopLength: number;
+  /** Pre-emphasis filter coefficient. */
   readonly preemphasis: number;
 };
 
@@ -27,6 +27,10 @@ export type ExtractFramesOptions = {
  * @param hann Precomputed Hann window, shape `[frameLength]`.
  * @param dst Pre-allocated destination, shape `[frames, fftLength]`.
  * @param options Framing options.
+ * @param options.numFrames Number of frames to write (must not exceed `dst`
+ * tensor's first dimension `dst.shape[0]`).
+ * @param options.hopLength Number of audio samples between consecutive frames.
+ * @param options.preemphasis Pre-emphasis filter coefficient.
  * @returns The `dst` tensor, for convenience.
  */
 export function extractFrames(

--- a/packages/react-native-executorch/src/hooks/useClassifier.ts
+++ b/packages/react-native-executorch/src/hooks/useClassifier.ts
@@ -34,7 +34,7 @@ export function useClassifier<L>(config: ClassifierModel<L>, options?: { prevent
     error: downloadError || error,
     downloadProgress,
     localPath,
-    labels: config.classifierOpts.labels,
+    labels: config.opts.labels,
     classify: model?.classify,
     classifyWorklet: model?.classifyWorklet,
   };

--- a/packages/react-native-executorch/src/hooks/useClassifier.ts
+++ b/packages/react-native-executorch/src/hooks/useClassifier.ts
@@ -34,7 +34,7 @@ export function useClassifier<L>(config: ClassifierModel<L>, options?: { prevent
     error: downloadError || error,
     downloadProgress,
     localPath,
-    labels: config.opts.labels,
+    labels: config.modelOpts.labels,
     classify: model?.classify,
     classifyWorklet: model?.classifyWorklet,
   };

--- a/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
+++ b/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
@@ -44,6 +44,6 @@ export function useInstanceSegmenter<F extends BoxFormat, L>(
     localPath,
     segmentInstances: model?.segmentInstances,
     segmentInstancesWorklet: model?.segmentInstancesWorklet,
-    labels: config.opts.labels,
+    labels: config.modelOpts.labels,
   };
 }

--- a/packages/react-native-executorch/src/hooks/useKeypointDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useKeypointDetector.ts
@@ -42,7 +42,7 @@ export function useKeypointDetector<F extends BoxFormat, L extends PropertyKey>(
     error: downloadError || error,
     downloadProgress,
     localPath,
-    landmarks: config.opts.landmarks,
+    landmarks: config.modelOpts.landmarks,
     detectKeypoints: model?.detectKeypoints,
     detectKeypointsWorklet: model?.detectKeypointsWorklet,
   };

--- a/packages/react-native-executorch/src/hooks/useObjectDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useObjectDetector.ts
@@ -42,7 +42,7 @@ export function useObjectDetector<F extends BoxFormat, L>(
     error: downloadError || error,
     downloadProgress,
     localPath,
-    labels: config.opts.labels,
+    labels: config.modelOpts.labels,
     detectObjects: model?.detectObjects,
     detectObjectsWorklet: model?.detectObjectsWorklet,
   };

--- a/packages/react-native-executorch/src/hooks/useSemanticSegmenter.ts
+++ b/packages/react-native-executorch/src/hooks/useSemanticSegmenter.ts
@@ -42,6 +42,6 @@ export function useSemanticSegmenter<L extends PropertyKey = string>(
     localPath,
     segment: model?.segment,
     segmentWorklet: model?.segmentWorklet,
-    labels: config.opts.labels,
+    labels: config.modelOpts.labels,
   };
 }

--- a/packages/react-native-executorch/src/hooks/useSemanticSegmenter.ts
+++ b/packages/react-native-executorch/src/hooks/useSemanticSegmenter.ts
@@ -2,7 +2,7 @@ import { useModel } from './useModel';
 import { useResourceDownload } from './useResourceDownload';
 import {
   createSemanticSegmenter,
-  type SemanticSegmentationModel,
+  type SemanticSegmenterModel,
 } from '../extensions/cv/tasks/semanticSegmentation';
 
 /**
@@ -22,7 +22,7 @@ import {
  * progress, and segmentation functions.
  */
 export function useSemanticSegmenter<L extends PropertyKey = string>(
-  config: SemanticSegmentationModel<L>,
+  config: SemanticSegmenterModel<L>,
   options?: { preventLoad?: boolean }
 ) {
   const { localPath, downloadProgress, downloadError } = useResourceDownload(

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -38,8 +38,7 @@ const NEXT_VERSION_TAG = 'resolve/v0.10.0';
 const EFFICIENTNET_V2_S_OPTS = {
   resizeMode: 'stretch' as const,
   interpolation: 'linear' as const,
-  alpha: 1 / 255.0,
-  beta: 0.0,
+  normalizeOpts: { alpha: 1 / 255.0, beta: 0.0 },
   labels: IMAGENET1K_LABELS,
 };
 const EFFICIENTNET_V2_S_XNNPACK_INT8: ClassifierModel<ImageNet1KLabel> = {
@@ -61,10 +60,8 @@ const EFFICIENTNET_V2_S_COREML_FP16: ClassifierModel<ImageNet1KLabel> = {
 const STYLE_TRANSFER_OPTS = {
   resizeMode: 'stretch' as const,
   interpolation: 'linear' as const,
-  alpha: 1 / 255.0,
-  beta: 0.0,
-  outAlpha: 255.0,
-  outBeta: 0.0,
+  normalizeOpts: { alpha: 1 / 255.0, beta: 0.0 },
+  outNormalizeOpts: { alpha: 255.0, beta: 0.0 },
   outInterpolation: 'lanczos' as const,
 };
 const STYLE_TRANSFER_CANDY_XNNPACK_FP32: StyleTransferModel = {
@@ -141,8 +138,7 @@ const SELFIE_SEGMENTATION_XNNPACK_FP32: SemanticSegmenterModel<'background' | 'p
     labels: ['background', 'person'] as const,
     resizeMode: 'stretch',
     interpolation: 'linear',
-    alpha: 1 / 255.0,
-    beta: 0.0,
+    normalizeOpts: { alpha: 1 / 255.0, beta: 0.0 },
     outInterpolation: 'lanczos',
   },
 };
@@ -152,7 +148,7 @@ const LRASPP_MOBILENET_V3_LARGE_OPTS = {
   resizeMode: 'stretch' as const,
   interpolation: 'linear' as const,
   outInterpolation: 'lanczos' as const,
-  ...IMAGENET_NORM,
+  normalizeOpts: IMAGENET_NORM,
 };
 const LRASPP_MOBILENET_V3_LARGE_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-lraspp/${VERSION_TAG}/xnnpack/lraspp_mobilenet_v3_large_xnnpack_fp32.pte`,
@@ -168,7 +164,7 @@ const DEEPLAB_V3_OPTS = {
   resizeMode: 'stretch' as const,
   interpolation: 'linear' as const,
   outInterpolation: 'lanczos' as const,
-  ...IMAGENET_NORM,
+  normalizeOpts: IMAGENET_NORM,
 };
 const DEEPLAB_V3_RESNET50_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/xnnpack/deeplab_v3_resnet50_xnnpack_fp32.pte`,
@@ -200,7 +196,7 @@ const FCN_OPTS = {
   resizeMode: 'stretch' as const,
   interpolation: 'linear' as const,
   outInterpolation: 'lanczos' as const,
-  ...IMAGENET_NORM,
+  normalizeOpts: IMAGENET_NORM,
 };
 const FCN_RESNET50_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-fcn/${NEXT_VERSION_TAG}/xnnpack/fcn_resnet50_xnnpack_fp32.pte`,
@@ -227,8 +223,7 @@ const SSDLITE320_MOBILENET_V3_LARGE_OPTS = {
   boxFormat: 'xyxy' as const,
   resizeMode: 'stretch' as const,
   interpolation: 'linear' as const,
-  alpha: 1 / 255.0,
-  beta: 0.0,
+  normalizeOpts: { alpha: 1 / 255.0, beta: 0.0 },
   defaultConfidenceThreshold: 0.5,
   defaultIouThreshold: 0.55,
 };
@@ -250,7 +245,7 @@ const RFDETR_NANO_DETECTOR_OPTS = {
   boxFormat: 'xyxy' as const,
   resizeMode: 'stretch' as const,
   interpolation: 'linear' as const,
-  ...IMAGENET_NORM,
+  normalizeOpts: IMAGENET_NORM,
   defaultConfidenceThreshold: 0.5,
   defaultIouThreshold: 0.55,
 };
@@ -268,8 +263,7 @@ const YOLO26_DETECTOR_OPTS = {
   boxFormat: 'xyxy' as const,
   resizeMode: 'letterbox' as const,
   interpolation: 'linear' as const,
-  alpha: 1 / 255.0,
-  beta: 0.0,
+  normalizeOpts: { alpha: 1 / 255.0, beta: 0.0 },
   defaultConfidenceThreshold: 0.25,
   defaultIouThreshold: 0.7,
 };
@@ -348,8 +342,7 @@ const BLAZEFACE_XNNPACK_FP32: KeypointDetectorModel<'xyxy', BlazeFaceLandmark> =
     boxFormat: 'xyxy',
     resizeMode: 'letterbox',
     interpolation: 'linear',
-    alpha: 1 / 127.5,
-    beta: -1.0,
+    normalizeOpts: { alpha: 1 / 127.5, beta: -1.0 },
     defaultIouThreshold: 0.3,
     defaultConfidenceThreshold: 0.75,
     landmarks: BLAZEFACE_LANDMARKS,
@@ -360,8 +353,7 @@ const YOLO26_POSE_OPTS = {
   boxFormat: 'xyxy' as const,
   resizeMode: 'letterbox' as const,
   interpolation: 'linear' as const,
-  alpha: 1 / 255.0,
-  beta: 0.0,
+  normalizeOpts: { alpha: 1 / 255.0, beta: 0.0 },
   defaultIouThreshold: 0.7,
   defaultConfidenceThreshold: 0.25,
   landmarks: COCO_LANDMARKS,
@@ -383,7 +375,7 @@ const RFDETR_KEYPOINT_OPTS = {
   boxFormat: 'xyxy' as const,
   resizeMode: 'stretch' as const,
   interpolation: 'linear' as const,
-  ...IMAGENET_NORM,
+  normalizeOpts: IMAGENET_NORM,
   defaultIouThreshold: 0.55,
   defaultConfidenceThreshold: 0.5,
   landmarks: COCO_LANDMARKS,
@@ -409,8 +401,7 @@ const FASTSAM_OPTS = {
   boxFormat: 'xyxy' as const,
   resizeMode: 'stretch' as const,
   interpolation: 'linear' as const,
-  alpha: 1 / 255.0,
-  beta: 0.0,
+  normalizeOpts: { alpha: 1 / 255.0, beta: 0.0 },
   defaultConfidenceThreshold: 0.5,
   defaultIouThreshold: 0.9,
   defaultMaskThreshold: 0.5,
@@ -445,7 +436,7 @@ const RFDETR_NANO_SEG_OPTS = {
   boxFormat: 'xyxy' as const,
   resizeMode: 'stretch' as const,
   interpolation: 'linear' as const,
-  ...IMAGENET_NORM,
+  normalizeOpts: IMAGENET_NORM,
   defaultConfidenceThreshold: 0.5,
   defaultIouThreshold: 0.55,
   defaultMaskThreshold: 0.5,
@@ -464,8 +455,7 @@ const YOLO26_SEG_OPTS = {
   boxFormat: 'xyxy' as const,
   resizeMode: 'stretch' as const,
   interpolation: 'linear' as const,
-  alpha: 1 / 255.0,
-  beta: 0.0,
+  normalizeOpts: { alpha: 1 / 255.0, beta: 0.0 },
   defaultConfidenceThreshold: 0.25,
   defaultIouThreshold: 0.7,
   defaultMaskThreshold: 0.5,
@@ -584,8 +574,7 @@ const LFM2_5_EMBEDDING_350M_MLX_INT4: TextEmbedderModel = {
 const CLIP_IMAGE_EMBEDDINGS_OPTS = {
   resizeMode: 'stretch' as const,
   interpolation: 'linear' as const,
-  alpha: 1 / 255.0,
-  beta: 0.0,
+  normalizeOpts: { alpha: 1 / 255.0, beta: 0.0 },
 };
 const CLIP_VIT_BASE_PATCH32_IMAGE_XNNPACK_FP32: ImageEmbedderModel = {
   modelPath: `${BASE_URL}-clip-vit-base-patch32/${NEXT_VERSION_TAG}/xnnpack/clip_vit_base_patch32_image_xnnpack_fp32.pte`,

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -1,7 +1,7 @@
 import type { ClassifierModel } from './extensions/cv/tasks/classification';
 import type { ObjectDetectorModel } from './extensions/cv/tasks/objectDetection';
 import type { StyleTransferModel } from './extensions/cv/tasks/styleTransfer';
-import type { SemanticSegmentationModel } from './extensions/cv/tasks/semanticSegmentation';
+import type { SemanticSegmenterModel } from './extensions/cv/tasks/semanticSegmentation';
 import type { KeypointDetectorModel } from './extensions/cv/tasks/keypointDetection';
 import type { InstanceSegmenterModel } from './extensions/cv/tasks/instanceSegmentation';
 import type { ImageEmbedderModel } from './extensions/cv/tasks/imageEmbedding';
@@ -44,15 +44,15 @@ const EFFICIENTNET_V2_S_OPTS = {
 };
 const EFFICIENTNET_V2_S_XNNPACK_INT8: ClassifierModel<ImageNet1KLabel> = {
   modelPath: `${BASE_URL}-efficientnet-v2-s/${VERSION_TAG}/xnnpack/efficientnet_v2_s_xnnpack_int8.pte`,
-  classifierOpts: EFFICIENTNET_V2_S_OPTS,
+  opts: EFFICIENTNET_V2_S_OPTS,
 };
 const EFFICIENTNET_V2_S_XNNPACK_FP32: ClassifierModel<ImageNet1KLabel> = {
   modelPath: `${BASE_URL}-efficientnet-v2-s/${VERSION_TAG}/xnnpack/efficientnet_v2_s_xnnpack_fp32.pte`,
-  classifierOpts: EFFICIENTNET_V2_S_OPTS,
+  opts: EFFICIENTNET_V2_S_OPTS,
 };
 const EFFICIENTNET_V2_S_COREML_FP16: ClassifierModel<ImageNet1KLabel> = {
   modelPath: `${BASE_URL}-efficientnet-v2-s/${VERSION_TAG}/coreml/efficientnet_v2_s_coreml_fp16.pte`,
-  classifierOpts: EFFICIENTNET_V2_S_OPTS,
+  opts: EFFICIENTNET_V2_S_OPTS,
 };
 
 // =============================================================================
@@ -135,7 +135,7 @@ const STYLE_TRANSFER_UDNIE_COREML_FP32: StyleTransferModel = {
 // =============================================================================
 // Semantic Segmentation
 // =============================================================================
-const SELFIE_SEGMENTATION_XNNPACK_FP32: SemanticSegmentationModel<'background' | 'person'> = {
+const SELFIE_SEGMENTATION_XNNPACK_FP32: SemanticSegmenterModel<'background' | 'person'> = {
   modelPath: `${BASE_URL}-selfie-segmentation/${VERSION_TAG}/xnnpack/selfie_segmentation_xnnpack_fp32.pte`,
   opts: {
     labels: ['background', 'person'] as const,
@@ -154,11 +154,11 @@ const LRASPP_MOBILENET_V3_LARGE_OPTS = {
   outInterpolation: 'lanczos' as const,
   ...IMAGENET_NORM,
 };
-const LRASPP_MOBILENET_V3_LARGE_XNNPACK_FP32: SemanticSegmentationModel<PascalVocLabel> = {
+const LRASPP_MOBILENET_V3_LARGE_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-lraspp/${VERSION_TAG}/xnnpack/lraspp_mobilenet_v3_large_xnnpack_fp32.pte`,
   opts: LRASPP_MOBILENET_V3_LARGE_OPTS,
 };
-const LRASPP_MOBILENET_V3_LARGE_XNNPACK_INT8: SemanticSegmentationModel<PascalVocLabel> = {
+const LRASPP_MOBILENET_V3_LARGE_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-lraspp/${VERSION_TAG}/xnnpack/lraspp_mobilenet_v3_large_xnnpack_int8.pte`,
   opts: LRASPP_MOBILENET_V3_LARGE_OPTS,
 };
@@ -170,27 +170,27 @@ const DEEPLAB_V3_OPTS = {
   outInterpolation: 'lanczos' as const,
   ...IMAGENET_NORM,
 };
-const DEEPLAB_V3_RESNET50_XNNPACK_FP32: SemanticSegmentationModel<PascalVocLabel> = {
+const DEEPLAB_V3_RESNET50_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/xnnpack/deeplab_v3_resnet50_xnnpack_fp32.pte`,
   opts: DEEPLAB_V3_OPTS,
 };
-const DEEPLAB_V3_RESNET50_XNNPACK_INT8: SemanticSegmentationModel<PascalVocLabel> = {
+const DEEPLAB_V3_RESNET50_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/xnnpack/deeplab_v3_resnet50_xnnpack_int8.pte`,
   opts: DEEPLAB_V3_OPTS,
 };
-const DEEPLAB_V3_RESNET101_XNNPACK_FP32: SemanticSegmentationModel<PascalVocLabel> = {
+const DEEPLAB_V3_RESNET101_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/xnnpack/deeplab_v3_resnet101_xnnpack_fp32.pte`,
   opts: DEEPLAB_V3_OPTS,
 };
-const DEEPLAB_V3_RESNET101_XNNPACK_INT8: SemanticSegmentationModel<PascalVocLabel> = {
+const DEEPLAB_V3_RESNET101_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/xnnpack/deeplab_v3_resnet101_xnnpack_int8.pte`,
   opts: DEEPLAB_V3_OPTS,
 };
-const DEEPLAB_V3_MOBILENET_V3_LARGE_XNNPACK_FP32: SemanticSegmentationModel<PascalVocLabel> = {
+const DEEPLAB_V3_MOBILENET_V3_LARGE_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/xnnpack/deeplab_v3_mobilenet_v3_large_xnnpack_fp32.pte`,
   opts: DEEPLAB_V3_OPTS,
 };
-const DEEPLAB_V3_MOBILENET_V3_LARGE_XNNPACK_INT8: SemanticSegmentationModel<PascalVocLabel> = {
+const DEEPLAB_V3_MOBILENET_V3_LARGE_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/xnnpack/deeplab_v3_mobilenet_v3_large_xnnpack_int8.pte`,
   opts: DEEPLAB_V3_OPTS,
 };
@@ -202,19 +202,19 @@ const FCN_OPTS = {
   outInterpolation: 'lanczos' as const,
   ...IMAGENET_NORM,
 };
-const FCN_RESNET50_XNNPACK_FP32: SemanticSegmentationModel<PascalVocLabel> = {
+const FCN_RESNET50_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-fcn/${NEXT_VERSION_TAG}/xnnpack/fcn_resnet50_xnnpack_fp32.pte`,
   opts: FCN_OPTS,
 };
-const FCN_RESNET50_XNNPACK_INT8: SemanticSegmentationModel<PascalVocLabel> = {
+const FCN_RESNET50_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-fcn/${NEXT_VERSION_TAG}/xnnpack/fcn_resnet50_xnnpack_int8.pte`,
   opts: FCN_OPTS,
 };
-const FCN_RESNET101_XNNPACK_FP32: SemanticSegmentationModel<PascalVocLabel> = {
+const FCN_RESNET101_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-fcn/${NEXT_VERSION_TAG}/xnnpack/fcn_resnet101_xnnpack_fp32.pte`,
   opts: FCN_OPTS,
 };
-const FCN_RESNET101_XNNPACK_INT8: SemanticSegmentationModel<PascalVocLabel> = {
+const FCN_RESNET101_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-fcn/${NEXT_VERSION_TAG}/xnnpack/fcn_resnet101_xnnpack_int8.pte`,
   opts: FCN_OPTS,
 };

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -43,15 +43,15 @@ const EFFICIENTNET_V2_S_OPTS = {
 };
 const EFFICIENTNET_V2_S_XNNPACK_INT8: ClassifierModel<ImageNet1KLabel> = {
   modelPath: `${BASE_URL}-efficientnet-v2-s/${VERSION_TAG}/xnnpack/efficientnet_v2_s_xnnpack_int8.pte`,
-  opts: EFFICIENTNET_V2_S_OPTS,
+  modelOpts: EFFICIENTNET_V2_S_OPTS,
 };
 const EFFICIENTNET_V2_S_XNNPACK_FP32: ClassifierModel<ImageNet1KLabel> = {
   modelPath: `${BASE_URL}-efficientnet-v2-s/${VERSION_TAG}/xnnpack/efficientnet_v2_s_xnnpack_fp32.pte`,
-  opts: EFFICIENTNET_V2_S_OPTS,
+  modelOpts: EFFICIENTNET_V2_S_OPTS,
 };
 const EFFICIENTNET_V2_S_COREML_FP16: ClassifierModel<ImageNet1KLabel> = {
   modelPath: `${BASE_URL}-efficientnet-v2-s/${VERSION_TAG}/coreml/efficientnet_v2_s_coreml_fp16.pte`,
-  opts: EFFICIENTNET_V2_S_OPTS,
+  modelOpts: EFFICIENTNET_V2_S_OPTS,
 };
 
 // =============================================================================
@@ -66,67 +66,67 @@ const STYLE_TRANSFER_OPTS = {
 };
 const STYLE_TRANSFER_CANDY_XNNPACK_FP32: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-candy/${VERSION_TAG}/xnnpack/style_transfer_candy_xnnpack_fp32.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 const STYLE_TRANSFER_CANDY_XNNPACK_INT8: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-candy/${VERSION_TAG}/xnnpack/style_transfer_candy_xnnpack_int8.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 const STYLE_TRANSFER_CANDY_COREML_FP16: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-candy/${VERSION_TAG}/coreml/style_transfer_candy_coreml_fp16.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 const STYLE_TRANSFER_CANDY_COREML_FP32: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-candy/${VERSION_TAG}/coreml/style_transfer_candy_coreml_fp32.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 const STYLE_TRANSFER_MOSAIC_XNNPACK_FP32: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-mosaic/${VERSION_TAG}/xnnpack/style_transfer_mosaic_xnnpack_fp32.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 const STYLE_TRANSFER_MOSAIC_XNNPACK_INT8: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-mosaic/${VERSION_TAG}/xnnpack/style_transfer_mosaic_xnnpack_int8.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 const STYLE_TRANSFER_MOSAIC_COREML_FP16: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-mosaic/${VERSION_TAG}/coreml/style_transfer_mosaic_coreml_fp16.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 const STYLE_TRANSFER_MOSAIC_COREML_FP32: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-mosaic/${VERSION_TAG}/coreml/style_transfer_mosaic_coreml_fp32.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 const STYLE_TRANSFER_RAIN_PRINCESS_XNNPACK_FP32: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-rain-princess/${VERSION_TAG}/xnnpack/style_transfer_rain_princess_xnnpack_fp32.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 const STYLE_TRANSFER_RAIN_PRINCESS_XNNPACK_INT8: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-rain-princess/${VERSION_TAG}/xnnpack/style_transfer_rain_princess_xnnpack_int8.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 const STYLE_TRANSFER_RAIN_PRINCESS_COREML_FP16: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-rain-princess/${VERSION_TAG}/coreml/style_transfer_rain_princess_coreml_fp16.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 const STYLE_TRANSFER_RAIN_PRINCESS_COREML_FP32: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-rain-princess/${VERSION_TAG}/coreml/style_transfer_rain_princess_coreml_fp32.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 const STYLE_TRANSFER_UDNIE_XNNPACK_FP32: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-udnie/${VERSION_TAG}/xnnpack/style_transfer_udnie_xnnpack_fp32.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 const STYLE_TRANSFER_UDNIE_XNNPACK_INT8: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-udnie/${VERSION_TAG}/xnnpack/style_transfer_udnie_xnnpack_int8.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 const STYLE_TRANSFER_UDNIE_COREML_FP16: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-udnie/${VERSION_TAG}/coreml/style_transfer_udnie_coreml_fp16.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 const STYLE_TRANSFER_UDNIE_COREML_FP32: StyleTransferModel = {
   modelPath: `${BASE_URL}-style-transfer-udnie/${VERSION_TAG}/coreml/style_transfer_udnie_coreml_fp32.pte`,
-  opts: STYLE_TRANSFER_OPTS,
+  modelOpts: STYLE_TRANSFER_OPTS,
 };
 
 // =============================================================================
@@ -134,7 +134,7 @@ const STYLE_TRANSFER_UDNIE_COREML_FP32: StyleTransferModel = {
 // =============================================================================
 const SELFIE_SEGMENTATION_XNNPACK_FP32: SemanticSegmenterModel<'background' | 'person'> = {
   modelPath: `${BASE_URL}-selfie-segmentation/${VERSION_TAG}/xnnpack/selfie_segmentation_xnnpack_fp32.pte`,
-  opts: {
+  modelOpts: {
     labels: ['background', 'person'] as const,
     resizeMode: 'stretch',
     interpolation: 'linear',
@@ -152,11 +152,11 @@ const LRASPP_MOBILENET_V3_LARGE_OPTS = {
 };
 const LRASPP_MOBILENET_V3_LARGE_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-lraspp/${VERSION_TAG}/xnnpack/lraspp_mobilenet_v3_large_xnnpack_fp32.pte`,
-  opts: LRASPP_MOBILENET_V3_LARGE_OPTS,
+  modelOpts: LRASPP_MOBILENET_V3_LARGE_OPTS,
 };
 const LRASPP_MOBILENET_V3_LARGE_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-lraspp/${VERSION_TAG}/xnnpack/lraspp_mobilenet_v3_large_xnnpack_int8.pte`,
-  opts: LRASPP_MOBILENET_V3_LARGE_OPTS,
+  modelOpts: LRASPP_MOBILENET_V3_LARGE_OPTS,
 };
 
 const DEEPLAB_V3_OPTS = {
@@ -168,27 +168,27 @@ const DEEPLAB_V3_OPTS = {
 };
 const DEEPLAB_V3_RESNET50_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/xnnpack/deeplab_v3_resnet50_xnnpack_fp32.pte`,
-  opts: DEEPLAB_V3_OPTS,
+  modelOpts: DEEPLAB_V3_OPTS,
 };
 const DEEPLAB_V3_RESNET50_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/xnnpack/deeplab_v3_resnet50_xnnpack_int8.pte`,
-  opts: DEEPLAB_V3_OPTS,
+  modelOpts: DEEPLAB_V3_OPTS,
 };
 const DEEPLAB_V3_RESNET101_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/xnnpack/deeplab_v3_resnet101_xnnpack_fp32.pte`,
-  opts: DEEPLAB_V3_OPTS,
+  modelOpts: DEEPLAB_V3_OPTS,
 };
 const DEEPLAB_V3_RESNET101_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/xnnpack/deeplab_v3_resnet101_xnnpack_int8.pte`,
-  opts: DEEPLAB_V3_OPTS,
+  modelOpts: DEEPLAB_V3_OPTS,
 };
 const DEEPLAB_V3_MOBILENET_V3_LARGE_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/xnnpack/deeplab_v3_mobilenet_v3_large_xnnpack_fp32.pte`,
-  opts: DEEPLAB_V3_OPTS,
+  modelOpts: DEEPLAB_V3_OPTS,
 };
 const DEEPLAB_V3_MOBILENET_V3_LARGE_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/xnnpack/deeplab_v3_mobilenet_v3_large_xnnpack_int8.pte`,
-  opts: DEEPLAB_V3_OPTS,
+  modelOpts: DEEPLAB_V3_OPTS,
 };
 
 const FCN_OPTS = {
@@ -200,19 +200,19 @@ const FCN_OPTS = {
 };
 const FCN_RESNET50_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-fcn/${NEXT_VERSION_TAG}/xnnpack/fcn_resnet50_xnnpack_fp32.pte`,
-  opts: FCN_OPTS,
+  modelOpts: FCN_OPTS,
 };
 const FCN_RESNET50_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-fcn/${NEXT_VERSION_TAG}/xnnpack/fcn_resnet50_xnnpack_int8.pte`,
-  opts: FCN_OPTS,
+  modelOpts: FCN_OPTS,
 };
 const FCN_RESNET101_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-fcn/${NEXT_VERSION_TAG}/xnnpack/fcn_resnet101_xnnpack_fp32.pte`,
-  opts: FCN_OPTS,
+  modelOpts: FCN_OPTS,
 };
 const FCN_RESNET101_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> = {
   modelPath: `${BASE_URL}-fcn/${NEXT_VERSION_TAG}/xnnpack/fcn_resnet101_xnnpack_int8.pte`,
-  opts: FCN_OPTS,
+  modelOpts: FCN_OPTS,
 };
 
 // =============================================================================
@@ -229,15 +229,15 @@ const SSDLITE320_MOBILENET_V3_LARGE_OPTS = {
 };
 const SSDLITE320_MOBILENET_V3_LARGE_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClass> = {
   modelPath: `${BASE_URL}-ssdlite320-mobilenet-v3-large/${VERSION_TAG}/xnnpack/ssdlite320_mobilenet_v3_large_xnnpack_fp32.pte`,
-  opts: SSDLITE320_MOBILENET_V3_LARGE_OPTS,
+  modelOpts: SSDLITE320_MOBILENET_V3_LARGE_OPTS,
 };
 const SSDLITE320_MOBILENET_V3_LARGE_COREML_FP16: ObjectDetectorModel<'xyxy', CocoClass> = {
   modelPath: `${BASE_URL}-ssdlite320-mobilenet-v3-large/${VERSION_TAG}/coreml/ssdlite320_mobilenet_v3_large_coreml_fp16.pte`,
-  opts: SSDLITE320_MOBILENET_V3_LARGE_OPTS,
+  modelOpts: SSDLITE320_MOBILENET_V3_LARGE_OPTS,
 };
 const SSDLITE320_MOBILENET_V3_LARGE_COREML_FP32: ObjectDetectorModel<'xyxy', CocoClass> = {
   modelPath: `${BASE_URL}-ssdlite320-mobilenet-v3-large/${VERSION_TAG}/coreml/ssdlite320_mobilenet_v3_large_coreml_fp32.pte`,
-  opts: SSDLITE320_MOBILENET_V3_LARGE_OPTS,
+  modelOpts: SSDLITE320_MOBILENET_V3_LARGE_OPTS,
 };
 
 const RFDETR_NANO_DETECTOR_OPTS = {
@@ -251,11 +251,11 @@ const RFDETR_NANO_DETECTOR_OPTS = {
 };
 const RFDETR_NANO_DETECTOR_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClass> = {
   modelPath: `${BASE_URL}-rfdetr-nano-detector/${VERSION_TAG}/xnnpack/rfdetr_nano_xnnpack_fp32.pte`,
-  opts: RFDETR_NANO_DETECTOR_OPTS,
+  modelOpts: RFDETR_NANO_DETECTOR_OPTS,
 };
 const RFDETR_NANO_DETECTOR_COREML_INT8: ObjectDetectorModel<'xyxy', CocoClass> = {
   modelPath: `${BASE_URL}-rfdetr-nano-detector/${VERSION_TAG}/coreml/rfdetr_nano_coreml_int8.pte`,
-  opts: RFDETR_NANO_DETECTOR_OPTS,
+  modelOpts: RFDETR_NANO_DETECTOR_OPTS,
 };
 
 const YOLO26_DETECTOR_OPTS = {
@@ -270,67 +270,67 @@ const YOLO26_DETECTOR_OPTS = {
 
 const YOLO26_NANO_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/n/xnnpack/yolo26n_384_xnnpack_fp32.pte`,
-  opts: YOLO26_DETECTOR_OPTS,
+  modelOpts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_NANO_512_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/n/xnnpack/yolo26n_512_xnnpack_fp32.pte`,
-  opts: YOLO26_DETECTOR_OPTS,
+  modelOpts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_NANO_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/n/xnnpack/yolo26n_640_xnnpack_fp32.pte`,
-  opts: YOLO26_DETECTOR_OPTS,
+  modelOpts: YOLO26_DETECTOR_OPTS,
 };
 
 const YOLO26_SMALL_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/s/xnnpack/yolo26s_384_xnnpack_fp32.pte`,
-  opts: YOLO26_DETECTOR_OPTS,
+  modelOpts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_SMALL_512_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/s/xnnpack/yolo26s_512_xnnpack_fp32.pte`,
-  opts: YOLO26_DETECTOR_OPTS,
+  modelOpts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_SMALL_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/s/xnnpack/yolo26s_640_xnnpack_fp32.pte`,
-  opts: YOLO26_DETECTOR_OPTS,
+  modelOpts: YOLO26_DETECTOR_OPTS,
 };
 
 const YOLO26_MEDIUM_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/m/xnnpack/yolo26m_384_xnnpack_fp32.pte`,
-  opts: YOLO26_DETECTOR_OPTS,
+  modelOpts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_MEDIUM_512_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/m/xnnpack/yolo26m_512_xnnpack_fp32.pte`,
-  opts: YOLO26_DETECTOR_OPTS,
+  modelOpts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_MEDIUM_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/m/xnnpack/yolo26m_640_xnnpack_fp32.pte`,
-  opts: YOLO26_DETECTOR_OPTS,
+  modelOpts: YOLO26_DETECTOR_OPTS,
 };
 
 const YOLO26_LARGE_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/l/xnnpack/yolo26l_384_xnnpack_fp32.pte`,
-  opts: YOLO26_DETECTOR_OPTS,
+  modelOpts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_LARGE_512_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/l/xnnpack/yolo26l_512_xnnpack_fp32.pte`,
-  opts: YOLO26_DETECTOR_OPTS,
+  modelOpts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_LARGE_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/l/xnnpack/yolo26l_640_xnnpack_fp32.pte`,
-  opts: YOLO26_DETECTOR_OPTS,
+  modelOpts: YOLO26_DETECTOR_OPTS,
 };
 
 const YOLO26_XLARGE_384_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/x/xnnpack/yolo26x_384_xnnpack_fp32.pte`,
-  opts: YOLO26_DETECTOR_OPTS,
+  modelOpts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_XLARGE_512_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/x/xnnpack/yolo26x_512_xnnpack_fp32.pte`,
-  opts: YOLO26_DETECTOR_OPTS,
+  modelOpts: YOLO26_DETECTOR_OPTS,
 };
 const YOLO26_XLARGE_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26/${NEXT_VERSION_TAG}/x/xnnpack/yolo26x_640_xnnpack_fp32.pte`,
-  opts: YOLO26_DETECTOR_OPTS,
+  modelOpts: YOLO26_DETECTOR_OPTS,
 };
 
 // =============================================================================
@@ -338,7 +338,7 @@ const YOLO26_XLARGE_640_XNNPACK_FP32: ObjectDetectorModel<'xyxy', CocoClassYolo>
 // =============================================================================
 const BLAZEFACE_XNNPACK_FP32: KeypointDetectorModel<'xyxy', BlazeFaceLandmark> = {
   modelPath: `${BASE_URL}-blazeface/${NEXT_VERSION_TAG}/xnnpack/blazeface_xnnpack_fp32.pte`,
-  opts: {
+  modelOpts: {
     boxFormat: 'xyxy',
     resizeMode: 'letterbox',
     interpolation: 'linear',
@@ -360,15 +360,15 @@ const YOLO26_POSE_OPTS = {
 };
 const YOLO26_POSE_384_XNNPACK_FP32: KeypointDetectorModel<'xyxy', CocoLandmark> = {
   modelPath: `${BASE_URL}-yolo26-pose/${NEXT_VERSION_TAG}/xnnpack/yolo26n_pose_384_xnnpack_fp32.pte`,
-  opts: YOLO26_POSE_OPTS,
+  modelOpts: YOLO26_POSE_OPTS,
 };
 const YOLO26_POSE_512_XNNPACK_FP32: KeypointDetectorModel<'xyxy', CocoLandmark> = {
   modelPath: `${BASE_URL}-yolo26-pose/${NEXT_VERSION_TAG}/xnnpack/yolo26n_pose_512_xnnpack_fp32.pte`,
-  opts: YOLO26_POSE_OPTS,
+  modelOpts: YOLO26_POSE_OPTS,
 };
 const YOLO26_POSE_640_XNNPACK_FP32: KeypointDetectorModel<'xyxy', CocoLandmark> = {
   modelPath: `${BASE_URL}-yolo26-pose/${NEXT_VERSION_TAG}/xnnpack/yolo26n_pose_640_xnnpack_fp32.pte`,
-  opts: YOLO26_POSE_OPTS,
+  modelOpts: YOLO26_POSE_OPTS,
 };
 
 const RFDETR_KEYPOINT_OPTS = {
@@ -382,15 +382,15 @@ const RFDETR_KEYPOINT_OPTS = {
 };
 const RFDETR_KEYPOINT_XNNPACK_FP32: KeypointDetectorModel<'xyxy', CocoLandmark> = {
   modelPath: `${BASE_URL}-rfdetr-keypoint/${VERSION_TAG}/preview/xnnpack/rfdetr_keypoint_preview_xnnpack_fp32.pte`,
-  opts: RFDETR_KEYPOINT_OPTS,
+  modelOpts: RFDETR_KEYPOINT_OPTS,
 };
 const RFDETR_KEYPOINT_COREML_FP32: KeypointDetectorModel<'xyxy', CocoLandmark> = {
   modelPath: `${BASE_URL}-rfdetr-keypoint/${VERSION_TAG}/preview/coreml/rfdetr_keypoint_preview_coreml_fp32.pte`,
-  opts: RFDETR_KEYPOINT_OPTS,
+  modelOpts: RFDETR_KEYPOINT_OPTS,
 };
 const RFDETR_KEYPOINT_MLX_FP32: KeypointDetectorModel<'xyxy', CocoLandmark> = {
   modelPath: `${BASE_URL}-rfdetr-keypoint/${VERSION_TAG}/preview/mlx/rfdetr_keypoint_preview_mlx_fp32.pte`,
-  opts: RFDETR_KEYPOINT_OPTS,
+  modelOpts: RFDETR_KEYPOINT_OPTS,
 };
 
 // =============================================================================
@@ -408,27 +408,27 @@ const FASTSAM_OPTS = {
 };
 const FASTSAM_S_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', 'object'> = {
   modelPath: `${BASE_URL}-fast-sam/${NEXT_VERSION_TAG}/s/xnnpack/fast_sam_s_xnnpack_fp32.pte`,
-  opts: FASTSAM_OPTS,
+  modelOpts: FASTSAM_OPTS,
 };
 const FASTSAM_S_COREML_FP32: InstanceSegmenterModel<'xyxy', 'object'> = {
   modelPath: `${BASE_URL}-fast-sam/${NEXT_VERSION_TAG}/s/coreml/fast_sam_s_coreml_fp32.pte`,
-  opts: FASTSAM_OPTS,
+  modelOpts: FASTSAM_OPTS,
 };
 const FASTSAM_S_COREML_FP16: InstanceSegmenterModel<'xyxy', 'object'> = {
   modelPath: `${BASE_URL}-fast-sam/${NEXT_VERSION_TAG}/s/coreml/fast_sam_s_coreml_fp16.pte`,
-  opts: FASTSAM_OPTS,
+  modelOpts: FASTSAM_OPTS,
 };
 const FASTSAM_X_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', 'object'> = {
   modelPath: `${BASE_URL}-fast-sam/${NEXT_VERSION_TAG}/x/xnnpack/fast_sam_x_xnnpack_fp32.pte`,
-  opts: FASTSAM_OPTS,
+  modelOpts: FASTSAM_OPTS,
 };
 const FASTSAM_X_COREML_FP32: InstanceSegmenterModel<'xyxy', 'object'> = {
   modelPath: `${BASE_URL}-fast-sam/${NEXT_VERSION_TAG}/x/coreml/fast_sam_x_coreml_fp32.pte`,
-  opts: FASTSAM_OPTS,
+  modelOpts: FASTSAM_OPTS,
 };
 const FASTSAM_X_COREML_FP16: InstanceSegmenterModel<'xyxy', 'object'> = {
   modelPath: `${BASE_URL}-fast-sam/${NEXT_VERSION_TAG}/x/coreml/fast_sam_x_coreml_fp16.pte`,
-  opts: FASTSAM_OPTS,
+  modelOpts: FASTSAM_OPTS,
 };
 
 const RFDETR_NANO_SEG_OPTS = {
@@ -443,11 +443,11 @@ const RFDETR_NANO_SEG_OPTS = {
 };
 const RFDETR_NANO_SEG_COREML_INT8: InstanceSegmenterModel<'xyxy', CocoClass> = {
   modelPath: `${BASE_URL}-rfdetr-nano-segmentation/${NEXT_VERSION_TAG}/coreml/rfdetr_nano_coreml_int8.pte`,
-  opts: RFDETR_NANO_SEG_OPTS,
+  modelOpts: RFDETR_NANO_SEG_OPTS,
 };
 const RFDETR_NANO_SEG_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClass> = {
   modelPath: `${BASE_URL}-rfdetr-nano-segmentation/${NEXT_VERSION_TAG}/xnnpack/rfdetr_nano_xnnpack_fp32.pte`,
-  opts: RFDETR_NANO_SEG_OPTS,
+  modelOpts: RFDETR_NANO_SEG_OPTS,
 };
 
 const YOLO26_SEG_OPTS = {
@@ -463,67 +463,67 @@ const YOLO26_SEG_OPTS = {
 
 const YOLO26_NANO_SEG_384_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/n/xnnpack/yolo26_seg_n_384_xnnpack_fp32.pte`,
-  opts: YOLO26_SEG_OPTS,
+  modelOpts: YOLO26_SEG_OPTS,
 };
 const YOLO26_NANO_SEG_512_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/n/xnnpack/yolo26_seg_n_512_xnnpack_fp32.pte`,
-  opts: YOLO26_SEG_OPTS,
+  modelOpts: YOLO26_SEG_OPTS,
 };
 const YOLO26_NANO_SEG_640_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/n/xnnpack/yolo26_seg_n_640_xnnpack_fp32.pte`,
-  opts: YOLO26_SEG_OPTS,
+  modelOpts: YOLO26_SEG_OPTS,
 };
 
 const YOLO26_SMALL_SEG_384_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/s/xnnpack/yolo26_seg_s_384_xnnpack_fp32.pte`,
-  opts: YOLO26_SEG_OPTS,
+  modelOpts: YOLO26_SEG_OPTS,
 };
 const YOLO26_SMALL_SEG_512_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/s/xnnpack/yolo26_seg_s_512_xnnpack_fp32.pte`,
-  opts: YOLO26_SEG_OPTS,
+  modelOpts: YOLO26_SEG_OPTS,
 };
 const YOLO26_SMALL_SEG_640_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/s/xnnpack/yolo26_seg_s_640_xnnpack_fp32.pte`,
-  opts: YOLO26_SEG_OPTS,
+  modelOpts: YOLO26_SEG_OPTS,
 };
 
 const YOLO26_MEDIUM_SEG_384_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/m/xnnpack/yolo26_seg_m_384_xnnpack_fp32.pte`,
-  opts: YOLO26_SEG_OPTS,
+  modelOpts: YOLO26_SEG_OPTS,
 };
 const YOLO26_MEDIUM_SEG_512_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/m/xnnpack/yolo26_seg_m_512_xnnpack_fp32.pte`,
-  opts: YOLO26_SEG_OPTS,
+  modelOpts: YOLO26_SEG_OPTS,
 };
 const YOLO26_MEDIUM_SEG_640_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/m/xnnpack/yolo26_seg_m_640_xnnpack_fp32.pte`,
-  opts: YOLO26_SEG_OPTS,
+  modelOpts: YOLO26_SEG_OPTS,
 };
 
 const YOLO26_LARGE_SEG_384_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/l/xnnpack/yolo26_seg_l_384_xnnpack_fp32.pte`,
-  opts: YOLO26_SEG_OPTS,
+  modelOpts: YOLO26_SEG_OPTS,
 };
 const YOLO26_LARGE_SEG_512_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/l/xnnpack/yolo26_seg_l_512_xnnpack_fp32.pte`,
-  opts: YOLO26_SEG_OPTS,
+  modelOpts: YOLO26_SEG_OPTS,
 };
 const YOLO26_LARGE_SEG_640_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/l/xnnpack/yolo26_seg_l_640_xnnpack_fp32.pte`,
-  opts: YOLO26_SEG_OPTS,
+  modelOpts: YOLO26_SEG_OPTS,
 };
 
 const YOLO26_XLARGE_SEG_384_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/x/xnnpack/yolo26_seg_x_384_xnnpack_fp32.pte`,
-  opts: YOLO26_SEG_OPTS,
+  modelOpts: YOLO26_SEG_OPTS,
 };
 const YOLO26_XLARGE_SEG_512_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/x/xnnpack/yolo26_seg_x_512_xnnpack_fp32.pte`,
-  opts: YOLO26_SEG_OPTS,
+  modelOpts: YOLO26_SEG_OPTS,
 };
 const YOLO26_XLARGE_SEG_640_XNNPACK_FP32: InstanceSegmenterModel<'xyxy', CocoClassYolo> = {
   modelPath: `${BASE_URL}-yolo26-seg/${NEXT_VERSION_TAG}/x/xnnpack/yolo26_seg_x_640_xnnpack_fp32.pte`,
-  opts: YOLO26_SEG_OPTS,
+  modelOpts: YOLO26_SEG_OPTS,
 };
 
 // =============================================================================
@@ -578,11 +578,11 @@ const CLIP_IMAGE_EMBEDDINGS_OPTS = {
 };
 const CLIP_VIT_BASE_PATCH32_IMAGE_XNNPACK_FP32: ImageEmbedderModel = {
   modelPath: `${BASE_URL}-clip-vit-base-patch32/${NEXT_VERSION_TAG}/xnnpack/clip_vit_base_patch32_image_xnnpack_fp32.pte`,
-  opts: CLIP_IMAGE_EMBEDDINGS_OPTS,
+  modelOpts: CLIP_IMAGE_EMBEDDINGS_OPTS,
 };
 const CLIP_VIT_BASE_PATCH32_IMAGE_XNNPACK_INT8: ImageEmbedderModel = {
   modelPath: `${BASE_URL}-clip-vit-base-patch32/${NEXT_VERSION_TAG}/xnnpack/clip_vit_base_patch32_image_xnnpack_int8.pte`,
-  opts: CLIP_IMAGE_EMBEDDINGS_OPTS,
+  modelOpts: CLIP_IMAGE_EMBEDDINGS_OPTS,
 };
 
 // =============================================================================


### PR DESCRIPTION
## Description

- **Naming Consistency**: Standardized `ClassifierModel.opts` (renamed from `classifierOpts`) and `SemanticSegmenterModel` / `SemanticSegmenterOptions` (renamed from `SemanticSegmentationModel`).

- **Preprocessor Options**: Replaced top-level `alpha`/`beta` fields with a required `normalizeOpts: NormalizeOptions` property across all task option interfaces and `models.ts` presets.

- **TSDoc Standardization**: Converted top-level `@property` tags to inline member JSDoc comments (`/** ... */`) and added function-level `@param options.field` fallback notes.

- **Immutability**: Enforced `readonly` property modifiers on task results (`SemanticSegmentationResult`, `BoxMap`).

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

- [ ] Run the CV example app and verify that preprocessor options change didn't break anything.

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
