### PR TITLE
[RNE Rewrite] docs(models): add JSDoc documentation to model registry presets

### DIFF
--- a/.cspell-wordlist.txt
+++ b/.cspell-wordlist.txt
@@ -298,3 +298,11 @@ deis
 Coeff
 Multistep
 multistep
+Picabia
+Picabia's
+atrous
+Convolutional
+Roboflow
+Ultralytics
+
+

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -754,7 +754,17 @@ const ALL_MINILM_L6_V2_TOKENIZER = `${BASE_URL}-all-MiniLM-L6-v2/${VERSION_TAG}/
  * @category Utils
  */
 export const models = {
+  /**
+   * Image classification models that categorize input images into pre-defined
+   * classes.
+   */
   classification: {
+    /**
+     * EfficientNetV2-S image classification model pre-trained on ImageNet-1k
+     * (1000 categories, see {@link IMAGENET1K_LABELS}).
+     * Compact and efficient architecture providing high accuracy for
+     * general-purpose image classification.
+     */
     EFFICIENTNET_V2_S: {
       ...EFFICIENTNET_V2_S_XNNPACK_INT8,
       XNNPACK_INT8: EFFICIENTNET_V2_S_XNNPACK_INT8,
@@ -762,7 +772,16 @@ export const models = {
       COREML_FP16: EFFICIENTNET_V2_S_COREML_FP16,
     },
   },
+
+  /**
+   * Artistic style transfer models that re-style input images according to
+   * artwork patterns.
+   */
   styleTransfer: {
+    /**
+     * Fast neural style transfer model generating a vibrant, artistic "Candy"
+     * style effect.
+     */
     CANDY: {
       ...STYLE_TRANSFER_CANDY_XNNPACK_INT8,
       XNNPACK_FP32: STYLE_TRANSFER_CANDY_XNNPACK_FP32,
@@ -770,6 +789,10 @@ export const models = {
       COREML_FP16: STYLE_TRANSFER_CANDY_COREML_FP16,
       COREML_FP32: STYLE_TRANSFER_CANDY_COREML_FP32,
     },
+    /**
+     * Fast neural style transfer model applying a classic tile mosaic
+     * artistic pattern.
+     */
     MOSAIC: {
       ...STYLE_TRANSFER_MOSAIC_XNNPACK_INT8,
       XNNPACK_FP32: STYLE_TRANSFER_MOSAIC_XNNPACK_FP32,
@@ -777,6 +800,10 @@ export const models = {
       COREML_FP16: STYLE_TRANSFER_MOSAIC_COREML_FP16,
       COREML_FP32: STYLE_TRANSFER_MOSAIC_COREML_FP32,
     },
+    /**
+     * Fast neural style transfer model applying a painterly "Rain Princess"
+     * oil painting aesthetic.
+     */
     RAIN_PRINCESS: {
       ...STYLE_TRANSFER_RAIN_PRINCESS_XNNPACK_INT8,
       XNNPACK_FP32: STYLE_TRANSFER_RAIN_PRINCESS_XNNPACK_FP32,
@@ -784,6 +811,10 @@ export const models = {
       COREML_FP16: STYLE_TRANSFER_RAIN_PRINCESS_COREML_FP16,
       COREML_FP32: STYLE_TRANSFER_RAIN_PRINCESS_COREML_FP32,
     },
+    /**
+     * Fast neural style transfer model applying Francis Picabia's "Udnie"
+     * abstract art style.
+     */
     UDNIE: {
       ...STYLE_TRANSFER_UDNIE_XNNPACK_INT8,
       XNNPACK_FP32: STYLE_TRANSFER_UDNIE_XNNPACK_FP32,
@@ -792,80 +823,158 @@ export const models = {
       COREML_FP32: STYLE_TRANSFER_UDNIE_COREML_FP32,
     },
   },
+
+  /**
+   * Semantic segmentation models that classify each pixel into target object
+   * or background classes.
+   */
   semanticSegmentation: {
+    /**
+     * Lightweight portrait selfie segmentation model for real-time person vs
+     * background separation. Categorizes pixels into `background` and
+     * `person`. Ideal for background blur and replacement effects.
+     */
     SELFIE_SEGMENTATION: {
       ...SELFIE_SEGMENTATION_XNNPACK_FP32,
       XNNPACK_FP32: SELFIE_SEGMENTATION_XNNPACK_FP32,
     },
+    /**
+     * Lite R-ASPP semantic segmentation model with MobileNetV3-Large backbone
+     * (21 classes, see {@link PASCAL_VOC_LABELS}). Optimized for low-latency,
+     * real-time pixel-level segmentation on mobile devices.
+     */
     LRASPP_MOBILENET_V3_LARGE: {
       ...LRASPP_MOBILENET_V3_LARGE_XNNPACK_INT8,
       XNNPACK_FP32: LRASPP_MOBILENET_V3_LARGE_XNNPACK_FP32,
       XNNPACK_INT8: LRASPP_MOBILENET_V3_LARGE_XNNPACK_INT8,
     },
+    /**
+     * DeepLabV3 semantic segmentation model with ResNet-50 backbone
+     * (21 classes, see {@link PASCAL_VOC_LABELS}). High-accuracy segmentation
+     * utilizing atrous spatial pyramid pooling.
+     */
     DEEPLAB_V3_RESNET50: {
       ...DEEPLAB_V3_RESNET50_XNNPACK_INT8,
       XNNPACK_FP32: DEEPLAB_V3_RESNET50_XNNPACK_FP32,
       XNNPACK_INT8: DEEPLAB_V3_RESNET50_XNNPACK_INT8,
     },
+    /**
+     * DeepLabV3 semantic segmentation model with ResNet-101 backbone
+     * (21 classes, see {@link PASCAL_VOC_LABELS}). High-capacity backbone for
+     * maximum segmentation detail and boundary accuracy.
+     */
     DEEPLAB_V3_RESNET101: {
       ...DEEPLAB_V3_RESNET101_XNNPACK_INT8,
       XNNPACK_FP32: DEEPLAB_V3_RESNET101_XNNPACK_FP32,
       XNNPACK_INT8: DEEPLAB_V3_RESNET101_XNNPACK_INT8,
     },
+    /**
+     * DeepLabV3 semantic segmentation model with MobileNetV3-Large backbone
+     * (21 classes, see {@link PASCAL_VOC_LABELS}). Combines DeepLabV3 feature
+     * extraction quality with a lightweight mobile backbone.
+     */
     DEEPLAB_V3_MOBILENET_V3_LARGE: {
       ...DEEPLAB_V3_MOBILENET_V3_LARGE_XNNPACK_INT8,
       XNNPACK_FP32: DEEPLAB_V3_MOBILENET_V3_LARGE_XNNPACK_FP32,
       XNNPACK_INT8: DEEPLAB_V3_MOBILENET_V3_LARGE_XNNPACK_INT8,
     },
+    /**
+     * Fully Convolutional Network (FCN) semantic segmentation model with
+     * ResNet-50 backbone (21 classes, see {@link PASCAL_VOC_LABELS}).
+     */
     FCN_RESNET50: {
       ...FCN_RESNET50_XNNPACK_INT8,
       XNNPACK_FP32: FCN_RESNET50_XNNPACK_FP32,
       XNNPACK_INT8: FCN_RESNET50_XNNPACK_INT8,
     },
+    /**
+     * Fully Convolutional Network (FCN) semantic segmentation model with
+     * ResNet-101 backbone (21 classes, see {@link PASCAL_VOC_LABELS}).
+     */
     FCN_RESNET101: {
       ...FCN_RESNET101_XNNPACK_INT8,
       XNNPACK_FP32: FCN_RESNET101_XNNPACK_FP32,
       XNNPACK_INT8: FCN_RESNET101_XNNPACK_INT8,
     },
   },
+
+  /**
+   * Object detection models that identify object locations and bounding boxes.
+   */
   objectDetection: {
+    /**
+     * SSDLite object detector with MobileNetV3-Large backbone trained on COCO
+     * (see {@link COCO_CLASSES}) at 320x320 resolution. Fast, lightweight
+     * detector suited for real-time mobile applications.
+     */
     SSDLITE320_MOBILENET_V3_LARGE: {
       ...SSDLITE320_MOBILENET_V3_LARGE_XNNPACK_FP32,
       XNNPACK_FP32: SSDLITE320_MOBILENET_V3_LARGE_XNNPACK_FP32,
       COREML_FP16: SSDLITE320_MOBILENET_V3_LARGE_COREML_FP16,
       COREML_FP32: SSDLITE320_MOBILENET_V3_LARGE_COREML_FP32,
     },
+    /**
+     * RF-DETR (Roboflow Detection Transformer) Nano variant trained on COCO
+     * (see {@link COCO_CLASSES}). Modern end-to-end DINOv2-based transformer
+     * object detector.
+     */
     RFDETR_NANO: {
       ...RFDETR_NANO_DETECTOR_XNNPACK_FP32,
       XNNPACK_FP32: RFDETR_NANO_DETECTOR_XNNPACK_FP32,
       COREML_INT8: RFDETR_NANO_DETECTOR_COREML_INT8,
     },
+    /**
+     * Ultralytics YOLO26 real-time object detection models trained on COCO
+     * (80 classes, see {@link COCO_CLASSES_YOLO}). Available across multiple
+     * scale sizes (NANO, SMALL, MEDIUM, LARGE, XLARGE) and resolutions
+     * (384x384, 512x512, 640x640).
+     */
     YOLO26: {
       ...YOLO26_NANO_384_XNNPACK_FP32,
+      /**
+       * Nano scale YOLO26 object detection model. High speed,
+       * ultra low latency.
+       */
       NANO: {
         ...YOLO26_NANO_384_XNNPACK_FP32,
         SIZE_384: { XNNPACK_FP32: YOLO26_NANO_384_XNNPACK_FP32 },
         SIZE_512: { XNNPACK_FP32: YOLO26_NANO_512_XNNPACK_FP32 },
         SIZE_640: { XNNPACK_FP32: YOLO26_NANO_640_XNNPACK_FP32 },
       },
+      /**
+       * Small scale YOLO26 object detection model. Balanced
+       * latency and accuracy.
+       */
       SMALL: {
         ...YOLO26_SMALL_384_XNNPACK_FP32,
         SIZE_384: { XNNPACK_FP32: YOLO26_SMALL_384_XNNPACK_FP32 },
         SIZE_512: { XNNPACK_FP32: YOLO26_SMALL_512_XNNPACK_FP32 },
         SIZE_640: { XNNPACK_FP32: YOLO26_SMALL_640_XNNPACK_FP32 },
       },
+      /**
+       * Medium scale YOLO26 object detection model. Higher
+       * precision for complex scenes.
+       */
       MEDIUM: {
         ...YOLO26_MEDIUM_384_XNNPACK_FP32,
         SIZE_384: { XNNPACK_FP32: YOLO26_MEDIUM_384_XNNPACK_FP32 },
         SIZE_512: { XNNPACK_FP32: YOLO26_MEDIUM_512_XNNPACK_FP32 },
         SIZE_640: { XNNPACK_FP32: YOLO26_MEDIUM_640_XNNPACK_FP32 },
       },
+      /**
+       * Large scale YOLO26 object detection model. High accuracy
+       * model variant.
+       */
       LARGE: {
         ...YOLO26_LARGE_384_XNNPACK_FP32,
         SIZE_384: { XNNPACK_FP32: YOLO26_LARGE_384_XNNPACK_FP32 },
         SIZE_512: { XNNPACK_FP32: YOLO26_LARGE_512_XNNPACK_FP32 },
         SIZE_640: { XNNPACK_FP32: YOLO26_LARGE_640_XNNPACK_FP32 },
       },
+      /**
+       * Extra Large scale YOLO26 object detection model.
+       * Maximum detection performance.
+       */
       XLARGE: {
         ...YOLO26_XLARGE_384_XNNPACK_FP32,
         SIZE_384: { XNNPACK_FP32: YOLO26_XLARGE_384_XNNPACK_FP32 },
@@ -874,17 +983,35 @@ export const models = {
       },
     },
   },
+
+  /**
+   * Keypoint and pose detection models that estimate facial landmarks or human
+   * body skeletal keypoints.
+   */
   keypointDetection: {
+    /**
+     * MediaPipe BlazeFace lightweight face detection and 6-point facial landmark
+     * locator (eyes, nose, mouth, ears, see {@link BLAZEFACE_LANDMARKS}).
+     */
     BLAZEFACE: {
       ...BLAZEFACE_XNNPACK_FP32,
       XNNPACK_FP32: BLAZEFACE_XNNPACK_FP32,
     },
+    /**
+     * YOLO26 human pose estimation model predicting 17 COCO body keypoints
+     * (see {@link COCO_LANDMARKS}). Available across 384x384, 512x512, and
+     * 640x640 resolutions.
+     */
     YOLO26_POSE: {
       ...YOLO26_POSE_384_XNNPACK_FP32,
       SIZE_384: { XNNPACK_FP32: YOLO26_POSE_384_XNNPACK_FP32 },
       SIZE_512: { XNNPACK_FP32: YOLO26_POSE_512_XNNPACK_FP32 },
       SIZE_640: { XNNPACK_FP32: YOLO26_POSE_640_XNNPACK_FP32 },
     },
+    /**
+     * RF-DETR (Roboflow Detection Transformer) pose keypoint detector
+     * predicting 17 COCO body keypoints (see {@link COCO_LANDMARKS}).
+     */
     RFDETR_KEYPOINT: {
       ...RFDETR_KEYPOINT_XNNPACK_FP32,
       XNNPACK_FP32: RFDETR_KEYPOINT_XNNPACK_FP32,
@@ -892,14 +1019,31 @@ export const models = {
       MLX_FP32: RFDETR_KEYPOINT_MLX_FP32,
     },
   },
+
+  /**
+   * Instance segmentation models predicting both bounding boxes and fine-grained
+   * pixel masks per object instance.
+   */
   instanceSegmentation: {
+    /**
+     * Fast Segment Anything Model (FastSAM) for promptable or global object
+     * instance mask segmentation. Available in Small (S) and Extra Large (X)
+     * variants.
+     */
     FASTSAM: {
+      /**
+       * FastSAM Small - lightweight instance segmenter for
+       * mobile.
+       */
       S: {
         ...FASTSAM_S_XNNPACK_FP32,
         XNNPACK_FP32: FASTSAM_S_XNNPACK_FP32,
         COREML_FP32: FASTSAM_S_COREML_FP32,
         COREML_FP16: FASTSAM_S_COREML_FP16,
       },
+      /**
+       * FastSAM Extra Large - high-accuracy instance segmenter.
+       */
       X: {
         ...FASTSAM_X_XNNPACK_FP32,
         XNNPACK_FP32: FASTSAM_X_XNNPACK_FP32,
@@ -907,37 +1051,56 @@ export const models = {
         COREML_FP16: FASTSAM_X_COREML_FP16,
       },
     },
+    /**
+     * RF-DETR (Roboflow Detection Transformer) Nano instance segmentation
+     * model predicting COCO class masks and bounding boxes
+     * (see {@link COCO_CLASSES}).
+     */
     RFDETR_NANO: {
       ...RFDETR_NANO_SEG_COREML_INT8,
       COREML_INT8: RFDETR_NANO_SEG_COREML_INT8,
       XNNPACK_FP32: RFDETR_NANO_SEG_XNNPACK_FP32,
     },
+    /**
+     * YOLO26 instance segmentation models predicting COCO class instance masks
+     * and bounding boxes (see {@link COCO_CLASSES_YOLO}). Available across
+     * multiple sizes (NANO, SMALL, MEDIUM, LARGE, XLARGE) and resolutions
+     * (384x384, 512x512, 640x640).
+     */
     YOLO26: {
       ...YOLO26_NANO_SEG_384_XNNPACK_FP32,
+      /**
+       * Nano scale YOLO26 instance segmentation model. High
+       * speed.
+       */
       NANO: {
         ...YOLO26_NANO_SEG_384_XNNPACK_FP32,
         SIZE_384: { XNNPACK_FP32: YOLO26_NANO_SEG_384_XNNPACK_FP32 },
         SIZE_512: { XNNPACK_FP32: YOLO26_NANO_SEG_512_XNNPACK_FP32 },
         SIZE_640: { XNNPACK_FP32: YOLO26_NANO_SEG_640_XNNPACK_FP32 },
       },
+      /** Small scale YOLO26 instance segmentation model. */
       SMALL: {
         ...YOLO26_SMALL_SEG_384_XNNPACK_FP32,
         SIZE_384: { XNNPACK_FP32: YOLO26_SMALL_SEG_384_XNNPACK_FP32 },
         SIZE_512: { XNNPACK_FP32: YOLO26_SMALL_SEG_512_XNNPACK_FP32 },
         SIZE_640: { XNNPACK_FP32: YOLO26_SMALL_SEG_640_XNNPACK_FP32 },
       },
+      /** Medium scale YOLO26 instance segmentation model. */
       MEDIUM: {
         ...YOLO26_MEDIUM_SEG_384_XNNPACK_FP32,
         SIZE_384: { XNNPACK_FP32: YOLO26_MEDIUM_SEG_384_XNNPACK_FP32 },
         SIZE_512: { XNNPACK_FP32: YOLO26_MEDIUM_SEG_512_XNNPACK_FP32 },
         SIZE_640: { XNNPACK_FP32: YOLO26_MEDIUM_SEG_640_XNNPACK_FP32 },
       },
+      /** Large scale YOLO26 instance segmentation model. */
       LARGE: {
         ...YOLO26_LARGE_SEG_384_XNNPACK_FP32,
         SIZE_384: { XNNPACK_FP32: YOLO26_LARGE_SEG_384_XNNPACK_FP32 },
         SIZE_512: { XNNPACK_FP32: YOLO26_LARGE_SEG_512_XNNPACK_FP32 },
         SIZE_640: { XNNPACK_FP32: YOLO26_LARGE_SEG_640_XNNPACK_FP32 },
       },
+      /** Extra Large scale YOLO26 instance segmentation model. */
       XLARGE: {
         ...YOLO26_XLARGE_SEG_384_XNNPACK_FP32,
         SIZE_384: { XNNPACK_FP32: YOLO26_XLARGE_SEG_384_XNNPACK_FP32 },
@@ -946,47 +1109,89 @@ export const models = {
       },
     },
   },
+
+  /**
+   * Voice Activity Detection (VAD) models detecting speech vs non-speech
+   * intervals in real-time audio streams.
+   */
   voiceActivityDetection: {
+    /**
+     * Feedforward Sequential Memory Network (FSMN) Voice Activity Detection
+     * model. Extremely lightweight model evaluating continuous speech
+     * probability chunks for live mic streaming and STT preprocessing.
+     */
     FSMN_VAD: {
       ...FSMN_VAD_XNNPACK_FP32,
       XNNPACK_FP32: FSMN_VAD_XNNPACK_FP32,
     },
   },
+
+  /**
+   * Automatic Speech Recognition (ASR) / Speech-to-Text models.
+   */
   speechToText: {
+    /**
+     * OpenAI Whisper automatic speech recognition model family with integrated
+     * Voice Activity Detection. Includes multilingual and English-only (`EN`)
+     * variants across model sizes (`TINY`, `BASE`, `SMALL`).
+     */
     WHISPER: {
-      ...WHISPER_TINY_XNNPACK_FP32,
+      /**
+       * Multilingual Whisper Tiny model. Supporting 99+
+       * languages. High speed speech recognition.
+       */
       TINY: {
         ...WHISPER_TINY_XNNPACK_FP32,
         XNNPACK_FP32: WHISPER_TINY_XNNPACK_FP32,
         COREML_FP16: WHISPER_TINY_COREML_FP16,
         MLX_BF16: WHISPER_TINY_MLX_BF16,
       },
+      /**
+       * Multilingual Whisper Base model. Higher accuracy across
+       * supported languages.
+       */
       BASE: {
         ...WHISPER_BASE_XNNPACK_FP32,
         XNNPACK_FP32: WHISPER_BASE_XNNPACK_FP32,
         COREML_FP16: WHISPER_BASE_COREML_FP16,
         MLX_BF16: WHISPER_BASE_MLX_BF16,
       },
+      /**
+       * Multilingual Whisper Small model. Best accuracy for
+       * complex multi-language audio.
+       */
       SMALL: {
         ...WHISPER_SMALL_XNNPACK_FP32,
         XNNPACK_FP32: WHISPER_SMALL_XNNPACK_FP32,
         COREML_FP16: WHISPER_SMALL_COREML_FP16,
         MLX_BF16: WHISPER_SMALL_MLX_BF16,
       },
+      /** English-only optimized Whisper models (`TINY`, `BASE`, `SMALL`). */
       EN: {
-        ...WHISPER_TINY_EN_XNNPACK_FP32,
+        /**
+         * English-only Whisper Tiny model. Fast and compact for
+         * English STT.
+         */
         TINY: {
           ...WHISPER_TINY_EN_XNNPACK_FP32,
           XNNPACK_FP32: WHISPER_TINY_EN_XNNPACK_FP32,
           COREML_FP16: WHISPER_TINY_EN_COREML_FP16,
           MLX_BF16: WHISPER_TINY_EN_MLX_BF16,
         },
+        /**
+         * English-only Whisper Base model. High accuracy
+         * English speech recognition.
+         */
         BASE: {
           ...WHISPER_BASE_EN_XNNPACK_FP32,
           XNNPACK_FP32: WHISPER_BASE_EN_XNNPACK_FP32,
           COREML_FP16: WHISPER_BASE_EN_COREML_FP16,
           MLX_BF16: WHISPER_BASE_EN_MLX_BF16,
         },
+        /**
+         * English-only Whisper Small model. Superior accuracy
+         * for English transcription.
+         */
         SMALL: {
           ...WHISPER_SMALL_EN_XNNPACK_FP32,
           XNNPACK_FP32: WHISPER_SMALL_EN_XNNPACK_FP32,
@@ -996,41 +1201,83 @@ export const models = {
       },
     },
   },
+
+  /**
+   * Standalone text tokenizers for preprocessing strings into token ID arrays.
+   */
   tokenizer: {
+    /** WordPiece tokenizer URL for the `all-MiniLM-L6-v2` embedding model. */
     ALL_MINILM_L6_V2: ALL_MINILM_L6_V2_TOKENIZER,
   },
+
+  /**
+   * Text embedding models mapping sentences and documents into dense vector
+   * representations for semantic search and RAG.
+   */
   textEmbeddings: {
+    /**
+     * Compact 384-dimensional sentence transformer mapping text to a dense
+     * vector space. Optimized for fast, general-purpose semantic search,
+     * sentence similarity, and clustering.
+     */
     ALL_MINILM_L6_V2: {
       ...ALL_MINILM_L6_V2_EMBEDDINGS,
       XNNPACK_FP32: ALL_MINILM_L6_V2_EMBEDDINGS,
     },
+    /**
+     * High-quality 768-dimensional sentence transformer model based on MPNet.
+     * Provides higher quality semantic embeddings compared to MiniLM.
+     */
     ALL_MPNET_BASE_V2: {
       ...ALL_MPNET_BASE_V2_EMBEDDINGS,
       XNNPACK_FP32: ALL_MPNET_BASE_V2_EMBEDDINGS,
     },
+    /**
+     * 384-dimensional sentence transformer fine-tuned specifically for
+     * semantic QA matching using cosine similarity.
+     */
     MULTI_QA_MINILM_L6_COS_V1: {
       ...MULTI_QA_MINILM_L6_COS_V1_EMBEDDINGS,
       XNNPACK_FP32: MULTI_QA_MINILM_L6_COS_V1_EMBEDDINGS,
     },
+    /**
+     * 768-dimensional sentence transformer fine-tuned specifically for
+     * question-answering matching using dot product distance.
+     */
     MULTI_QA_MPNET_BASE_DOT_V1: {
       ...MULTI_QA_MPNET_BASE_DOT_V1_EMBEDDINGS,
       XNNPACK_FP32: MULTI_QA_MPNET_BASE_DOT_V1_EMBEDDINGS,
     },
+    /**
+     * 384-dimensional sentence transformer supporting 50+ languages for
+     * cross-lingual semantic similarity.
+     */
     PARAPHRASE_MULTILINGUAL_MINILM_L12_V2: {
       ...PARAPHRASE_MULTILINGUAL_MINILM_L12_V2_EMBEDDINGS,
       XNNPACK_8DA4W: PARAPHRASE_MULTILINGUAL_MINILM_L12_V2_EMBEDDINGS,
     },
+    /**
+     * Multilingual sentence transformer supporting 50+ languages, based on
+     * distilled Universal Sentence Encoder (512-dim output).
+     */
     DISTILUSE_BASE_MULTILINGUAL_CASED_V2: {
       ...DISTILUSE_BASE_MULTILINGUAL_CASED_V2_EMBEDDINGS,
       XNNPACK_8DA4W: DISTILUSE_BASE_MULTILINGUAL_CASED_V2_EMBEDDINGS,
     },
+    /**
+     * CLIP text encoder (ViT-B/32) mapping text queries into a
+     * 512-dimensional joint text-image embedding space. Used in combination
+     * with `imageEmbeddings.CLIP_VIT_BASE_PATCH32` for zero-shot text-to-image
+     * search.
+     */
     CLIP_VIT_BASE_PATCH32_TEXT: {
       ...CLIP_VIT_BASE_PATCH32_TEXT_EMBEDDINGS,
       XNNPACK_FP32: CLIP_VIT_BASE_PATCH32_TEXT_EMBEDDINGS,
     },
     /**
-     * Asymmetric retrieval model: prompt queries with `query: ` (the default)
-     * and passages with `document: ` via `embed(text, 'document: ')`.
+     * Liquid AI LFM 2.5 350M parameter embedding model for asymmetric search
+     * and retrieval tasks. Prompts queries with `query: ` (the default) and
+     * passages with `document: ` via `embed(text, 'document: ')`.
      */
     LFM2_5_EMBEDDING_350M: {
       ...LFM2_5_EMBEDDING_350M_EMBEDDINGS,
@@ -1038,14 +1285,32 @@ export const models = {
       MLX_INT4: LFM2_5_EMBEDDING_350M_MLX_INT4,
     },
   },
+
+  /**
+   * Image feature extraction and vision embedding models.
+   */
   imageEmbeddings: {
+    /**
+     * CLIP vision encoder (ViT-B/32) mapping images into a 512-dimensional
+     * shared text-image space. Used for zero-shot visual classification and
+     * cross-modal image search.
+     */
     CLIP_VIT_BASE_PATCH32: {
       ...CLIP_VIT_BASE_PATCH32_IMAGE_XNNPACK_FP32,
       XNNPACK_FP32: CLIP_VIT_BASE_PATCH32_IMAGE_XNNPACK_FP32,
       XNNPACK_INT8: CLIP_VIT_BASE_PATCH32_IMAGE_XNNPACK_INT8,
     },
   },
+
+  /**
+   * Generative text-to-image synthesis models.
+   */
   textToImage: {
+    /**
+     * Ultra-fast SDXS (Stable Diffusion eXtreme Speed) 512x512 text-to-image
+     * generation model based on DreamShaper. Generates high-quality images
+     * from text prompts in real time.
+     */
     SDXS_512_DREAMSHAPER: {
       ...SDXS_512_DREAMSHAPER_XNNPACK_FP32,
       XNNPACK_FP32: SDXS_512_DREAMSHAPER_XNNPACK_FP32,


### PR DESCRIPTION
## Description

Adds JSDoc documentation comments to all model preset categories and entries in `models.ts` to improve developer autocompletion and TypeDoc reference generation.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

N/A

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

Closes #1341 

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
