### PR TITLE
[RNE Rewrite] fix(schema): require positive integer min bound for RangeDim

### DIFF
--- a/packages/react-native-executorch/cpp/core/schema.cpp
+++ b/packages/react-native-executorch/cpp/core/schema.cpp
@@ -300,8 +300,8 @@ void validateConcreteDim(const ConcreteDim &dim, const std::string &ctx) {
             }
         },
         [&](const RangeDim &r) {
-            if (r.min < 0) {
-                throw std::runtime_error(std::format("{}: range min must be non-negative", ctx));
+            if (r.min <= 0) {
+                throw std::runtime_error(std::format("{}: range min must be positive", ctx));
             }
             if (r.max < r.min) {
                 throw std::runtime_error(std::format("{}: range max must be >= min", ctx));

--- a/packages/react-native-executorch/src/core/schema.ts
+++ b/packages/react-native-executorch/src/core/schema.ts
@@ -290,14 +290,14 @@ export const EnumDim = (choices: readonly number[]): ConcreteDim => {
  * @throws {Error} If the range bounds or step are not valid positive integers.
  */
 export const RangeDim = (min: number, max: number, step?: number): ConcreteDim => {
-  if (min < 0 || !Number.isInteger(min)) {
-    throw new Error(`Invalid range min (${min}): must be a non-negative integer.`);
+  if (min <= 0 || !Number.isInteger(min)) {
+    throw new Error(`Invalid range min (${min}): must be a positive integer.`);
   }
   if (max < min) {
     throw new Error(`Invalid range [${min}, ${max}]: max cannot be less than min.`);
   }
   if (!Number.isInteger(max)) {
-    throw new Error(`Invalid range max (${max}): must be a non-negative integer.`);
+    throw new Error(`Invalid range max (${max}): must be a positive integer.`);
   }
   if (step !== undefined && (step <= 0 || !Number.isInteger(step))) {
     throw new Error(`Invalid range step (${step}): must be a positive integer.`);
@@ -644,8 +644,8 @@ function validateDimDomains(modelSpec: ModelSpec<SymbolicDim>): void {
           }
         }
         if (dim.kind === 'range') {
-          if (dim.range.min < 0 || !Number.isInteger(dim.range.min)) {
-            throw new Error(`${ctx}: range min must be a non-negative integer.`);
+          if (dim.range.min <= 0 || !Number.isInteger(dim.range.min)) {
+            throw new Error(`${ctx}: range min must be a positive integer.`);
           }
           if (dim.range.max < dim.range.min || !Number.isInteger(dim.range.max)) {
             throw new Error(`${ctx}: range max must be >= min.`);


### PR DESCRIPTION
## Description

Fixes the lower bound constraint for range dims to be consistent with other dim types.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

N/A

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
