### PR TITLE
fix(ios): make ExecutorchLib buildable again, and against ExecuTorch 1.4.1

### DIFF
--- a/packages/react-native-executorch/third-party/ios/ExecutorchLib/ExecutorchLib.xcodeproj/project.pbxproj
+++ b/packages/react-native-executorch/third-party/ios/ExecutorchLib/ExecutorchLib.xcodeproj/project.pbxproj
@@ -10,9 +10,10 @@
 		0E4A7F472D67549100D8DCBA /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E4A7F442D67549100D8DCBA /* Metal.framework */; };
 		0E4A7F482D67549100D8DCBA /* MetalPerformanceShaders.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E4A7F452D67549100D8DCBA /* MetalPerformanceShaders.framework */; };
 		0E4A7F492D67549100D8DCBA /* MetalPerformanceShadersGraph.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E4A7F462D67549100D8DCBA /* MetalPerformanceShadersGraph.framework */; };
-		5576B4B92CEF970E005027B7 /* ETModel.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5576B4B82CEF970C005027B7 /* ETModel.mm */; };
+		5576B4B92CEF970E005027B7 /* ExecutorchLib.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5576B4B82CEF970C005027B7 /* ExecutorchLib.mm */; };
 		55EA2C572CB90E7D004315B3 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55EA2C562CB90E7D004315B3 /* Accelerate.framework */; };
 		55EA2C592CB90E80004315B3 /* CoreML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55EA2C582CB90E80004315B3 /* CoreML.framework */; };
+		55EA2C5B2CB90E82004315B3 /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55EA2C5A2CB90E82004315B3 /* CoreImage.framework */; };
 		55EA2C5B2CB90E85004315B3 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 55EA2C5A2CB90E85004315B3 /* libsqlite3.tbd */; };
 /* End PBXBuildFile section */
 
@@ -20,11 +21,11 @@
 		0E4A7F442D67549100D8DCBA /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		0E4A7F452D67549100D8DCBA /* MetalPerformanceShaders.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalPerformanceShaders.framework; path = System/Library/Frameworks/MetalPerformanceShaders.framework; sourceTree = SDKROOT; };
 		0E4A7F462D67549100D8DCBA /* MetalPerformanceShadersGraph.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalPerformanceShadersGraph.framework; path = System/Library/Frameworks/MetalPerformanceShadersGraph.framework; sourceTree = SDKROOT; };
-		5576B4B62CEF9705005027B7 /* ETModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ETModel.h; sourceTree = "<group>"; };
-		5576B4B82CEF970C005027B7 /* ETModel.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ETModel.mm; sourceTree = "<group>"; };
+		5576B4B82CEF970C005027B7 /* ExecutorchLib.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ExecutorchLib.mm; sourceTree = "<group>"; };
 		55EA2C1C2CB90C22004315B3 /* ExecutorchLib.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ExecutorchLib.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		55EA2C562CB90E7D004315B3 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		55EA2C582CB90E80004315B3 /* CoreML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreML.framework; path = System/Library/Frameworks/CoreML.framework; sourceTree = SDKROOT; };
+		55EA2C5A2CB90E82004315B3 /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = System/Library/Frameworks/CoreImage.framework; sourceTree = SDKROOT; };
 		55EA2C5A2CB90E85004315B3 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -38,6 +39,7 @@
 				0E4A7F492D67549100D8DCBA /* MetalPerformanceShadersGraph.framework in Frameworks */,
 				55EA2C5B2CB90E85004315B3 /* libsqlite3.tbd in Frameworks */,
 				55EA2C592CB90E80004315B3 /* CoreML.framework in Frameworks */,
+				55EA2C5B2CB90E82004315B3 /* CoreImage.framework in Frameworks */,
 				55EA2C572CB90E7D004315B3 /* Accelerate.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -73,8 +75,7 @@
 		55EA2C352CB90C7A004315B3 /* Exported */ = {
 			isa = PBXGroup;
 			children = (
-				5576B4B82CEF970C005027B7 /* ETModel.mm */,
-				5576B4B62CEF9705005027B7 /* ETModel.h */,
+				5576B4B82CEF970C005027B7 /* ExecutorchLib.mm */,
 			);
 			path = Exported;
 			sourceTree = "<group>";
@@ -87,6 +88,7 @@
 				0E4A7F462D67549100D8DCBA /* MetalPerformanceShadersGraph.framework */,
 				55EA2C5A2CB90E85004315B3 /* libsqlite3.tbd */,
 				55EA2C582CB90E80004315B3 /* CoreML.framework */,
+				55EA2C5A2CB90E82004315B3 /* CoreImage.framework */,
 				55EA2C562CB90E7D004315B3 /* Accelerate.framework */,
 			);
 			name = Frameworks;
@@ -163,7 +165,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5576B4B92CEF970E005027B7 /* ETModel.mm in Sources */,
+				5576B4B92CEF970E005027B7 /* ExecutorchLib.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/react-native-executorch/third-party/ios/ExecutorchLib/ExecutorchLib/Exported/ExecutorchLib.mm
+++ b/packages/react-native-executorch/third-party/ios/ExecutorchLib/ExecutorchLib/Exported/ExecutorchLib.mm
@@ -1,0 +1,12 @@
+// ExecutorchLib exists to package the ExecuTorch runtime static libraries into a
+// single framework: the payload comes from the -force_load entries in
+// OTHER_LDFLAGS, not from code compiled here. This translation unit only gives
+// the framework target something to compile.
+//
+// The Objective-C wrapper this target used to hold (ETModel) belonged to the
+// pre-rewrite API and was removed in #1255; the project kept referencing it,
+// which left the framework unbuildable.
+//
+// It is Objective-C++ on purpose: the ExecuTorch runtime is C++, so the target
+// needs at least one C++ translation unit for the C++ standard library to be
+// linked into the framework.

--- a/packages/react-native-executorch/third-party/ios/ExecutorchLib/build.sh
+++ b/packages/react-native-executorch/third-party/ios/ExecutorchLib/build.sh
@@ -37,6 +37,37 @@ FRAMEWORK_NAME="$SCHEME_NAME.framework"
 XCFRAMEWORK_NAME="$SCHEME_NAME.xcframework"
 XCFRAMEWORK_PATH="$OUTPUT_FOLDER/$XCFRAMEWORK_NAME"
 
+# --- KleidiAI ---
+# libkernels_torchao references kai_* symbols, and the framework is a dylib, so
+# they have to resolve at link time. ExecuTorch used to ship a standalone
+# libkleidiai_<platform>.a but no longer does: as of 1.4.1 the kai_* objects are
+# folded into libbackend_xnnpack, which ships as its own force_loaded
+# xcframework and is deliberately NOT linked here. Rebuild the standalone
+# archive from those objects when it is missing so the framework still links.
+for platform in ios simulator; do
+  kleidiai="$LIBS_DIR/libkleidiai_$platform.a"
+  xnnpack="$LIBS_DIR/libbackend_xnnpack_$platform.a"
+
+  if [ -f "$kleidiai" ] || [ ! -f "$xnnpack" ]; then
+    continue
+  fi
+
+  echo "Rebuilding $(basename "$kleidiai") from $(basename "$xnnpack")"
+  staging=$(mktemp -d)
+  (
+    cd "$staging"
+    ar x "$xnnpack"
+    kai_objects=$(ls | grep -i '^kai_' || true)
+    if [ -z "$kai_objects" ]; then
+      echo "  No kai_* objects found; leaving it to the linker to complain." >&2
+      exit 0
+    fi
+    # shellcheck disable=SC2086
+    xcrun ar rcs "$kleidiai" $kai_objects
+  )
+  rm -rf "$staging"
+done
+
 # --- Script ---
 rm -rf "$BUILD_FOLDER" "$OUTPUT_FOLDER"
 mkdir -p "$OUTPUT_FOLDER"


### PR DESCRIPTION
## Description

`third-party/ios/ExecutorchLib` could not be built on this branch at all, and two further breakages show up once its static libs come from ExecuTorch 1.4.1. All three block producing iOS artifacts for the 1.4.1 bump.

- **Restore a source file for the framework target.** #1255 removed the pre-rewrite Objective-C wrapper (`ETModel.{h,mm}`) but left the project referencing it, so the build failed on a missing input before compiling anything (`Build input file cannot be found: .../ETModel.mm`). Nothing in the rewrite uses that API, so rather than resurrect it the target now holds a placeholder translation unit that documents what the framework is for. It is Objective-C++ because the target needs at least one C++ translation unit for the C++ standard library to be linked (with a plain `.m` the link fails on `std::logic_error`, `std::runtime_error::what()` and friends from `libkernels_optimized`).
- **Link CoreImage.** 1.4.1 adds `image_processor_apple_gpu.o` to `libexecutorch`, which references `CIContext` and `CIImage`. 1.3.1 shipped no such object, so the framework linked without it.
- **Rebuild `libkleidiai_<platform>.a` when missing.** `libkernels_torchao` references `kai_*` symbols and the framework is a dylib, so they have to resolve at link time. ExecuTorch used to ship a standalone kleidiai archive; as of 1.4.1 those objects are folded into `libbackend_xnnpack`, which ships as its own force_loaded xcframework and is deliberately not linked into this framework. `build.sh` now reconstructs the archive from those objects when the artifact set does not provide one, so this keeps working across ExecuTorch versions either way.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

1. Stage ExecuTorch 1.4.1 iOS artifacts into `third-party/ios/libs/executorch` (the `*_ios.a` and `*_simulator.a` set plus `mlx.metallib`). Use this branch: https://github.com/software-mansion-labs/executorch/tree/%40ms/separate-backends-1.4.1 for building them.
2. Run `third-party/ios/ExecutorchLib/build.sh`. All four xcframeworks (ExecutorchLib, XnnpackBackend, CoreMLBackend, MLXBackend) build from a clean checkout with no manual steps; the log shows the kleidiai archive being reconstructed.
3. Copy `output/*.xcframework` into `third-party/ios/`, then build and run a demo app on a physical device.

Verified end to end on an iPhone with the computer-vision app: the app links against the resulting framework and runs its models. Android is untouched by this change.

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

The kleidiai reconstruction is a workaround placed at the consumer. The cleaner home for it is the ExecuTorch-side artifact build, which could ship the standalone archive again; doing it here means the framework builds regardless of which ExecuTorch version produced the artifacts.
