### PR TITLE
feat(tts): add a Core ML Kokoro synthesizer variant

### DIFF
--- a/apps/speech/screens/TextToSpeechScreen.tsx
+++ b/apps/speech/screens/TextToSpeechScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Text,
   View,
@@ -81,17 +81,40 @@ const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 // (`() => TextToSpeechModelConfig`); call them to get the actual configs.
 const kokoroVoicesByLang = models.text_to_speech.kokoro as unknown as Record<
   string,
-  Record<string, () => TextToSpeechModelConfig>
+  Record<
+    string,
+    (opts?: { backend?: 'xnnpack' | 'coreml' }) => TextToSpeechModelConfig
+  >
 >;
 
-const KOKORO_VOICES: ModelOption<TextToSpeechModelConfig>[] = Object.entries(
-  kokoroVoicesByLang
-).flatMap(([lang, voices]) =>
-  Object.entries(voices).map(([name, factory]) => ({
-    label: `${KOKORO_LANG_LABELS[lang] ?? lang} · ${capitalize(name)}`,
-    value: factory(),
-  }))
-);
+type KokoroBackend = 'xnnpack' | 'coreml';
+
+// Core ML only covers the standard model, so the polish and german voices stay
+// on XNNPACK and their factories throw if asked for Core ML.
+const kokoroVoices = (
+  backend: KokoroBackend
+): ModelOption<TextToSpeechModelConfig>[] =>
+  Object.entries(kokoroVoicesByLang).flatMap(([lang, voices]) =>
+    Object.entries(voices).map(([name, factory]) => {
+      let value: TextToSpeechModelConfig;
+      try {
+        value = factory({ backend });
+      } catch {
+        value = factory();
+      }
+      return {
+        label: `${KOKORO_LANG_LABELS[lang] ?? lang} · ${capitalize(name)}`,
+        value,
+      };
+    })
+  );
+
+const KOKORO_VOICES = kokoroVoices('xnnpack');
+
+const KOKORO_BACKENDS: ModelOption<KokoroBackend>[] = [
+  { label: 'XNNPACK', value: 'xnnpack' },
+  { label: 'Core ML (iOS)', value: 'coreml' },
+];
 
 type TtsModelType = 'supertonic' | 'kokoro';
 
@@ -147,6 +170,21 @@ export const TextToSpeechScreen = ({ onBack }: { onBack: () => void }) => {
   const [selectedLang, setSelectedLang] =
     useState<TextToSpeechSupertonicLanguage>('en');
   const [totalSteps, setTotalSteps] = useState<number>(8);
+  const [kokoroBackend, setKokoroBackend] = useState<KokoroBackend>('xnnpack');
+
+  const kokoroVoiceOptions = useMemo(
+    () => kokoroVoices(kokoroBackend),
+    [kokoroBackend]
+  );
+
+  const handleSelectKokoroBackend = (backend: KokoroBackend) => {
+    if (backend === kokoroBackend) return;
+    const index = kokoroVoices(kokoroBackend).findIndex(
+      (o) => o.value === selectedSpeaker
+    );
+    setKokoroBackend(backend);
+    if (index >= 0) setSelectedSpeaker(kokoroVoices(backend)[index]!.value);
+  };
 
   const model = useTextToSpeech(selectedSpeaker);
 
@@ -306,12 +344,22 @@ export const TextToSpeechScreen = ({ onBack }: { onBack: () => void }) => {
             <ModelPicker
               label="Voice"
               models={
-                selectedTtsModel === 'supertonic' ? VOICES : KOKORO_VOICES
+                selectedTtsModel === 'supertonic' ? VOICES : kokoroVoiceOptions
               }
               selectedModel={selectedSpeaker}
               disabled={model.isGenerating}
               onSelect={(m) => setSelectedSpeaker(m)}
             />
+
+            {selectedTtsModel === 'kokoro' && Platform.OS === 'ios' && (
+              <ModelPicker
+                label="Synthesizer backend"
+                models={KOKORO_BACKENDS}
+                selectedModel={kokoroBackend}
+                disabled={model.isGenerating || isPlaying}
+                onSelect={handleSelectKokoroBackend}
+              />
+            )}
 
             {selectedTtsModel === 'supertonic' && (
               <>

--- a/packages/react-native-executorch/src/constants/modelRegistry.ts
+++ b/packages/react-native-executorch/src/constants/modelRegistry.ts
@@ -39,7 +39,12 @@ import {
   SUPERTONIC_FEMALE_4,
   SUPERTONIC_FEMALE_5,
 } from './tts/voices';
-import { SUPERTONIC_XNNPACK, SUPERTONIC_MLX } from './tts/models';
+import {
+  SUPERTONIC_XNNPACK,
+  SUPERTONIC_MLX,
+  KOKORO_STANDARD,
+  KOKORO_STANDARD_COREML,
+} from './tts/models';
 import {
   TextToSpeechModelConfig,
   TextToSpeechModelSources,
@@ -220,8 +225,19 @@ function pair<D extends { modelName: string }, Q extends { modelName: string }>(
 // don't share the `{ modelName: string }` shape of the rest of the registry,
 // and have no quant/backend axis. Expose them as a plain `() => Config`
 // accessor so the call style stays consistent (`models.text_to_speech.en_us.heart()`).
-function tts<C extends TextToSpeechModelConfig>(c: C): () => C {
-  return () => c;
+function tts<C extends TextToSpeechModelConfig>(
+  c: C
+): (opts?: { backend?: 'xnnpack' | 'coreml' }) => C {
+  return (opts) => {
+    if (opts?.backend !== 'coreml') return c;
+    if (c.model !== KOKORO_STANDARD) {
+      throw new Error(
+        'Core ML is only available for the standard Kokoro model; ' +
+          'the polish and german variants ship on XNNPACK only.'
+      );
+    }
+    return { ...c, model: KOKORO_STANDARD_COREML } as C;
+  };
 }
 
 type TTSBackendMap = Partial<Record<Backend, TextToSpeechModelSources>>;

--- a/packages/react-native-executorch/src/constants/tts/models.ts
+++ b/packages/react-native-executorch/src/constants/tts/models.ts
@@ -3,9 +3,28 @@ import { URL_PREFIX, PREVIOUS_VERSION_TAG, VERSION_TAG } from '../versions';
 
 // Text to speech (tts) - Kokoro model(s)
 const KOKORO_MODEL_ROOT = `${URL_PREFIX}-kokoro/${PREVIOUS_VERSION_TAG}/xnnpack`;
+const KOKORO_COREML_MODEL_ROOT = `${URL_PREFIX}-kokoro/${VERSION_TAG}/coreml`;
 const KOKORO_STANDARD_MODEL_ROOT = `${KOKORO_MODEL_ROOT}/standard`;
+const KOKORO_COREML_STANDARD_MODEL_ROOT = `${KOKORO_COREML_MODEL_ROOT}/standard`;
 const KOKORO_POLISH_MODEL_ROOT = `${KOKORO_MODEL_ROOT}/polish`;
 const KOKORO_GERMAN_MODEL_ROOT = `${KOKORO_MODEL_ROOT}/german`;
+
+/**
+ * The standard Kokoro instance with the synthesizer running on Core ML. iOS only.
+ *
+ * The synthesizer is the expensive half of Kokoro. On an iPhone 16 this build
+ * produces 7.4 s of audio in 627 ms, against 4741 ms for the XNNPACK one, at the
+ * cost of a one-time compile on the first call that is cached across launches.
+ * The duration predictor stays on XNNPACK, so this config mixes backends.
+ *
+ * Use {@link KOKORO_STANDARD} on Android.
+ * @category Models - Text to Speech
+ */
+export const KOKORO_STANDARD_COREML = {
+  modelName: 'kokoro' as const,
+  durationPredictorSource: `${KOKORO_STANDARD_MODEL_ROOT}/duration_predictor_std.pte`,
+  synthesizerSource: `${KOKORO_COREML_STANDARD_MODEL_ROOT}/synthesizer_coreml_fp32.pte`,
+};
 
 /**
  * A standard Kokoro instance which processes the text in batches of maximum 128 tokens.


### PR DESCRIPTION
## Description

Adds `KOKORO_STANDARD_COREML`: the Kokoro synthesizer on Core ML, with the duration predictor left on XNNPACK. The synthesizer is the expensive half of Kokoro, and on an iPhone 16 it produces 7.4 s of audio in **627 ms** against **4741 ms** for the XNNPACK build (warm median of 6 runs, real af_heart voice and the real duration predictor output). The first call pays a 12 s Core ML compile, which is cached across launches (0.46 s on a relaunch).

Quality against eager on the same inputs: spectral correlation 0.9993, RMS ratio 0.9991.

The registry voice factories now take an optional `{ backend }` argument, so `models.text_to_speech.kokoro.en_us.heart({ backend: 'coreml' })` returns the same voice pointed at the Core ML synthesizer. Core ML only covers the standard model, so the polish and german variants throw a clear error instead of silently falling back.

The duration predictor stays on XNNPACK because its contract is a single dynamic `forward` and coremltools cannot express that today (dynamic `F.pad` on a rank > 1 tensor is unsupported, and the `cat` workaround makes `torch.export` derive a non-equality constraint on the token dim). It is also the cheap half, at 233 ms.

**The artifact is not published yet.** `synthesizer_coreml_fp32.pte` (296 MB) has to land at `<hf>/react-native-executorch-kokoro/resolve/v0.10.0/coreml/standard/` before this config resolves. The export lives in export-scripts MR !17.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

The `.pte` was benchmarked and verified on an iPhone 16 through a standalone harness (`ExecutorchModule` loading the artifact from the app container), not yet through this config, since the artifact is not on HF. Once it is published:

1. Run `apps/speech` on an iOS device.
2. Text to speech screen, pick Kokoro, then switch "Synthesizer backend" to Core ML.
3. The first generation is slow (one-time compile), later ones are noticeably faster than XNNPACK.

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

Core ML export and the two model fixes it needed: export-scripts MR !17. One of them is an upstream coremltools bug, apple/coremltools#2836 (`x % 1` converts to zeros), which silently broke the excitation until it was worked around.

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

Core ML is pinned to `CPU_ONLY` in the export. `ComputeUnit.ALL` on this model gave a 25 minute compile for one duration predictor method and an execute failure for another, and fp16 drops spectral correlation to 0.973 against 0.9993 for fp32, so the shipped artifact is fp32 CPU_ONLY.
