### PR TITLE
[RNE Rewrite] feat(tts): add a Core ML Kokoro variant

### DIFF
--- a/apps/speech/app/kokoro-text-to-speech/index.tsx
+++ b/apps/speech/app/kokoro-text-to-speech/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { View, Text, StyleSheet, ScrollView, TextInput } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TextInput, Platform } from 'react-native';
 import {
   useTextToSpeech,
   models,
@@ -27,6 +27,20 @@ const LANGUAGE_OPTIONS = [
 ];
 
 type KokoroLanguage = (typeof LANGUAGE_OPTIONS)[number]['value'];
+
+// Core ML is exported for the standard weights only, and only runs on iOS.
+const BACKEND_OPTIONS = [
+  { label: 'XNNPACK', value: 'XNNPACK_FP32' as const },
+  { label: 'Core ML', value: 'COREML_FP32' as const },
+];
+
+type KokoroBackend = (typeof BACKEND_OPTIONS)[number]['value'];
+
+const kokoroModel = (language: KokoroLanguage, backend: KokoroBackend) => {
+  const entry = models.textToSpeech.KOKORO[language];
+  const model = backend in entry ? entry[backend as keyof typeof entry] : entry.XNNPACK_FP32;
+  return model as KokoroTtsModel<string>;
+};
 
 // cspell:disable
 const SAMPLE_TEXTS: Record<KokoroLanguage, string> = {
@@ -65,7 +79,9 @@ function KokoroContent() {
   const [runError, setRunError] = useState<string | null>(null);
   const [totalDuration, setTotalDuration] = useState<number | null>(null);
 
-  const model = models.textToSpeech.KOKORO[language].XNNPACK_FP32 as KokoroTtsModel<string>;
+  const [backend, setBackend] = useState<KokoroBackend>('XNNPACK_FP32');
+
+  const model = kokoroModel(language, backend);
   const voiceNames = Object.keys(model.voices);
   const [voice, setVoice] = useState(voiceNames[0]!);
 
@@ -77,6 +93,9 @@ function KokoroContent() {
   useEffect(() => {
     setVoice(Object.keys(models.textToSpeech.KOKORO[language].XNNPACK_FP32.voices)[0]!);
     setText(SAMPLE_TEXTS[language]);
+    if (!('COREML_FP32' in models.textToSpeech.KOKORO[language])) {
+      setBackend('XNNPACK_FP32');
+    }
   }, [language]);
 
   const getAudioContext = useCallback(async () => {
@@ -198,6 +217,14 @@ function KokoroContent() {
           selectedValue={language}
           onValueChange={setLanguage}
         />
+        {Platform.OS === 'ios' && 'COREML_FP32' in models.textToSpeech.KOKORO[language] && (
+          <ModelPicker
+            label="Backend"
+            options={BACKEND_OPTIONS.map((b) => ({ ...b, disabled: isBusy }))}
+            selectedValue={backend}
+            onValueChange={setBackend}
+          />
+        )}
         <ModelPicker
           label="Voice"
           options={voiceNames.map((name) => ({ label: name, value: name, disabled: isBusy }))}

--- a/apps/speech/app/kokoro-text-to-speech/index.tsx
+++ b/apps/speech/app/kokoro-text-to-speech/index.tsx
@@ -28,7 +28,7 @@ const LANGUAGE_OPTIONS = [
 
 type KokoroLanguage = (typeof LANGUAGE_OPTIONS)[number]['value'];
 
-// Core ML is exported for the standard weights only, and only runs on iOS.
+// Every language ships both backends; Core ML runs on iOS only.
 const BACKEND_OPTIONS = [
   { label: 'XNNPACK', value: 'XNNPACK_FP32' as const },
   { label: 'Core ML', value: 'COREML_FP32' as const },
@@ -36,11 +36,8 @@ const BACKEND_OPTIONS = [
 
 type KokoroBackend = (typeof BACKEND_OPTIONS)[number]['value'];
 
-const kokoroModel = (language: KokoroLanguage, backend: KokoroBackend) => {
-  const entry = models.textToSpeech.KOKORO[language];
-  const model = backend in entry ? entry[backend as keyof typeof entry] : entry.XNNPACK_FP32;
-  return model as KokoroTtsModel<string>;
-};
+const kokoroModel = (language: KokoroLanguage, backend: KokoroBackend) =>
+  models.textToSpeech.KOKORO[language][backend] as KokoroTtsModel<string>;
 
 // cspell:disable
 const SAMPLE_TEXTS: Record<KokoroLanguage, string> = {
@@ -93,9 +90,6 @@ function KokoroContent() {
   useEffect(() => {
     setVoice(Object.keys(models.textToSpeech.KOKORO[language].XNNPACK_FP32.voices)[0]!);
     setText(SAMPLE_TEXTS[language]);
-    if (!('COREML_FP32' in models.textToSpeech.KOKORO[language])) {
-      setBackend('XNNPACK_FP32');
-    }
   }, [language]);
 
   const getAudioContext = useCallback(async () => {
@@ -217,7 +211,7 @@ function KokoroContent() {
           selectedValue={language}
           onValueChange={setLanguage}
         />
-        {Platform.OS === 'ios' && 'COREML_FP32' in models.textToSpeech.KOKORO[language] && (
+        {Platform.OS === 'ios' && (
           <ModelPicker
             label="Backend"
             options={BACKEND_OPTIONS.map((b) => ({ ...b, disabled: isBusy }))}

--- a/packages/react-native-executorch/scripts/download-libs.js
+++ b/packages/react-native-executorch/scripts/download-libs.js
@@ -126,8 +126,8 @@ const FEATURE_MAP = {
   privacyFilter: { backends: ['xnnpack', 'mlx'], libs: [] },
   // Whisper ships xnnpack + coreml.
   speechToText: { backends: ['xnnpack', 'coreml'], libs: [] },
-  // Kokoro ships xnnpack only.
-  textToSpeech: { backends: ['xnnpack'], libs: ['phonemis'] },
+  // Kokoro ships xnnpack + coreml.
+  textToSpeech: { backends: ['xnnpack', 'coreml'], libs: ['phonemis'] },
   // FSMN VAD — xnnpack only.
   vad: { backends: ['xnnpack'], libs: [] },
   // LFM2.5-Embedding ships an MLX iOS export alongside xnnpack.

--- a/packages/react-native-executorch/src/extensions/speech/tasks/kokoroTextToSpeech.ts
+++ b/packages/react-native-executorch/src/extensions/speech/tasks/kokoroTextToSpeech.ts
@@ -16,6 +16,7 @@ import {
   bool,
   DynamicDim as Dyn,
   constraint,
+  type SpecMatch,
 } from '../../../core/schema';
 import { wrapAsync } from '../../../core/runtime';
 import { createResourceScope } from '../../../core/lifetime';
@@ -51,6 +52,14 @@ const SILENCE_PADDING_MS = 50; // silence kept at both edges of a synthesized ch
 
 // Distinguishes spoken phonemes from punctuation and suprasegmental markers.
 const LETTER_PATTERN = /\p{L}/u;
+
+// Token counts a Kokoro sub-model accepts. A padded model takes one count and
+// one only, so its bounds collapse onto that single constant.
+const tokenBounds = (spec: SpecMatch<'dynamic' | 'padded'>) => {
+  if (spec.variant !== 'padded') return spec.dim('T', 'range');
+  const tokens = spec.dim('T', 'constant');
+  return { min: tokens, max: tokens };
+};
 
 /**
  * Model configuration required to instantiate the Kokoro Text-to-Speech pipeline.
@@ -237,7 +246,7 @@ export async function createKokoroTextToSpeech<K extends PropertyKey>(
         ],
         [f32(1, 1, Dyn('AUDIO_LEN'))], // audio
         [
-          constr.linear(
+          constraint.linear(
             { paramSide: 'output', tensorIdx: 0, dimIdx: 2 },
             { paramSide: 'input', tensorIdx: 2, dimIdx: 0 },
             TICKS_PER_DURATION
@@ -246,39 +255,23 @@ export async function createKokoroTextToSpeech<K extends PropertyKey>(
       ),
     });
 
-    if (predictorSpec.variant !== synthesizerSpec.variant) {
-      throw RnExecuTorchError(
-        'SCHEMA_MISMATCH',
-        `The duration predictor and the synthesizer declare different token axes ` +
-          `('${String(predictorSpec.variant)}' vs '${String(synthesizerSpec.variant)}').`
-      );
-    }
-
     const [durations] = synthesizerSpec.dims.range('D');
     const maxDurationTicks = durations.max;
 
-    let minTokens: number;
-    let maxTokens: number;
+    // Both sub-models see the same tokens, so only the counts they both accept
+    // are usable. A padded pair collapses this to its single fixed count.
+    const predictorTokens = tokenBounds(predictorSpec);
+    const synthesizerTokens = tokenBounds(synthesizerSpec);
+    const minTokens = Math.max(predictorTokens.min, synthesizerTokens.min);
+    const maxTokens = Math.min(predictorTokens.max, synthesizerTokens.max);
 
-    if (predictorSpec.variant === 'padded') {
-      // A padded model takes one token count and one only, so both bounds
-      // collapse onto it and every chunk is padded up to it.
-      const predictorTokens = predictorSpec.dim('T', 'constant');
-      const synthesizerTokens = synthesizerSpec.dim('T', 'constant');
-      if (predictorTokens !== synthesizerTokens) {
-        throw RnExecuTorchError(
-          'SCHEMA_MISMATCH',
-          `The duration predictor and the synthesizer are padded to different token ` +
-            `counts (${predictorTokens} and ${synthesizerTokens}).`
-        );
-      }
-      minTokens = predictorTokens;
-      maxTokens = predictorTokens;
-    } else {
-      const [predictorTokens] = predictorSpec.dims.range('T');
-      const [synthesizerTokens] = synthesizerSpec.dims.range('T');
-      minTokens = Math.max(predictorTokens.min, synthesizerTokens.min);
-      maxTokens = predictorTokens.max;
+    if (minTokens > maxTokens) {
+      throw RnExecuTorchError(
+        'SCHEMA_MISMATCH',
+        `The duration predictor and the synthesizer share no token count ` +
+          `(${predictorTokens.min}..${predictorTokens.max} and ` +
+          `${synthesizerTokens.min}..${synthesizerTokens.max}).`
+      );
     }
 
     const phonemizer = await wrapAsync(createPhonemizer, runtime)(config.phonemizer);

--- a/packages/react-native-executorch/src/extensions/speech/tasks/kokoroTextToSpeech.ts
+++ b/packages/react-native-executorch/src/extensions/speech/tasks/kokoroTextToSpeech.ts
@@ -164,7 +164,7 @@ export async function createKokoroTextToSpeech<K extends PropertyKey>(
     const synthesizer = scope.track(await load(config.modelPaths.synthesizer));
     const models = { durationPredictor, synthesizer };
     const predictorSpec = validateSpec(models.durationPredictor.schema, {
-      default: method(
+      dynamic: method(
         'forward',
         [
           i64(1, Dyn('T')), // tokens
@@ -185,10 +185,25 @@ export async function createKokoroTextToSpeech<K extends PropertyKey>(
           ),
         ]
       ),
+      // Core ML cannot express the token axis dynamically, so its export fixes
+      // it and every chunk is padded up to that length.
+      padded: method(
+        'forward',
+        [
+          i64(1, 'T'), // tokens
+          bool(1, 'T'), // textMask
+          f32(1, VOICE_REF_HALF_SIZE), // voiceRef
+          f32(1), // speed
+        ],
+        [
+          i64('T'), // predictedDurations
+          f32(1, 'T', DURATION_FEATURE_DIM), // durationFeatures
+        ]
+      ),
     });
 
     const synthesizerSpec = validateSpec(models.synthesizer.schema, {
-      default: method(
+      dynamic: method(
         'forward',
         [
           i64(1, Dyn('T')), // tokens
@@ -211,14 +226,60 @@ export async function createKokoroTextToSpeech<K extends PropertyKey>(
           ),
         ]
       ),
+      padded: method(
+        'forward',
+        [
+          i64(1, 'T'), // tokens
+          bool(1, 'T'), // textMask
+          i64(Dyn('D')), // indices
+          f32(1, 'T', DURATION_FEATURE_DIM), // durationFeatures
+          f32(1, VOICE_REF_SIZE), // voiceRef
+        ],
+        [f32(1, 1, Dyn('AUDIO_LEN'))], // audio
+        [
+          constr.linear(
+            { paramSide: 'output', tensorIdx: 0, dimIdx: 2 },
+            { paramSide: 'input', tensorIdx: 2, dimIdx: 0 },
+            TICKS_PER_DURATION
+          ),
+        ]
+      ),
     });
 
-    const [predictorTokens] = predictorSpec.dims.range('T');
-    const [synthesizerTokens, durations] = synthesizerSpec.dims.range('T', 'D');
+    if (predictorSpec.variant !== synthesizerSpec.variant) {
+      throw RnExecuTorchError(
+        'SCHEMA_MISMATCH',
+        `The duration predictor and the synthesizer declare different token axes ` +
+          `('${String(predictorSpec.variant)}' vs '${String(synthesizerSpec.variant)}').`
+      );
+    }
 
-    const minTokens = Math.max(predictorTokens.min, synthesizerTokens.min);
-    const maxTokens = predictorTokens.max;
+    const [durations] = synthesizerSpec.dims.range('D');
     const maxDurationTicks = durations.max;
+
+    let minTokens: number;
+    let maxTokens: number;
+
+    if (predictorSpec.variant === 'padded') {
+      // A padded model takes one token count and one only, so both bounds
+      // collapse onto it and every chunk is padded up to it.
+      const predictorTokens = predictorSpec.dim('T', 'constant');
+      const synthesizerTokens = synthesizerSpec.dim('T', 'constant');
+      if (predictorTokens !== synthesizerTokens) {
+        throw RnExecuTorchError(
+          'SCHEMA_MISMATCH',
+          `The duration predictor and the synthesizer are padded to different token ` +
+            `counts (${predictorTokens} and ${synthesizerTokens}).`
+        );
+      }
+      minTokens = predictorTokens;
+      maxTokens = predictorTokens;
+    } else {
+      const [predictorTokens] = predictorSpec.dims.range('T');
+      const [synthesizerTokens] = synthesizerSpec.dims.range('T');
+      minTokens = Math.max(predictorTokens.min, synthesizerTokens.min);
+      maxTokens = predictorTokens.max;
+    }
 
     const phonemizer = await wrapAsync(createPhonemizer, runtime)(config.phonemizer);
     scope.track(phonemizer);

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -899,14 +899,6 @@ const kokoroModelPaths = (
   synthesizer: `${KOKORO_ROOT}/${backend}/${dir}/synthesizer_${variant}_${backend}_fp32.pte`,
 });
 
-const KOKORO_STANDARD_PATHS = kokoroModelPaths('xnnpack', 'std', 'standard');
-const KOKORO_POLISH_PATHS = kokoroModelPaths('xnnpack', 'pl', 'polish');
-const KOKORO_GERMAN_PATHS = kokoroModelPaths('xnnpack', 'de', 'german');
-
-const KOKORO_STANDARD_COREML_PATHS = kokoroModelPaths('coreml', 'std', 'standard');
-const KOKORO_POLISH_COREML_PATHS = kokoroModelPaths('coreml', 'pl', 'polish');
-const KOKORO_GERMAN_COREML_PATHS = kokoroModelPaths('coreml', 'de', 'german');
-
 const kokoroVoices = <const N extends string>(names: readonly N[]) =>
   names.reduce(
     (acc, name) => ({ ...acc, [name]: `${KOKORO_ROOT}/voices/${name}.bin` }),
@@ -933,56 +925,56 @@ const KOKORO_EN_US_XNNPACK_FP32: KokoroTtsModel<
   'af_heart' | 'af_river' | 'af_sarah' | 'am_adam' | 'am_michael' | 'am_santa'
 > = {
   name: 'kokoro',
-  modelPaths: KOKORO_STANDARD_PATHS,
+  modelPaths: kokoroModelPaths('xnnpack', 'std', 'standard'),
   phonemizer: kokoroEnglishPhonemizer('en-us'),
   voices: kokoroVoices(['af_heart', 'af_river', 'af_sarah', 'am_adam', 'am_michael', 'am_santa']),
 };
 const KOKORO_EN_GB_XNNPACK_FP32: KokoroTtsModel<'bf_emma' | 'bm_daniel'> = {
   name: 'kokoro',
-  modelPaths: KOKORO_STANDARD_PATHS,
+  modelPaths: kokoroModelPaths('xnnpack', 'std', 'standard'),
   phonemizer: kokoroEnglishPhonemizer('en-gb'),
   voices: kokoroVoices(['bf_emma', 'bm_daniel']),
 };
 const KOKORO_ES_XNNPACK_FP32: KokoroTtsModel<'ef_dora' | 'em_alex'> = {
   name: 'kokoro',
-  modelPaths: KOKORO_STANDARD_PATHS,
+  modelPaths: kokoroModelPaths('xnnpack', 'std', 'standard'),
   phonemizer: kokoroNeuralPhonemizer('es'),
   voices: kokoroVoices(['ef_dora', 'em_alex']),
 };
 const KOKORO_FR_XNNPACK_FP32: KokoroTtsModel<'ff_siwis'> = {
   name: 'kokoro',
-  modelPaths: KOKORO_STANDARD_PATHS,
+  modelPaths: kokoroModelPaths('xnnpack', 'std', 'standard'),
   phonemizer: kokoroNeuralPhonemizer('fr'),
   voices: kokoroVoices(['ff_siwis']),
 };
 const KOKORO_IT_XNNPACK_FP32: KokoroTtsModel<'if_sara' | 'im_nicola'> = {
   name: 'kokoro',
-  modelPaths: KOKORO_STANDARD_PATHS,
+  modelPaths: kokoroModelPaths('xnnpack', 'std', 'standard'),
   phonemizer: kokoroNeuralPhonemizer('it'),
   voices: kokoroVoices(['if_sara', 'im_nicola']),
 };
 const KOKORO_PT_XNNPACK_FP32: KokoroTtsModel<'pf_dora' | 'pm_santa'> = {
   name: 'kokoro',
-  modelPaths: KOKORO_STANDARD_PATHS,
+  modelPaths: kokoroModelPaths('xnnpack', 'std', 'standard'),
   phonemizer: kokoroNeuralPhonemizer('pt'),
   voices: kokoroVoices(['pf_dora', 'pm_santa']),
 };
 const KOKORO_HI_XNNPACK_FP32: KokoroTtsModel<'hf_alpha' | 'hm_omega' | 'hm_psi'> = {
   name: 'kokoro',
-  modelPaths: KOKORO_STANDARD_PATHS,
+  modelPaths: kokoroModelPaths('xnnpack', 'std', 'standard'),
   phonemizer: kokoroNeuralPhonemizer('hi'),
   voices: kokoroVoices(['hf_alpha', 'hm_omega', 'hm_psi']),
 };
 
 const KOKORO_PL_XNNPACK_FP32: KokoroTtsModel<'pm_mateusz'> = {
   name: 'kokoro',
-  modelPaths: KOKORO_POLISH_PATHS,
+  modelPaths: kokoroModelPaths('xnnpack', 'pl', 'polish'),
   phonemizer: kokoroNeuralPhonemizer('pl'),
   voices: kokoroVoices(['pm_mateusz']),
 };
 const KOKORO_DE_XNNPACK_FP32: KokoroTtsModel<'df_anna'> = {
   name: 'kokoro',
-  modelPaths: KOKORO_GERMAN_PATHS,
+  modelPaths: kokoroModelPaths('xnnpack', 'de', 'german'),
   phonemizer: kokoroNeuralPhonemizer('de'),
   voices: kokoroVoices(['df_anna']),
 };
@@ -990,26 +982,63 @@ const KOKORO_DE_XNNPACK_FP32: KokoroTtsModel<'df_anna'> = {
 // Core ML counterparts: the same weights, phonemizer and voices as the XNNPACK
 // presets, only the `.pte` files differ. Their token axis is fixed at 128, so
 // the pipeline pads every chunk up to it. iOS only.
-const kokoroCoreML = <K extends PropertyKey>(
-  base: KokoroTtsModel<K>,
-  modelPaths: KokoroTtsModel<K>['modelPaths']
-): KokoroTtsModel<K> => ({ ...base, modelPaths });
+const KOKORO_EN_US_COREML_FP32: KokoroTtsModel<
+  'af_heart' | 'af_river' | 'af_sarah' | 'am_adam' | 'am_michael' | 'am_santa'
+> = {
+  name: 'kokoro',
+  modelPaths: kokoroModelPaths('coreml', 'std', 'standard'),
+  phonemizer: kokoroEnglishPhonemizer('en-us'),
+  voices: kokoroVoices(['af_heart', 'af_river', 'af_sarah', 'am_adam', 'am_michael', 'am_santa']),
+};
+const KOKORO_EN_GB_COREML_FP32: KokoroTtsModel<'bf_emma' | 'bm_daniel'> = {
+  name: 'kokoro',
+  modelPaths: kokoroModelPaths('coreml', 'std', 'standard'),
+  phonemizer: kokoroEnglishPhonemizer('en-gb'),
+  voices: kokoroVoices(['bf_emma', 'bm_daniel']),
+};
+const KOKORO_ES_COREML_FP32: KokoroTtsModel<'ef_dora' | 'em_alex'> = {
+  name: 'kokoro',
+  modelPaths: kokoroModelPaths('coreml', 'std', 'standard'),
+  phonemizer: kokoroNeuralPhonemizer('es'),
+  voices: kokoroVoices(['ef_dora', 'em_alex']),
+};
+const KOKORO_FR_COREML_FP32: KokoroTtsModel<'ff_siwis'> = {
+  name: 'kokoro',
+  modelPaths: kokoroModelPaths('coreml', 'std', 'standard'),
+  phonemizer: kokoroNeuralPhonemizer('fr'),
+  voices: kokoroVoices(['ff_siwis']),
+};
+const KOKORO_IT_COREML_FP32: KokoroTtsModel<'if_sara' | 'im_nicola'> = {
+  name: 'kokoro',
+  modelPaths: kokoroModelPaths('coreml', 'std', 'standard'),
+  phonemizer: kokoroNeuralPhonemizer('it'),
+  voices: kokoroVoices(['if_sara', 'im_nicola']),
+};
+const KOKORO_PT_COREML_FP32: KokoroTtsModel<'pf_dora' | 'pm_santa'> = {
+  name: 'kokoro',
+  modelPaths: kokoroModelPaths('coreml', 'std', 'standard'),
+  phonemizer: kokoroNeuralPhonemizer('pt'),
+  voices: kokoroVoices(['pf_dora', 'pm_santa']),
+};
+const KOKORO_HI_COREML_FP32: KokoroTtsModel<'hf_alpha' | 'hm_omega' | 'hm_psi'> = {
+  name: 'kokoro',
+  modelPaths: kokoroModelPaths('coreml', 'std', 'standard'),
+  phonemizer: kokoroNeuralPhonemizer('hi'),
+  voices: kokoroVoices(['hf_alpha', 'hm_omega', 'hm_psi']),
+};
 
-const KOKORO_EN_US_COREML_FP32 = kokoroCoreML(
-  KOKORO_EN_US_XNNPACK_FP32,
-  KOKORO_STANDARD_COREML_PATHS
-);
-const KOKORO_EN_GB_COREML_FP32 = kokoroCoreML(
-  KOKORO_EN_GB_XNNPACK_FP32,
-  KOKORO_STANDARD_COREML_PATHS
-);
-const KOKORO_ES_COREML_FP32 = kokoroCoreML(KOKORO_ES_XNNPACK_FP32, KOKORO_STANDARD_COREML_PATHS);
-const KOKORO_FR_COREML_FP32 = kokoroCoreML(KOKORO_FR_XNNPACK_FP32, KOKORO_STANDARD_COREML_PATHS);
-const KOKORO_IT_COREML_FP32 = kokoroCoreML(KOKORO_IT_XNNPACK_FP32, KOKORO_STANDARD_COREML_PATHS);
-const KOKORO_PT_COREML_FP32 = kokoroCoreML(KOKORO_PT_XNNPACK_FP32, KOKORO_STANDARD_COREML_PATHS);
-const KOKORO_HI_COREML_FP32 = kokoroCoreML(KOKORO_HI_XNNPACK_FP32, KOKORO_STANDARD_COREML_PATHS);
-const KOKORO_PL_COREML_FP32 = kokoroCoreML(KOKORO_PL_XNNPACK_FP32, KOKORO_POLISH_COREML_PATHS);
-const KOKORO_DE_COREML_FP32 = kokoroCoreML(KOKORO_DE_XNNPACK_FP32, KOKORO_GERMAN_COREML_PATHS);
+const KOKORO_PL_COREML_FP32: KokoroTtsModel<'pm_mateusz'> = {
+  name: 'kokoro',
+  modelPaths: kokoroModelPaths('coreml', 'pl', 'polish'),
+  phonemizer: kokoroNeuralPhonemizer('pl'),
+  voices: kokoroVoices(['pm_mateusz']),
+};
+const KOKORO_DE_COREML_FP32: KokoroTtsModel<'df_anna'> = {
+  name: 'kokoro',
+  modelPaths: kokoroModelPaths('coreml', 'de', 'german'),
+  phonemizer: kokoroNeuralPhonemizer('de'),
+  voices: kokoroVoices(['df_anna']),
+};
 
 // =============================================================================
 // Privacy Filter

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -905,6 +905,8 @@ const KOKORO_GERMAN_PATHS = kokoroModelPaths('xnnpack', 'de', 'german');
 
 // Core ML is exported for the standard (multi-language) weights only.
 const KOKORO_STANDARD_COREML_PATHS = kokoroModelPaths('coreml', 'std', 'standard');
+const KOKORO_POLISH_COREML_PATHS = kokoroModelPaths('coreml', 'pl', 'polish');
+const KOKORO_GERMAN_COREML_PATHS = kokoroModelPaths('coreml', 'de', 'german');
 
 const kokoroVoices = <const N extends string>(names: readonly N[]) =>
   names.reduce(
@@ -1032,6 +1034,15 @@ const KOKORO_DE_XNNPACK_FP32: KokoroTtsModel<'df_anna'> = {
   modelPaths: KOKORO_GERMAN_PATHS,
   phonemizer: kokoroNeuralPhonemizer('de'),
   voices: kokoroVoices(['df_anna']),
+};
+
+const KOKORO_PL_COREML_FP32: KokoroTtsModel<'pm_mateusz'> = {
+  ...KOKORO_PL_XNNPACK_FP32,
+  modelPaths: KOKORO_POLISH_COREML_PATHS,
+};
+const KOKORO_DE_COREML_FP32: KokoroTtsModel<'df_anna'> = {
+  ...KOKORO_DE_XNNPACK_FP32,
+  modelPaths: KOKORO_GERMAN_COREML_PATHS,
 };
 
 // =============================================================================
@@ -2402,10 +2413,12 @@ export const models = {
       PL: {
         DEFAULT: KOKORO_PL_XNNPACK_FP32,
         XNNPACK_FP32: KOKORO_PL_XNNPACK_FP32,
+        COREML_FP32: KOKORO_PL_COREML_FP32,
       },
       DE: {
         DEFAULT: KOKORO_DE_XNNPACK_FP32,
         XNNPACK_FP32: KOKORO_DE_XNNPACK_FP32,
+        COREML_FP32: KOKORO_DE_COREML_FP32,
       },
     },
   },

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -890,14 +890,21 @@ const SUPERTONIC_3_MLX_FP32: SupertonicTtsModel<SupertonicDefaultVoiceName> = {
 const KOKORO_ROOT = `${BASE_URL}-kokoro/${NEXT_VERSION_TAG}`;
 const KOKORO_PHONEMIZER_ROOT = `${KOKORO_ROOT}/phonemizer`;
 
-const kokoroModelPaths = (variant: 'std' | 'pl' | 'de', dir: string) => ({
-  durationPredictor: `${KOKORO_ROOT}/xnnpack/${dir}/duration_predictor_${variant}_xnnpack_fp32.pte`,
-  synthesizer: `${KOKORO_ROOT}/xnnpack/${dir}/synthesizer_${variant}_xnnpack_fp32.pte`,
+const kokoroModelPaths = (
+  backend: 'xnnpack' | 'coreml',
+  variant: 'std' | 'pl' | 'de',
+  dir: string
+) => ({
+  durationPredictor: `${KOKORO_ROOT}/${backend}/${dir}/duration_predictor_${variant}_${backend}_fp32.pte`,
+  synthesizer: `${KOKORO_ROOT}/${backend}/${dir}/synthesizer_${variant}_${backend}_fp32.pte`,
 });
 
-const KOKORO_STANDARD_PATHS = kokoroModelPaths('std', 'standard');
-const KOKORO_POLISH_PATHS = kokoroModelPaths('pl', 'polish');
-const KOKORO_GERMAN_PATHS = kokoroModelPaths('de', 'german');
+const KOKORO_STANDARD_PATHS = kokoroModelPaths('xnnpack', 'std', 'standard');
+const KOKORO_POLISH_PATHS = kokoroModelPaths('xnnpack', 'pl', 'polish');
+const KOKORO_GERMAN_PATHS = kokoroModelPaths('xnnpack', 'de', 'german');
+
+// Core ML is exported for the standard (multi-language) weights only.
+const KOKORO_STANDARD_COREML_PATHS = kokoroModelPaths('coreml', 'std', 'standard');
 
 const kokoroVoices = <const N extends string>(names: readonly N[]) =>
   names.reduce(
@@ -965,6 +972,55 @@ const KOKORO_HI_XNNPACK_FP32: KokoroTtsModel<'hf_alpha' | 'hm_omega' | 'hm_psi'>
   phonemizer: kokoroNeuralPhonemizer('hi'),
   voices: kokoroVoices(['hf_alpha', 'hm_omega', 'hm_psi']),
 };
+
+// Core ML counterparts of the standard-weight presets. They pad the token axis
+// to the models' fixed length, so only the languages served by the standard
+// weights have a Core ML variant.
+const KOKORO_EN_US_COREML_FP32: KokoroTtsModel<
+  'af_heart' | 'af_river' | 'af_sarah' | 'am_adam' | 'am_michael' | 'am_santa'
+> = {
+  name: 'kokoro',
+  modelPaths: KOKORO_STANDARD_COREML_PATHS,
+  phonemizer: kokoroEnglishPhonemizer('en-us'),
+  voices: kokoroVoices(['af_heart', 'af_river', 'af_sarah', 'am_adam', 'am_michael', 'am_santa']),
+};
+const KOKORO_EN_GB_COREML_FP32: KokoroTtsModel<'bf_emma' | 'bm_daniel'> = {
+  name: 'kokoro',
+  modelPaths: KOKORO_STANDARD_COREML_PATHS,
+  phonemizer: kokoroEnglishPhonemizer('en-gb'),
+  voices: kokoroVoices(['bf_emma', 'bm_daniel']),
+};
+const KOKORO_ES_COREML_FP32: KokoroTtsModel<'ef_dora' | 'em_alex'> = {
+  name: 'kokoro',
+  modelPaths: KOKORO_STANDARD_COREML_PATHS,
+  phonemizer: kokoroNeuralPhonemizer('es'),
+  voices: kokoroVoices(['ef_dora', 'em_alex']),
+};
+const KOKORO_FR_COREML_FP32: KokoroTtsModel<'ff_siwis'> = {
+  name: 'kokoro',
+  modelPaths: KOKORO_STANDARD_COREML_PATHS,
+  phonemizer: kokoroNeuralPhonemizer('fr'),
+  voices: kokoroVoices(['ff_siwis']),
+};
+const KOKORO_IT_COREML_FP32: KokoroTtsModel<'if_sara' | 'im_nicola'> = {
+  name: 'kokoro',
+  modelPaths: KOKORO_STANDARD_COREML_PATHS,
+  phonemizer: kokoroNeuralPhonemizer('it'),
+  voices: kokoroVoices(['if_sara', 'im_nicola']),
+};
+const KOKORO_PT_COREML_FP32: KokoroTtsModel<'pf_dora' | 'pm_santa'> = {
+  name: 'kokoro',
+  modelPaths: KOKORO_STANDARD_COREML_PATHS,
+  phonemizer: kokoroNeuralPhonemizer('pt'),
+  voices: kokoroVoices(['pf_dora', 'pm_santa']),
+};
+const KOKORO_HI_COREML_FP32: KokoroTtsModel<'hf_alpha' | 'hm_omega' | 'hm_psi'> = {
+  name: 'kokoro',
+  modelPaths: KOKORO_STANDARD_COREML_PATHS,
+  phonemizer: kokoroNeuralPhonemizer('hi'),
+  voices: kokoroVoices(['hf_alpha', 'hm_omega', 'hm_psi']),
+};
+
 const KOKORO_PL_XNNPACK_FP32: KokoroTtsModel<'pm_mateusz'> = {
   name: 'kokoro',
   modelPaths: KOKORO_POLISH_PATHS,
@@ -2311,30 +2367,37 @@ export const models = {
       EN_US: {
         DEFAULT: KOKORO_EN_US_XNNPACK_FP32,
         XNNPACK_FP32: KOKORO_EN_US_XNNPACK_FP32,
+        COREML_FP32: KOKORO_EN_US_COREML_FP32,
       },
       EN_GB: {
         DEFAULT: KOKORO_EN_GB_XNNPACK_FP32,
         XNNPACK_FP32: KOKORO_EN_GB_XNNPACK_FP32,
+        COREML_FP32: KOKORO_EN_GB_COREML_FP32,
       },
       ES: {
         DEFAULT: KOKORO_ES_XNNPACK_FP32,
         XNNPACK_FP32: KOKORO_ES_XNNPACK_FP32,
+        COREML_FP32: KOKORO_ES_COREML_FP32,
       },
       FR: {
         DEFAULT: KOKORO_FR_XNNPACK_FP32,
         XNNPACK_FP32: KOKORO_FR_XNNPACK_FP32,
+        COREML_FP32: KOKORO_FR_COREML_FP32,
       },
       IT: {
         DEFAULT: KOKORO_IT_XNNPACK_FP32,
         XNNPACK_FP32: KOKORO_IT_XNNPACK_FP32,
+        COREML_FP32: KOKORO_IT_COREML_FP32,
       },
       PT: {
         DEFAULT: KOKORO_PT_XNNPACK_FP32,
         XNNPACK_FP32: KOKORO_PT_XNNPACK_FP32,
+        COREML_FP32: KOKORO_PT_COREML_FP32,
       },
       HI: {
         DEFAULT: KOKORO_HI_XNNPACK_FP32,
         XNNPACK_FP32: KOKORO_HI_XNNPACK_FP32,
+        COREML_FP32: KOKORO_HI_COREML_FP32,
       },
       PL: {
         DEFAULT: KOKORO_PL_XNNPACK_FP32,

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -903,7 +903,6 @@ const KOKORO_STANDARD_PATHS = kokoroModelPaths('xnnpack', 'std', 'standard');
 const KOKORO_POLISH_PATHS = kokoroModelPaths('xnnpack', 'pl', 'polish');
 const KOKORO_GERMAN_PATHS = kokoroModelPaths('xnnpack', 'de', 'german');
 
-// Core ML is exported for the standard (multi-language) weights only.
 const KOKORO_STANDARD_COREML_PATHS = kokoroModelPaths('coreml', 'std', 'standard');
 const KOKORO_POLISH_COREML_PATHS = kokoroModelPaths('coreml', 'pl', 'polish');
 const KOKORO_GERMAN_COREML_PATHS = kokoroModelPaths('coreml', 'de', 'german');
@@ -975,54 +974,6 @@ const KOKORO_HI_XNNPACK_FP32: KokoroTtsModel<'hf_alpha' | 'hm_omega' | 'hm_psi'>
   voices: kokoroVoices(['hf_alpha', 'hm_omega', 'hm_psi']),
 };
 
-// Core ML counterparts of the standard-weight presets. They pad the token axis
-// to the models' fixed length, so only the languages served by the standard
-// weights have a Core ML variant.
-const KOKORO_EN_US_COREML_FP32: KokoroTtsModel<
-  'af_heart' | 'af_river' | 'af_sarah' | 'am_adam' | 'am_michael' | 'am_santa'
-> = {
-  name: 'kokoro',
-  modelPaths: KOKORO_STANDARD_COREML_PATHS,
-  phonemizer: kokoroEnglishPhonemizer('en-us'),
-  voices: kokoroVoices(['af_heart', 'af_river', 'af_sarah', 'am_adam', 'am_michael', 'am_santa']),
-};
-const KOKORO_EN_GB_COREML_FP32: KokoroTtsModel<'bf_emma' | 'bm_daniel'> = {
-  name: 'kokoro',
-  modelPaths: KOKORO_STANDARD_COREML_PATHS,
-  phonemizer: kokoroEnglishPhonemizer('en-gb'),
-  voices: kokoroVoices(['bf_emma', 'bm_daniel']),
-};
-const KOKORO_ES_COREML_FP32: KokoroTtsModel<'ef_dora' | 'em_alex'> = {
-  name: 'kokoro',
-  modelPaths: KOKORO_STANDARD_COREML_PATHS,
-  phonemizer: kokoroNeuralPhonemizer('es'),
-  voices: kokoroVoices(['ef_dora', 'em_alex']),
-};
-const KOKORO_FR_COREML_FP32: KokoroTtsModel<'ff_siwis'> = {
-  name: 'kokoro',
-  modelPaths: KOKORO_STANDARD_COREML_PATHS,
-  phonemizer: kokoroNeuralPhonemizer('fr'),
-  voices: kokoroVoices(['ff_siwis']),
-};
-const KOKORO_IT_COREML_FP32: KokoroTtsModel<'if_sara' | 'im_nicola'> = {
-  name: 'kokoro',
-  modelPaths: KOKORO_STANDARD_COREML_PATHS,
-  phonemizer: kokoroNeuralPhonemizer('it'),
-  voices: kokoroVoices(['if_sara', 'im_nicola']),
-};
-const KOKORO_PT_COREML_FP32: KokoroTtsModel<'pf_dora' | 'pm_santa'> = {
-  name: 'kokoro',
-  modelPaths: KOKORO_STANDARD_COREML_PATHS,
-  phonemizer: kokoroNeuralPhonemizer('pt'),
-  voices: kokoroVoices(['pf_dora', 'pm_santa']),
-};
-const KOKORO_HI_COREML_FP32: KokoroTtsModel<'hf_alpha' | 'hm_omega' | 'hm_psi'> = {
-  name: 'kokoro',
-  modelPaths: KOKORO_STANDARD_COREML_PATHS,
-  phonemizer: kokoroNeuralPhonemizer('hi'),
-  voices: kokoroVoices(['hf_alpha', 'hm_omega', 'hm_psi']),
-};
-
 const KOKORO_PL_XNNPACK_FP32: KokoroTtsModel<'pm_mateusz'> = {
   name: 'kokoro',
   modelPaths: KOKORO_POLISH_PATHS,
@@ -1036,14 +987,29 @@ const KOKORO_DE_XNNPACK_FP32: KokoroTtsModel<'df_anna'> = {
   voices: kokoroVoices(['df_anna']),
 };
 
-const KOKORO_PL_COREML_FP32: KokoroTtsModel<'pm_mateusz'> = {
-  ...KOKORO_PL_XNNPACK_FP32,
-  modelPaths: KOKORO_POLISH_COREML_PATHS,
-};
-const KOKORO_DE_COREML_FP32: KokoroTtsModel<'df_anna'> = {
-  ...KOKORO_DE_XNNPACK_FP32,
-  modelPaths: KOKORO_GERMAN_COREML_PATHS,
-};
+// Core ML counterparts: the same weights, phonemizer and voices as the XNNPACK
+// presets, only the `.pte` files differ. Their token axis is fixed at 128, so
+// the pipeline pads every chunk up to it. iOS only.
+const kokoroCoreML = <K extends PropertyKey>(
+  base: KokoroTtsModel<K>,
+  modelPaths: KokoroTtsModel<K>['modelPaths']
+): KokoroTtsModel<K> => ({ ...base, modelPaths });
+
+const KOKORO_EN_US_COREML_FP32 = kokoroCoreML(
+  KOKORO_EN_US_XNNPACK_FP32,
+  KOKORO_STANDARD_COREML_PATHS
+);
+const KOKORO_EN_GB_COREML_FP32 = kokoroCoreML(
+  KOKORO_EN_GB_XNNPACK_FP32,
+  KOKORO_STANDARD_COREML_PATHS
+);
+const KOKORO_ES_COREML_FP32 = kokoroCoreML(KOKORO_ES_XNNPACK_FP32, KOKORO_STANDARD_COREML_PATHS);
+const KOKORO_FR_COREML_FP32 = kokoroCoreML(KOKORO_FR_XNNPACK_FP32, KOKORO_STANDARD_COREML_PATHS);
+const KOKORO_IT_COREML_FP32 = kokoroCoreML(KOKORO_IT_XNNPACK_FP32, KOKORO_STANDARD_COREML_PATHS);
+const KOKORO_PT_COREML_FP32 = kokoroCoreML(KOKORO_PT_XNNPACK_FP32, KOKORO_STANDARD_COREML_PATHS);
+const KOKORO_HI_COREML_FP32 = kokoroCoreML(KOKORO_HI_XNNPACK_FP32, KOKORO_STANDARD_COREML_PATHS);
+const KOKORO_PL_COREML_FP32 = kokoroCoreML(KOKORO_PL_XNNPACK_FP32, KOKORO_POLISH_COREML_PATHS);
+const KOKORO_DE_COREML_FP32 = kokoroCoreML(KOKORO_DE_XNNPACK_FP32, KOKORO_GERMAN_COREML_PATHS);
 
 // =============================================================================
 // Privacy Filter


### PR DESCRIPTION
## Description

Adds a Core ML variant of Kokoro for iOS. Core ML cannot express the token axis dynamically, so its models fix it at 128 and every chunk is padded up to it; the frame axis stays dynamic (16..296), so durations and audio length are unchanged and no tempo scaling is involved.

On an iPhone 16 the static-shape synthesizer measured 627 ms on Core ML against 4741 ms on XNNPACK (warm); fp32 and CPU_ONLY: fp16 lands at 0.973 spectral correlation against eager versus 0.9993, and `ComputeUnit.ALL` gave a 25 minute compile plus an execute failure.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

Run `apps/speech`, open the Kokoro screen, pick Core ML in the Backend picker (iOS only, shown for the languages served by the standard weights) and synthesize. Compare against XNNPACK on the same text and voice.

### Screenshots

### Related issues

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

