### PR TITLE
[RNE Rewrite] feat(models): point LLM constants at the re-published artifacts

### DIFF
--- a/apps/nlp/constants/llm.ts
+++ b/apps/nlp/constants/llm.ts
@@ -488,8 +488,8 @@ export const LLM_MODELS: LLMModelConfig[] = [
   // SmolLM2 family
   {
     id: 'smollm2-135m-xnnpack',
-    name: 'SmolLM2 135M (8da4w)',
-    model: models.llm.SMOLLM2_135M.XNNPACK_8DA4W,
+    name: 'SmolLM2 135M (8da8w)',
+    model: models.llm.SMOLLM2_135M.XNNPACK_8DA8W,
     generationConfig: DEFAULT_GENERATION_CONFIG,
     systemPrompt: DEFAULT_SYSTEM_PROMPT,
     stopRegex: undefined,
@@ -497,8 +497,8 @@ export const LLM_MODELS: LLMModelConfig[] = [
   },
   {
     id: 'smollm2-360m-xnnpack',
-    name: 'SmolLM2 360M (8da4w)',
-    model: models.llm.SMOLLM2_360M.XNNPACK_8DA4W,
+    name: 'SmolLM2 360M (8da8w)',
+    model: models.llm.SMOLLM2_360M.XNNPACK_8DA8W,
     generationConfig: DEFAULT_GENERATION_CONFIG,
     systemPrompt: DEFAULT_SYSTEM_PROMPT,
     stopRegex: undefined,
@@ -506,8 +506,8 @@ export const LLM_MODELS: LLMModelConfig[] = [
   },
   {
     id: 'smollm2-1.7b-xnnpack',
-    name: 'SmolLM2 1.7B (8da4w)',
-    model: models.llm.SMOLLM2_1_7B.XNNPACK_8DA4W,
+    name: 'SmolLM2 1.7B (8da8w)',
+    model: models.llm.SMOLLM2_1_7B.XNNPACK_8DA8W,
     generationConfig: DEFAULT_GENERATION_CONFIG,
     systemPrompt: DEFAULT_SYSTEM_PROMPT,
     stopRegex: undefined,

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -1171,33 +1171,18 @@ const LLAMA3_2_1B_BF16: LLMModel = {
 
 const SMOLLM2_BASE_URL = `${BASE_URL}-smolLm-2/${NEXT_VERSION_TAG}`;
 
-const SMOLLM2_135M_8DA4W: LLMModel = {
-  modelPath: `${SMOLLM2_BASE_URL}/135m/xnnpack/smollm2_135m_xnnpack_8da4w.pte`,
+const SMOLLM2_135M_8DA8W: LLMModel = {
+  modelPath: `${SMOLLM2_BASE_URL}/135m/xnnpack/smollm2_135m_xnnpack_8da8w.pte`,
   tokenizerPath: `${SMOLLM2_BASE_URL}/tokenizer.json`,
   tokenizerConfigPath: `${SMOLLM2_BASE_URL}/tokenizer_config.json`,
 };
-const SMOLLM2_135M_BF16: LLMModel = {
-  modelPath: `${SMOLLM2_BASE_URL}/135m/xnnpack/smollm2_135m_xnnpack_bf16.pte`,
+const SMOLLM2_360M_8DA8W: LLMModel = {
+  modelPath: `${SMOLLM2_BASE_URL}/360m/xnnpack/smollm2_360m_xnnpack_8da8w.pte`,
   tokenizerPath: `${SMOLLM2_BASE_URL}/tokenizer.json`,
   tokenizerConfigPath: `${SMOLLM2_BASE_URL}/tokenizer_config.json`,
 };
-const SMOLLM2_360M_8DA4W: LLMModel = {
-  modelPath: `${SMOLLM2_BASE_URL}/360m/xnnpack/smollm2_360m_xnnpack_8da4w.pte`,
-  tokenizerPath: `${SMOLLM2_BASE_URL}/tokenizer.json`,
-  tokenizerConfigPath: `${SMOLLM2_BASE_URL}/tokenizer_config.json`,
-};
-const SMOLLM2_360M_BF16: LLMModel = {
-  modelPath: `${SMOLLM2_BASE_URL}/360m/xnnpack/smollm2_360m_xnnpack_bf16.pte`,
-  tokenizerPath: `${SMOLLM2_BASE_URL}/tokenizer.json`,
-  tokenizerConfigPath: `${SMOLLM2_BASE_URL}/tokenizer_config.json`,
-};
-const SMOLLM2_1_7B_8DA4W: LLMModel = {
-  modelPath: `${SMOLLM2_BASE_URL}/1_7b/xnnpack/smollm2_1_7b_xnnpack_8da4w.pte`,
-  tokenizerPath: `${SMOLLM2_BASE_URL}/tokenizer.json`,
-  tokenizerConfigPath: `${SMOLLM2_BASE_URL}/tokenizer_config.json`,
-};
-const SMOLLM2_1_7B_BF16: LLMModel = {
-  modelPath: `${SMOLLM2_BASE_URL}/1_7b/xnnpack/smollm2_1_7b_xnnpack_bf16.pte`,
+const SMOLLM2_1_7B_8DA8W: LLMModel = {
+  modelPath: `${SMOLLM2_BASE_URL}/1_7b/xnnpack/smollm2_1_7b_xnnpack_8da8w.pte`,
   tokenizerPath: `${SMOLLM2_BASE_URL}/tokenizer.json`,
   tokenizerConfigPath: `${SMOLLM2_BASE_URL}/tokenizer_config.json`,
 };
@@ -2022,9 +2007,8 @@ export const models = {
      * and background processing on low-power devices.
      */
     SMOLLM2_135M: {
-      DEFAULT: SMOLLM2_135M_8DA4W,
-      XNNPACK_8DA4W: SMOLLM2_135M_8DA4W,
-      XNNPACK_BF16: SMOLLM2_135M_BF16,
+      DEFAULT: SMOLLM2_135M_8DA8W,
+      XNNPACK_8DA8W: SMOLLM2_135M_8DA8W,
     },
     /**
      * Hugging Face SmolLM2 360M compact instruction-tuned model. Provides a
@@ -2033,9 +2017,8 @@ export const models = {
      * simplification, and structured data extraction.
      */
     SMOLLM2_360M: {
-      DEFAULT: SMOLLM2_360M_8DA4W,
-      XNNPACK_8DA4W: SMOLLM2_360M_8DA4W,
-      XNNPACK_BF16: SMOLLM2_360M_BF16,
+      DEFAULT: SMOLLM2_360M_8DA8W,
+      XNNPACK_8DA8W: SMOLLM2_360M_8DA8W,
     },
     /**
      * Hugging Face SmolLM2 1.7B language model trained on curated educational,
@@ -2044,9 +2027,8 @@ export const models = {
      * 2B-3B models while maintaining fast on-device inference.
      */
     SMOLLM2_1_7B: {
-      DEFAULT: SMOLLM2_1_7B_8DA4W,
-      XNNPACK_8DA4W: SMOLLM2_1_7B_8DA4W,
-      XNNPACK_BF16: SMOLLM2_1_7B_BF16,
+      DEFAULT: SMOLLM2_1_7B_8DA8W,
+      XNNPACK_8DA8W: SMOLLM2_1_7B_8DA8W,
     },
     /**
      * Hammer 2.1 0.5B specialized function-calling model. Fine-tuned


### PR DESCRIPTION
## Description

Points the LLM model constants at the re-published artifacts from export-scripts MR !16, which reconciles every LLM config against what is actually on the Hub and fixes the recipes that were wrong. All four families are re-exported and published.

| family | change | status |
|---|---|---|
| smollm2 (135m, 360m, 1_7b) | Ships one `8da8w` file per size; bf16 and `8da4w` are dropped because int8 is smaller, faster and answers better at every size. | landed |
| hammer2.1 (0_5b, 1_5b, 3b) | Re-export so all six files carry `get_eos_ids [151645, 151643]`; the bf16 builds currently emit `<\|im_end\|>` as visible text. | landed |
| qwen2.5 3b | Re-export so `8da4w` stops on `<\|im_end\|>` like every other qwen2.5 file, rather than `<\|endoftext\|>`. | landed |
| lfm2.5-text (350m, 1_2b) | Re-export at the group size the quantization sweep picked, which the published `8da4w` files predate. | landed |

Every LLM config also gains the corrected `get_n_layers` (it was `null` in all 15) and the real 2047 sequence dim, but those are config-side and need no constant change here.

### Introduces a breaking change?

- [x] Yes
- [ ] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

- [ ] Run the `nlp` demo app and generate with every model touched here (SmolLM2 135m/360m/1_7b, Hammer2.1 0_5b/1_5b/3b, Qwen2.5 3b, LFM2.5-text 350m/1_2b); check each loads, streams and stops cleanly
- [x] Review the smollm2 Hub PR: https://huggingface.co/software-mansion/react-native-executorch-smolLm-2/discussions/1
- [x] Review the hammer2.1 Hub PR: https://huggingface.co/software-mansion/react-native-executorch-hammer-2.1/discussions/1
- [x] Review the qwen2.5 3b Hub PR: https://huggingface.co/software-mansion/react-native-executorch-qwen-2.5/discussions/1
- [ ] Review the lfm2.5-text Hub PR: https://huggingface.co/software-mansion/react-native-executorch-lfm-2.5/discussions/1

### Related issues

Export side: export-scripts MR !16.

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

Do not merge until every family's artifacts are published: the new filenames do not exist at the version tag yet, so a premature merge 404s.




