### PR TITLE
[RNE Rewrite] fix(ios): keep the host C++ tests out of the pod

### DIFF
--- a/packages/react-native-executorch/react-native-executorch.podspec
+++ b/packages/react-native-executorch/react-native-executorch.podspec
@@ -68,7 +68,13 @@ Pod::Spec.new do |s|
   source_files += phonemis_source_files if enable_phonemis
   s.source_files = source_files
 
-  exclude_files = ["third-party/common/phonemis/src/phonemis/main.cpp"]
+  # cpp/tests holds the host GoogleTest suites, built by cpp/tests/CMakeLists.txt
+  # and never by the app: `cpp/**` above sweeps them in, and the pod carries no
+  # googletest headers, so an app build fails on <gmock/gmock.h>.
+  exclude_files = [
+    "third-party/common/phonemis/src/phonemis/main.cpp",
+    "cpp/tests/**/*",
+  ]
   exclude_files += opencv_source_files unless enable_opencv
   exclude_files += phonemis_source_files unless enable_phonemis
   s.exclude_files = exclude_files


### PR DESCRIPTION
## Description

The podspec collects `cpp/**/*.{cpp,c,h,hpp}`, which since #1347 also matches `cpp/tests/**`, the GoogleTest suites that `cpp/tests/CMakeLists.txt` builds on the host. The pod carries no googletest headers, so CocoaPods compiled them into the app target and every iOS example-app build failed with:

```
cpp/tests/core/UtilsTest.cpp:3:10: fatal error: 'gmock/gmock.h' file not found
```

Excluding them fixes the build. The host test target does not go through CocoaPods, so it is unaffected.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

1. `npx expo prebuild --platform ios` and build any example app on a device or simulator. On `rne-rewrite` it fails on the missing gmock header.
2. With this change, `pod install` then build: it succeeds, and `Pods/Pods.xcodeproj` lists the regular sources (`conversions.cpp`, `dtype.cpp`, `error.cpp`) with no `*Test.cpp` entries.
3. `cpp/tests` still builds on the host through its own CMake target.

### Screenshots

N/A

### Related issues

Regression from #1347.

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

Found while building apps/nlp on a device.
