### PR TITLE
[RNE Rewrite] fix(cv): report the peak NMS-group score as keypoint confidence

### DIFF
--- a/packages/react-native-executorch/__tests__/tasks/remainingTasks.test.ts
+++ b/packages/react-native-executorch/__tests__/tasks/remainingTasks.test.ts
@@ -21,7 +21,8 @@ import { createSdxsTextToImage } from '../../src/extensions/cv/tasks/sdxsTextToI
 import { createFsmnVoiceActivityDetector } from '../../src/extensions/speech/tasks/fsmnVoiceActivityDetection';
 import { createWhisperSpeechToText } from '../../src/extensions/speech/tasks/whisperSpeechToText';
 import { fakeJsi } from '../support/fakeJsi';
-import { STRETCH_PREPROCESSING, exported } from '../support/fixtures';
+import { tracked } from '../support/lifetime';
+import { STRETCH_PREPROCESSING, exported, imageBuffer, writesOutputs } from '../support/fixtures';
 
 const MODEL_PATH = '/models/task.pte';
 const TOKENIZER_PATH = '/models/tokenizer.json';
@@ -76,6 +77,64 @@ describe('createKeypointDetector', () => {
     });
 
     await expect(createKeypointDetector(config)).rejects.toThrow(/Rank mismatch/);
+  });
+
+  /**
+   * Weighted NMS merges a group of overlapping boxes into one detection. The
+   * box and the landmarks are score-weighted, so a near-zero member barely
+   * moves them; the reported confidence has to behave the same way, otherwise
+   * it silently rescales with the caller's confidence threshold — a lower
+   * threshold lets more weak boxes into the group and drags the mean down.
+   */
+  describe('merged detection confidence', () => {
+    const SIZE = 16;
+    // Two boxes with IoU 49/79 = 0.62, so they always merge into one group.
+    const BOXES = [0, 0, 8, 8, 1, 1, 9, 9];
+    const SCORES = [0.9, 0.01];
+    const KEYPOINTS = [1, 1, 0.9, 2, 2, 0.8, 3, 3, 0.7, 1, 1, 0.01, 2, 2, 0.01, 3, 3, 0.01];
+
+    const detectorConfig = {
+      modelPath: MODEL_PATH,
+      modelOpts: { ...config.modelOpts, defaultIouThreshold: 0.5 },
+    } as const;
+
+    beforeEach(() => {
+      fakeJsi.registerModel(MODEL_PATH, {
+        schema: exported(
+          method(
+            'forward',
+            [f32(1, 3, SIZE, SIZE)],
+            [f32(2, 4), f32(2), f32(2, LANDMARKS.length, 3)]
+          )
+        ),
+        execute: writesOutputs(BOXES, SCORES, KEYPOINTS),
+      });
+    });
+
+    it('reports the peak score of the group, not its mean', async () => {
+      const detector = tracked(await createKeypointDetector(detectorConfig));
+
+      const detections = await detector.detectKeypoints(imageBuffer(SIZE, SIZE), {
+        confidenceThreshold: 0.001,
+      });
+
+      expect(detections).toHaveLength(1);
+      expect(detections[0]!.confidence).toBeCloseTo(0.9, 5);
+    });
+
+    it('keeps the confidence stable when a lower threshold widens the group', async () => {
+      const detector = tracked(await createKeypointDetector(detectorConfig));
+      const image = imageBuffer(SIZE, SIZE);
+
+      // At 0.5 only the peak box is a candidate; at 0.001 the near-zero box
+      // joins its group. The detection is the same one either way.
+      const strict = await detector.detectKeypoints(image, { confidenceThreshold: 0.5 });
+      const loose = await detector.detectKeypoints(image, { confidenceThreshold: 0.001 });
+
+      expect(strict).toHaveLength(1);
+      expect(loose).toHaveLength(1);
+      expect(loose[0]!.confidence).toBeCloseTo(strict[0]!.confidence, 5);
+    });
   });
 });
 

--- a/packages/react-native-executorch/src/extensions/cv/tasks/keypointDetection.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/keypointDetection.ts
@@ -85,7 +85,11 @@ export type Landmarks<L extends PropertyKey> = Record<L, Point & { readonly conf
 export type KeypointDetection<F extends BoxFormat, L extends PropertyKey> = {
   /** Scaled bounding box coordinates matching the input image resolution. */
   readonly box: BoundingBox<F>;
-  /** Overall confidence score of the detection (between 0.0 and 1.0). */
+  /**
+   * Overall confidence score of the detection (between 0.0 and 1.0). When
+   * several boxes are merged by NMS, this is the highest score in the merged
+   * group, so it does not depend on how many low-scoring boxes were absorbed.
+   */
   readonly confidence: number;
   /** Map of landmark names to their scaled pixel coordinates and individual confidence scores. */
   readonly landmarks: Landmarks<L>;
@@ -163,6 +167,7 @@ function postprocess<F extends BoxFormat, L extends PropertyKey>(
 
   for (const group of nmsGroups) {
     const totalScore = group.reduce((total, idx) => total + (scores[idx] ?? 0), 0);
+    const peakScore = group.reduce((peak, idx) => Math.max(peak, scores[idx] ?? 0), 0);
     const weightedBox = new Float32Array(4);
     const weightedKpt = new Float32Array(options.landmarks.length * 3);
 
@@ -195,7 +200,7 @@ function postprocess<F extends BoxFormat, L extends PropertyKey>(
       landmarks[key] = { ...point, confidence };
     }
 
-    results.push({ box, confidence: totalScore / group.length, landmarks });
+    results.push({ box, confidence: peakScore, landmarks });
   }
 
   return results;


### PR DESCRIPTION
## Description

`detectKeypoints` reported a merged detection's confidence as the arithmetic mean of its NMS group. The box and the landmarks in the same loop are score-weighted, so a near-zero member barely moves them, but the mean let that member drag the confidence down in full.

The value therefore depended on the caller's `confidenceThreshold`: lowering it pulls more weak boxes into the group and shrinks the reported number. On RF-DETR keypoint the same single detection read 0.863 at a 0.3 threshold and 0.033 at 0.001.

This reports the peak score of the group instead, which is what the model and the other detection tasks mean by confidence.

`objectDetection` and `instanceSegmentation` both use `nmsType: 'standard'` and read `scores[index]` directly, so neither has the pattern.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

`yarn jest __tests__/tasks/remainingTasks.test.ts` in `packages/react-native-executorch`.

Two regression cases cover it: two boxes at IoU 0.62 with scores 0.9 and 0.01 merge into one detection, which reports 0.9, and reports the same value at `confidenceThreshold` 0.5 and 0.001. Both fail on the previous code.

Not device-tested, this is pure TypeScript postprocessing covered by the fake-JSI unit tests.

### Screenshots

### Related issues

Fixes #1394

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes
