### PR TITLE
feat(speech): accept a whisper model exported at a fixed audio length

### DIFF
--- a/packages/react-native-executorch/__tests__/tasks/remainingTasks.test.ts
+++ b/packages/react-native-executorch/__tests__/tasks/remainingTasks.test.ts
@@ -298,6 +298,36 @@ describe('createWhisperSpeechToText', () => {
     stt.dispose();
   });
 
+  it('accepts a model whose encode is exported at one fixed sample count', async () => {
+    register();
+    // Vulkan has no dynamic-shape support, so its encode takes a constant length.
+    fakeJsi.registerModel(MODEL_PATH, {
+      schema: exported({
+        ...method('encode', [f32(480000)], [f32(1, 1500, 3072)]),
+        ...method('decode', [i64(1, 1), i64(1), f32(1, 1500, 3072)], [f32(1, 1, 51865)]),
+      }),
+    });
+
+    const stt = await createWhisperSpeechToText(config);
+    expect(stt.transcribe).toBeInstanceOf(Function);
+
+    stt.dispose();
+  });
+
+  it('rejects a model whose encode signature matches no variant', async () => {
+    register();
+    fakeJsi.registerModel(MODEL_PATH, {
+      schema: exported({
+        ...method('encode', [f32(2, AUDIO_SAMPLES)], [f32(1, 1500, 384)]),
+        ...method('decode', [i64(1, 1), i64(1), f32(1, 1500, 384)], [f32(1, 1, 51865)]),
+      }),
+    });
+
+    await expect(createWhisperSpeechToText(config)).rejects.toThrow(
+      /doesn't match any of the provided variants/
+    );
+  });
+
   it('releases the model, the tokenizer and the nested VAD pipeline on dispose', async () => {
     register();
 

--- a/packages/react-native-executorch/src/extensions/speech/tasks/whisperSpeechToText.ts
+++ b/packages/react-native-executorch/src/extensions/speech/tasks/whisperSpeechToText.ts
@@ -27,6 +27,22 @@ import { createResourceScope } from '../../../core/lifetime';
  */
 export const WHISPER_SAMPLE_RATE_HZ = 16000;
 
+/**
+ * Zero-pads (or truncates) audio to exactly the length a model's `encode` was
+ * exported for. Returns the input untouched when it already matches, so the
+ * dynamic-shape path allocates nothing.
+ * @param samples The audio samples to fit.
+ * @param length The exact number of samples to produce.
+ * @returns A Float32Array of exactly `length` samples.
+ */
+const fitToLength = (samples: Float32Array, length: number): Float32Array => {
+  'worklet';
+  if (samples.length === length) return samples;
+  const fitted = new Float32Array(length);
+  fitted.set(samples.subarray(0, length));
+  return fitted;
+};
+
 const MAX_SEQ_LEN = 128; // maximum decoder output tokens per chunk
 const MIN_CHUNK_SIZE = 201; // shortest audio slice (samples) the model was exported for
 const CHUNK_LENGTH_SECONDS = 29; // Whisper's fixed context window length
@@ -208,22 +224,37 @@ export async function createWhisperSpeechToText<L extends WhisperLanguage = Whis
     const eotToken = tokenizer.tokenToId('<|endoftext|>')!;
     const isEnglishOnly = supportedLanguages.length === 1 && supportedLanguages[0] === 'en';
 
-    const { dims } = validateSpec(model.schema, {
+    const decodeMethod = method(
+      'decode',
+      [i64(1, 1), i64(1), f32(1, 'SeqLen', 'StateDim')],
+      [f32(1, 1, 'VocabSize')]
+    );
+
+    const { variant, dims } = validateSpec(model.schema, {
       default: {
         ...method(
           'encode', // prettier-ignore
           [f32(Dyn('T_audio'))], // Internally, model always pads audio to the maximum duration.
           [f32(1, 'SeqLen', 'StateDim')]
         ),
+        ...decodeMethod,
+      },
+      // Backends without dynamic-shape support (Vulkan) export `encode` at one
+      // fixed sample count. Whisper pads or truncates to a fixed 3000 mel frames
+      // internally regardless, so a fixed window is the shape the model already
+      // works in; the chunk is padded up to it before every call.
+      staticAudio: {
         ...method(
-          'decode',
-          [i64(1, 1), i64(1), f32(1, 'SeqLen', 'StateDim')],
-          [f32(1, 1, 'VocabSize')]
+          'encode', // prettier-ignore
+          [f32('AudioLen')],
+          [f32(1, 'SeqLen', 'StateDim')]
         ),
+        ...decodeMethod,
       },
     });
 
     const [seqLen, stateDim] = dims.constant('SeqLen', 'StateDim');
+    const staticAudioLen = variant === 'staticAudio' ? dims.constant('AudioLen')[0]! : null;
 
     const tensors = [
       tensor('int64', [1]), // tPosition
@@ -283,7 +314,9 @@ export async function createWhisperSpeechToText<L extends WhisperLanguage = Whis
           break;
         }
 
-        const tAudioInput = tensor('float32', [audioChunk.length], audioChunk);
+        const encodeInput =
+          staticAudioLen === null ? audioChunk : fitToLength(audioChunk, staticAudioLen);
+        const tAudioInput = tensor('float32', [encodeInput.length], encodeInput);
         try {
           model.execute('encode', [tAudioInput], [tEncodings]);
         } finally {


### PR DESCRIPTION
## Description

`createWhisperSpeechToText` declared `encode` as taking a dynamic `T_audio`, so a model exporting it at one fixed sample count was rejected at load with `Symbol 'T_audio' is 'constant', expected 'dynamic'`. The Vulkan delegate has no dynamic-shape support, so a fixed length is the only shape it can export.

Adds a second spec variant instead of a backend flag: `validateSpec` already tries variants in order and reports which one matched, so the model selects its own path from the schema it ships, the way the CV tasks do it. When the static variant matches, the chunk is zero-padded to the declared length before each `encode`.

Padding is free semantically: whisper's mel preprocessor pads or truncates to a fixed 3000 frames regardless, so a fixed window is the shape the model already works in internally. The dynamic path is untouched and allocates nothing extra, since `fitToLength` returns its input when the length already matches.

Note that the task feeds chunks of at most `CHUNK_LENGTH_SECONDS` (29 s), and as little as `MIN_CHUNK_SIZE`, so a static model pays for a full window on every chunk. That is inherent to exporting without dynamic shapes, not something the padding introduces.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] New feature (change which adds functionality)
- [ ] Bug fix (change which fixes an issue)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

`yarn typecheck`, `yarn lint` (from the repo root) and `yarn test` in `packages/react-native-executorch`. Two tests were added to `__tests__/tasks/remainingTasks.test.ts`: one accepting a model whose `encode` is exported at a constant 480000 samples, one rejecting an `encode` signature that matches neither variant.

Not yet exercised on device: the Vulkan whisper model this unblocks is still in review in export-scripts !20.

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

The static variant binds `StateDim` the same way the dynamic one does, so it also accommodates a wider encoder output than 384 without further changes.
