### PR TITLE
feat(speech): add Vulkan whisper-tiny variants

### DIFF
--- a/apps/speech/app/audio-file-transcription/index.tsx
+++ b/apps/speech/app/audio-file-transcription/index.tsx
@@ -74,6 +74,16 @@ const MODELS = [
     disabled: Platform.OS !== 'ios',
   },
   {
+    name: 'Tiny Multilingual (Vulkan fp16)',
+    config: models.speechToText.WHISPER.TINY.VULKAN_FP16,
+    disabled: Platform.OS !== 'android',
+  },
+  {
+    name: 'Tiny Multilingual (Vulkan int8)',
+    config: models.speechToText.WHISPER.TINY.VULKAN_INT8,
+    disabled: Platform.OS !== 'android',
+  },
+  {
     name: 'Base Multilingual (CPU)',
     config: models.speechToText.WHISPER.BASE.XNNPACK_FP32,
   },

--- a/apps/speech/app/microphone-transcription/index.tsx
+++ b/apps/speech/app/microphone-transcription/index.tsx
@@ -67,6 +67,16 @@ const MODELS = [
     disabled: Platform.OS !== 'ios',
   },
   {
+    name: 'Tiny Multilingual (Vulkan fp16)',
+    config: models.speechToText.WHISPER.TINY.VULKAN_FP16,
+    disabled: Platform.OS !== 'android',
+  },
+  {
+    name: 'Tiny Multilingual (Vulkan int8)',
+    config: models.speechToText.WHISPER.TINY.VULKAN_INT8,
+    disabled: Platform.OS !== 'android',
+  },
+  {
     name: 'Base Multilingual (CPU)',
     config: models.speechToText.WHISPER.BASE.XNNPACK_FP32,
   },

--- a/packages/react-native-executorch/scripts/download-libs.js
+++ b/packages/react-native-executorch/scripts/download-libs.js
@@ -124,8 +124,8 @@ const FEATURE_MAP = {
   multimodalLLM: { backends: ['xnnpack', 'mlx', 'vulkan'], libs: ['opencv'] },
   // Privacy filter classifiers ship xnnpack + an MLX iOS export.
   privacyFilter: { backends: ['xnnpack', 'mlx'], libs: [] },
-  // Whisper ships xnnpack + coreml.
-  speechToText: { backends: ['xnnpack', 'coreml'], libs: [] },
+  // Whisper ships xnnpack + coreml + a Vulkan Android export.
+  speechToText: { backends: ['xnnpack', 'coreml', 'vulkan'], libs: [] },
   // Kokoro ships xnnpack only.
   textToSpeech: { backends: ['xnnpack'], libs: ['phonemis'] },
   // FSMN VAD — xnnpack only.

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -750,6 +750,18 @@ const WHISPER_TINY_MLX_INT8: WhisperSttModel = {
   supportedLanguages: WHISPER_LANGUAGES,
   vadModel: FSMN_VAD_XNNPACK_FP32,
 };
+const WHISPER_TINY_VULKAN_FP16: WhisperSttModel = {
+  modelPath: `${BASE_URL}-whisper-tiny/${NEXT_VERSION_TAG}/vulkan/whisper_tiny_vulkan_fp16.pte`,
+  tokenizerPath: `${BASE_URL}-whisper-tiny/${NEXT_VERSION_TAG}/tokenizer.json`,
+  supportedLanguages: WHISPER_LANGUAGES,
+  vadModel: FSMN_VAD_XNNPACK_FP32,
+};
+const WHISPER_TINY_VULKAN_INT8: WhisperSttModel = {
+  modelPath: `${BASE_URL}-whisper-tiny/${NEXT_VERSION_TAG}/vulkan/whisper_tiny_vulkan_int8.pte`,
+  tokenizerPath: `${BASE_URL}-whisper-tiny/${NEXT_VERSION_TAG}/tokenizer.json`,
+  supportedLanguages: WHISPER_LANGUAGES,
+  vadModel: FSMN_VAD_XNNPACK_FP32,
+};
 
 const WHISPER_BASE_EN_XNNPACK_FP32: WhisperSttModel<'en'> = {
   modelPath: `${BASE_URL}-whisper-base.en/${NEXT_VERSION_TAG}/xnnpack/whisper_base_en_xnnpack_fp32.pte`,
@@ -1862,6 +1874,8 @@ export const models = {
         COREML_FP16: WHISPER_TINY_COREML_FP16,
         MLX_BF16: WHISPER_TINY_MLX_BF16,
         MLX_INT8: WHISPER_TINY_MLX_INT8,
+        VULKAN_FP16: WHISPER_TINY_VULKAN_FP16,
+        VULKAN_INT8: WHISPER_TINY_VULKAN_INT8,
       },
       /**
        * Multilingual Whisper Base model. Higher accuracy across supported


### PR DESCRIPTION
## Description

Registers the fp16 and int8 Vulkan exports of multilingual whisper-tiny as `WHISPER.TINY.VULKAN_FP16` / `WHISPER.TINY.VULKAN_INT8`, adds `vulkan` to the `speechToText` entry in the `download-libs.js` feature map so the backend lib is fetched, and offers both in the speech demo on Android.

Encode runs on Vulkan (mel preprocessor falls back to XNNPACK); decode stays on XNNPACK, where it measured faster. On an Adreno 840 the encode is about 1.6x the XNNPACK time and decode is 4.08 ms, down from 11.96 ms.

The exports require the ExecuTorch 1.4.1 Vulkan runtime published in `v0.10.0-libs-1.4.1`. Older Vulkan libs lack the gelu tanh clamp, the reduce-shader barrier fix and the Adreno local-work-group fix, and produce NaNs or a device loss.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

1. Run `apps/speech` on an Android device.
2. Open Transcribe Audio File, pick Tiny Multilingual (Vulkan fp16), transcribe the sample file, and check the transcript carries no `<|0.00|>` timestamp tokens.
3. Repeat with Tiny Multilingual (Vulkan int8).
4. Repeat both on Live Transcription (Mic).

### Screenshots

### Related issues

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

Verified on a Galaxy S26 Ultra against the exact `libvulkan_executorch_backend.so` published in `v0.10.0-libs-1.4.1` (md5 `3aba5c82...`, matched between the installed APK and the release tarball).

The `speechToText` feature map lists `xnnpack`, `coreml` and now `vulkan`, but not `mlx`, even though the registry exposes `MLX_BF16` / `MLX_INT8` whisper variants. That looks like a pre-existing gap and is left alone here.
