### PR TITLE
[RNE Rewrite] fix(test): allow 8da8w precision tag in model registry URL contract test

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,6 +7,9 @@ pre-commit:
     types:
       glob: '*.{js,ts,jsx,tsx}'
       run: yarn typecheck
+    test:
+      glob: '*.{js,ts,jsx,tsx}'
+      run: yarn workspace react-native-executorch test
     format-js:
       glob: '*.{js,ts,jsx,tsx}'
       run: npx prettier --write {staged_files} && git add {staged_files}

--- a/packages/react-native-executorch/__tests__/api/modelRegistry.test.ts
+++ b/packages/react-native-executorch/__tests__/api/modelRegistry.test.ts
@@ -105,7 +105,7 @@ const namedVariants = (group: Node): Node[] =>
 const BACKENDS = /^(xnnpack|coreml|mlx|qnn|vulkan)$/;
 // `spinquant` is a quantization recipe rather than a plain precision, but it is
 // what the published Llama builds are named after.
-const PRECISIONS = /^(fp32|fp16|bf16|int8|int4|8da4w|4w|dynamic|spinquant)$/;
+const PRECISIONS = /^(fp32|fp16|bf16|int8|int4|8da4w|8da8w|4w|dynamic|spinquant)$/;
 
 const basename = (url: string) => url.split('/').pop()!.replace('.pte', '');
 


### PR DESCRIPTION
## Description

Fixes a TypeScript test failure in CI by adding `8da8w` to the allowed `PRECISIONS` pattern in the model registry URL contract test.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

<!-- Provide step-by-step instructions on how to test your changes. Include setup details if necessary. -->

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
