### PR TITLE
[RNE Rewrite] feat(models): add a Vulkan Supertonic variant

### DIFF
--- a/apps/speech/app/text-to-speech/index.tsx
+++ b/apps/speech/app/text-to-speech/index.tsx
@@ -53,11 +53,14 @@ const STEPS_OPTIONS = [
 const MODEL_OPTIONS = [
   { label: 'XNNPACK (CPU)', value: 'XNNPACK_FP32' as const },
   { label: 'MLX (Apple Silicon)', value: 'MLX_FP32' as const, disabled: Platform.OS !== 'ios' },
+  { label: 'Vulkan (GPU)', value: 'VULKAN_FP16' as const, disabled: Platform.OS !== 'android' },
 ];
 
 function TTSContent() {
   const [text, setText] = useState(SAMPLE_TEXT);
-  const [selectedModel, setSelectedModel] = useState<'XNNPACK_FP32' | 'MLX_FP32'>('XNNPACK_FP32');
+  const [selectedModel, setSelectedModel] = useState<'XNNPACK_FP32' | 'MLX_FP32' | 'VULKAN_FP16'>(
+    Platform.OS === 'android' ? 'VULKAN_FP16' : 'XNNPACK_FP32'
+  );
   const [selectedVoice, setSelectedVoice] = useState<SupertonicDefaultVoiceName>('F1');
   const [selectedLang, setSelectedLang] = useState<speech.SupertonicLanguage>('en');
   const [speed, setSpeed] = useState(1.05);

--- a/packages/react-native-executorch/scripts/download-libs.js
+++ b/packages/react-native-executorch/scripts/download-libs.js
@@ -131,8 +131,12 @@ const FEATURE_MAP = {
   privacyFilter: { backends: ['xnnpack', 'mlx'], libs: [] },
   // Whisper ships xnnpack, coreml, an MLX iOS export and a Vulkan Android one.
   speechToText: { backends: ['xnnpack', 'coreml', 'mlx', 'vulkan'], libs: [] },
-  // Kokoro ships xnnpack + coreml; Supertonic adds an MLX iOS export.
-  textToSpeech: { backends: ['xnnpack', 'coreml', 'mlx'], libs: ['phonemis'] },
+  // Kokoro ships xnnpack + coreml; Supertonic adds an MLX iOS export and a
+  // Vulkan Android one.
+  textToSpeech: {
+    backends: ['xnnpack', 'coreml', 'mlx', 'vulkan'],
+    libs: ['phonemis'],
+  },
   // FSMN VAD — xnnpack only.
   vad: { backends: ['xnnpack'], libs: [] },
   // The MiniLM/CLIP-text/distiluse family ships coreml alongside xnnpack,

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -1116,6 +1116,18 @@ const SUPERTONIC_3_MLX_FP32: SupertonicTtsModel<SupertonicDefaultVoiceName> = {
   voiceStyles: SUPERTONIC_DEFAULT_VOICE_STYLES,
 };
 
+const SUPERTONIC_3_VULKAN_FP16: SupertonicTtsModel<SupertonicDefaultVoiceName> = {
+  name: 'supertonic',
+  modelPaths: {
+    durationPredictor: `${BASE_URL}-supertonic/${NEXT_VERSION_TAG}/vulkan/duration_predictor_vulkan_fp16.pte`,
+    vectorEstimator: `${BASE_URL}-supertonic/${NEXT_VERSION_TAG}/vulkan/vector_estimator_vulkan_fp16.pte`,
+    textEncoder: `${BASE_URL}-supertonic/${NEXT_VERSION_TAG}/vulkan/text_encoder_vulkan_fp16.pte`,
+    vocoder: `${BASE_URL}-supertonic/${NEXT_VERSION_TAG}/vulkan/vocoder_vulkan_fp16.pte`,
+  },
+  unicodeIndexerPath: `${BASE_URL}-supertonic/${NEXT_VERSION_TAG}/unicode_indexer.json`,
+  voiceStyles: SUPERTONIC_DEFAULT_VOICE_STYLES,
+};
+
 const KOKORO_ROOT = `${BASE_URL}-kokoro/${NEXT_VERSION_TAG}`;
 const KOKORO_PHONEMIZER_ROOT = `${KOKORO_ROOT}/phonemizer`;
 
@@ -2624,6 +2636,7 @@ export const models = {
     SUPERTONIC: variants({
       XNNPACK_FP32: SUPERTONIC_3_XNNPACK_FP32,
       MLX_FP32: SUPERTONIC_3_MLX_FP32,
+      VULKAN_FP16: SUPERTONIC_3_VULKAN_FP16,
     }),
 
     /**


### PR DESCRIPTION
## Description

Adds a Vulkan fp16 build of Supertonic, covering all four sub-models. Vulkan leads `BACKEND_ORDER.android`, so this becomes the Android default for `models.textToSpeech.SUPERTONIC`.

Measured on a Galaxy S26 Ultra (Adreno 840), medians over interleaved rounds, at 512 text tokens and 1000 latent frames:

| sub-model | vulkan fp16 | xnnpack fp32 | speedup |
| --- | --- | --- | --- |
| duration_predictor | 18.7 | 33.2 | 1.78x |
| text_encoder | 72.3 | 140.9 | 1.95x |
| vector_estimator | 682.5 | 1253.7 | 1.84x |
| vocoder | 865.8 | 1284.3 | 1.48x |

2.12x end to end at the default 8 flow-matching steps, where `vector_estimator` is 84% of the total. Outputs match the fp32 CPU references at cosine 1.000000, 0.999414, 0.999994 and 0.999977.

`textToSpeech` now provisions `vulkan` in download-libs. Without it the backend is never downloaded and the model silently falls back to XNNPACK.

Getting the model to lower correctly needed five ExecuTorch fixes, all open upstream and cherry-picked into the labs fork: pytorch/executorch#22399, #22401, #22402, #22403 and #22406. The Vulkan artifacts on the ExecuTorch 1.4.1 pre-release carry them.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

1. Run `apps/speech` on an Android device.
2. Open Text to Speech. The model picker now offers Vulkan (GPU) and starts on it.
3. Synthesize; compare against the XNNPACK entry in the same picker.

### Related issues

Stacked on #1392.

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
