### PR TITLE
[RNE Rewrite] feat(core): eagerly load and compile model methods during loadModel

### DIFF
--- a/.agents/skills/verify-and-build/SKILL.md
+++ b/.agents/skills/verify-and-build/SKILL.md
@@ -97,7 +97,7 @@ Compiles staged (or explicitly passed) `cpp/` sources with the same flags clangd
 ```bash
 # The script takes file paths as positional arguments and exits 0 immediately
 # with none — it has no built-in file discovery. Pass files explicitly:
-find cpp/ -name '*.cpp' -o -name '*.h' | \
+find cpp/ -path cpp/tests -prune -o \( -name '*.cpp' -o -name '*.h' \) -print | \
   xargs ./scripts/check-cpp-warnings.sh
 ```
 

--- a/packages/react-native-executorch/__tests__/core/model.test.ts
+++ b/packages/react-native-executorch/__tests__/core/model.test.ts
@@ -29,6 +29,15 @@ describe('loadModel', () => {
     model.dispose();
   });
 
+  it('accepts optional eagerLoadMethods option', () => {
+    const schema = exported(method('forward', [f32(4)], [f32(4)]));
+    fakeJsi.registerModel(PATH, { schema });
+
+    const model = loadModel(PATH, { eagerLoadMethods: false });
+    expect(model.path).toBe(PATH);
+    model.dispose();
+  });
+
   it('propagates a load failure as a thrown error', () => {
     expect(() => loadModel('/models/missing.pte')).toThrow(/missing.pte/);
   });

--- a/packages/react-native-executorch/__tests__/support/fakeJsi.ts
+++ b/packages/react-native-executorch/__tests__/support/fakeJsi.ts
@@ -321,7 +321,7 @@ const jsi = {
 
   createTensor: (shape: number[], dtype: DType) => new FakeTensor(dtype, shape),
 
-  loadModel: (path: string) => {
+  loadModel: (path: string, _options?: { eagerLoadMethods?: boolean }) => {
     const program = programs.get(path);
     if (!program) {
       throw new Error(`loadModel: no program registered at '${path}' (register one via fakeJsi)`);

--- a/packages/react-native-executorch/cpp/core/model.cpp
+++ b/packages/react-native-executorch/cpp/core/model.cpp
@@ -35,6 +35,12 @@ T unwrap(RnExecuTorchErrorCode code, const std::string &ctx, executorch::runtime
     return std::move(result.get());
 }
 
+void unwrap(RnExecuTorchErrorCode code, const std::string &ctx, executorch::runtime::Error error) {
+    if (error != executorch::runtime::Error::Ok) {
+        throw RnExecuTorchException(code, std::format("{}: {}", ctx, executorch::runtime::to_string(error)), error);
+    }
+}
+
 } // namespace
 
 namespace rnexecutorch::core::model {
@@ -43,7 +49,7 @@ namespace conversions = rnexecutorch::core::conversions;
 
 using rnexecutorch::core::tensor::TensorHostObject;
 
-ModelHostObject::ModelHostObject(const std::string &modelPath)
+ModelHostObject::ModelHostObject(const std::string &modelPath, const bool eagerLoadMethods)
     : modelPath_(modelPath),
       etModule_(std::make_unique<executorch::extension::Module>(modelPath)) {
 
@@ -70,6 +76,11 @@ ModelHostObject::ModelHostObject(const std::string &modelPath)
     }
 
     for (const auto &methodName : methodNames) {
+        if (eagerLoadMethods && methodName != kGetModelSchemaMethod) {
+            auto ctx = std::format("Load method '{}'", methodName);
+            unwrap(RnExecuTorchErrorCode::LoadFailed, ctx, etModule_->load_method(methodName));
+        }
+
         auto ctx = std::format("Method '{}'", methodName);
         auto methodMeta = unwrap(RnExecuTorchErrorCode::LoadFailed, ctx, etModule_->method_meta(methodName));
 
@@ -308,14 +319,21 @@ std::vector<facebook::jsi::PropNameID> ModelHostObject::getPropertyNames(jsi::Ru
 void install_loadModel(jsi::Runtime &rt, jsi::Object &module) {
     const auto *name = "loadModel";
     auto fnBody = [](jsi::Runtime &rt, const jsi::Value & /*thisVal*/, const jsi::Value *args, size_t count) -> jsi::Value {
-        if (count != 1) {
-            throw error::InvalidArgument("loadModel: Usage: loadModel(path)");
+        if (count < 1 || count > 2) {
+            throw error::InvalidArgument("loadModel: Usage: loadModel(path, options?)");
         }
 
         auto modelPath = conversions::asType<std::string>(rt, "loadModel: path", args[0]);
-        return jsi::Object::createFromHostObject(rt, std::make_shared<ModelHostObject>(modelPath));
+        bool eagerLoadMethods = true;
+
+        if (count >= 2 && !args[1].isUndefined() && !args[1].isNull()) {
+            auto options = conversions::asType<jsi::Object>(rt, "loadModel: options", args[1]);
+            eagerLoadMethods = conversions::getOptionalProperty<bool>(rt, "loadModel: options", options, "eagerLoadMethods").value_or(true);
+        }
+
+        return jsi::Object::createFromHostObject(rt, std::make_shared<ModelHostObject>(modelPath, eagerLoadMethods));
     };
-    auto fn = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name), 1, error::guarded(fnBody));
+    auto fn = jsi::Function::createFromHostFunction(rt, jsi::PropNameID::forAscii(rt, name), 2, error::guarded(fnBody));
 
     module.setProperty(rt, name, fn);
 }

--- a/packages/react-native-executorch/cpp/core/model.h
+++ b/packages/react-native-executorch/cpp/core/model.h
@@ -38,8 +38,9 @@ public:
      * method metadata, parses schemas, and populates backend delegates.
      *
      * @param modelPath Absolute file system path to the `.pte` model binary.
+     * @param eagerLoadMethods Whether to eagerly load and compile all model methods.
      */
-    explicit ModelHostObject(const std::string &modelPath);
+    explicit ModelHostObject(const std::string &modelPath, bool eagerLoadMethods);
 
     jsi::Value get(jsi::Runtime &rt, const jsi::PropNameID &name) override;
     std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;

--- a/packages/react-native-executorch/cpp/tests/core/ModelTest.cpp
+++ b/packages/react-native-executorch/cpp/tests/core/ModelTest.cpp
@@ -31,7 +31,7 @@ using ::testing::HasSubstr;
 constexpr const char *kFixture = RNE_MODEL_FIXTURE;
 
 std::string loadFixtureJs() {
-    return std::format("const model = __rnexecutorch_jsi__.loadModel('{}');", kFixture);
+    return std::format("const model = __rnexecutorch_jsi__.loadModel('{}', {{ eagerLoadMethods: false }});", kFixture);
 }
 
 // --- Metadata reflection, exercised directly ---------------------------------
@@ -189,7 +189,7 @@ TEST_F(ModelTest, ReportsAMissingFileAsLoadFailed) {
 
 TEST_F(ModelTest, RejectsWrongArgumentCount) {
     EXPECT_THAT(evalThrowingMessage("__rnexecutorch_jsi__.loadModel();"),
-                HasSubstr("Usage: loadModel(path)"));
+                HasSubstr("Usage: loadModel(path, options?)"));
 }
 
 TEST_F(ModelTest, RejectsANonStringPath) {

--- a/packages/react-native-executorch/src/core/model.ts
+++ b/packages/react-native-executorch/src/core/model.ts
@@ -77,6 +77,25 @@ export type Model = {
 };
 
 /**
+ * Configuration options for loading an ExecuTorch model into native memory.
+ * @category Core / Types
+ */
+export type LoadModelOptions = {
+  /**
+   * Whether to eagerly load and compile all model methods and delegate subgraphs
+   * during initialization.
+   *
+   * When `true` (the default), all exported methods are fully loaded and backend
+   * delegates (such as CoreML or Vulkan) are compiled into memory upfront,
+   * guaranteeing instantaneous first-inference latency.
+   *
+   * Set to `false` to lazily load and compile methods on their first execution.
+   * @default true
+   */
+  readonly eagerLoadMethods?: boolean;
+};
+
+/**
  * Loads and compiles an ExecuTorch `.pte` model from the local filesystem.
  *
  * The model is loaded synchronously into native memory. Prefer calling this
@@ -84,6 +103,7 @@ export type Model = {
  * JS thread during compilation.
  * @category Core / Functions
  * @param modelPath The absolute local path to the `.pte` model file.
+ * @param options Optional loading configuration. See {@link LoadModelOptions}.
  * @returns The compiled {@link Model} instance, ready for execution.
  * @throws {RnExecuTorchError} Thrown with code `LOAD_FAILED` if the model file
  * cannot be opened, has an invalid format, or fails native initialization.
@@ -103,7 +123,7 @@ export type Model = {
  * }
  * ```
  */
-export function loadModel(modelPath: string): Model {
+export function loadModel(modelPath: string, options?: LoadModelOptions): Model {
   'worklet';
-  return rnexecutorchJsi.loadModel(modelPath) as Model;
+  return rnexecutorchJsi.loadModel(modelPath, options) as Model;
 }


### PR DESCRIPTION
## Description

Adds an `eagerLoadMethods` option (defaulting to `true`) to `loadModel()`:
- Calls `etModule_->load_method(methodName)` during `ModelHostObject` initialization for all exported methods.
- Pre-compiles backend delegates and allocates execution buffers upfront while the model is loading, eliminating the first-inference lag spike.
- Allows opting out via `loadModel(path, { eagerLoadMethods: false })`.


### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

- [ ] Build and run example apps to make sure nothing is broken.

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

Closes #1393

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
