### PR TITLE
[RNE Rewrite] chore(package): make packaging standalone-install-safe and leaner

### DIFF
--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -69,6 +69,10 @@
     "!**/__tests__",
     "!**/__fixtures__",
     "!**/__mocks__",
+    "!third-party/**/test",
+    "!third-party/**/tests",
+    "!third-party/common/phonemis/data",
+    "!cpp/tests",
     "!**/.*"
   ],
   "scripts": {
@@ -80,7 +84,7 @@
     "lint:cpp": "./scripts/clang-tidy.sh",
     "prepack": "cp ../../README.md ./README.md",
     "postpack": "rm ./README.md",
-    "postinstall": "node scripts/download-libs.js && yarn run -T patch-package --patch-dir ../../patches"
+    "postinstall": "node scripts/download-libs.js"
   },
   "keywords": [
     "text-to-speech",


### PR DESCRIPTION
## Description

Fixes package installation when consuming `react-native-executorch` as a standalone npm dependency outside the monorepo workspace, and reduces the published npm tarball size.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

- [ ] Run 
   ```bash
       cd packages/react-native-executorch
       npm pack --dry-run
   ```
   and confirm tarball size is ~700 kB (unpacked ~3.5 MB).

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
