### PR TITLE
[RNE Rewrite] docs(src): refine TypeDoc cross-links and JSDoc annotations across hooks and tasks

### DIFF
--- a/packages/react-native-executorch/src/core/lifetime.ts
+++ b/packages/react-native-executorch/src/core/lifetime.ts
@@ -27,6 +27,9 @@ export type ResourceScope = {
   /**
    * Takes ownership of a resource and returns it unchanged, so it can wrap an
    * allocation in place.
+   * @typeParam R The concrete {@link NativeResource} type being tracked.
+   * @param resource The resource to take ownership of.
+   * @returns The same `resource`, unchanged.
    */
   readonly track: <R extends NativeResource>(resource: R) => R;
 

--- a/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts
@@ -207,7 +207,7 @@ export async function createInstanceSegmenter<F extends BoxFormat, L>(
 
     const segmentInstancesWorklet = (
       input: ImageBuffer,
-      options?: { confidenceThreshold?: number; iouThreshold?: number; maskThreshold?: number }
+      options?: SegmentInstancesOptions
     ): InstanceSegmentationResult<F, L>[] => {
       'worklet';
       const tInput = preprocessor.process(input);

--- a/packages/react-native-executorch/src/extensions/cv/tasks/keypointDetection.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/keypointDetection.ts
@@ -261,7 +261,7 @@ export async function createKeypointDetector<F extends BoxFormat, L extends Prop
 
     const detectKeypointsWorklet = (
       input: ImageBuffer,
-      options?: { confidenceThreshold?: number; iouThreshold?: number }
+      options?: DetectKeypointsOptions
     ): KeypointDetection<F, L>[] => {
       'worklet';
       const tInput = preprocessor.process(input);

--- a/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts
@@ -181,7 +181,7 @@ export async function createObjectDetector<F extends BoxFormat, L>(
 
     const detectObjectsWorklet = (
       input: ImageBuffer,
-      options?: { confidenceThreshold?: number; iouThreshold?: number }
+      options?: DetectObjectsOptions
     ): ObjectDetection<F, L>[] => {
       'worklet';
       const tInput = preprocessor.process(input);

--- a/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts
+++ b/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts
@@ -1,7 +1,6 @@
 /**
  * Multi-turn LLM chat session with history management, tool calling, and KV
  * cache prefilling.
- * @module LLM/Tasks/LLMChatSession
  */
 
 import { scheduleOnRN, type WorkletRuntime } from 'react-native-worklets';

--- a/packages/react-native-executorch/src/extensions/nlp/tasks/privacyFilter.ts
+++ b/packages/react-native-executorch/src/extensions/nlp/tasks/privacyFilter.ts
@@ -1,7 +1,6 @@
 /**
  * Privacy Filter task pipeline for detecting personally identifiable
  * information (PII).
- * @module NLP/Tasks/PrivacyFilter
  */
 
 import type { WorkletRuntime } from 'react-native-worklets';

--- a/packages/react-native-executorch/src/extensions/speech/tasks/supertonicTextToSpeech.ts
+++ b/packages/react-native-executorch/src/extensions/speech/tasks/supertonicTextToSpeech.ts
@@ -1,6 +1,5 @@
 /**
  * Supertonic Text-to-Speech (TTS) synthesis task pipeline.
- * @module Speech/Tasks/SupertonicTextToSpeech
  */
 
 import type { WorkletRuntime } from 'react-native-worklets';

--- a/packages/react-native-executorch/src/extensions/speech/tasks/whisperSpeechToText.ts
+++ b/packages/react-native-executorch/src/extensions/speech/tasks/whisperSpeechToText.ts
@@ -1,6 +1,5 @@
 /**
  * Whisper Speech-to-Text (STT) transcription and live-streaming task pipeline.
- * @module Speech/Tasks/WhisperSpeechToText
  */
 
 import type { WorkletRuntime } from 'react-native-worklets';

--- a/packages/react-native-executorch/src/hooks/useClassifier.ts
+++ b/packages/react-native-executorch/src/hooks/useClassifier.ts
@@ -16,9 +16,9 @@ import { createClassifier, type ClassifierModel } from '../extensions/cv/tasks/c
  * @param config The image classification model configuration.
  * See {@link ClassifierModel}.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createClassifier} (without `dispose`),
+ * @returns The same object as {@link Classifier} (without `dispose`),
  * combined with loading state, download progress, and labels.
- * @see {@link createClassifier}
+ * @see {@link Classifier}
  */
 export function useClassifier<L>(config: ClassifierModel<L>, options?: ResourceOptions) {
   const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);

--- a/packages/react-native-executorch/src/hooks/useImageEmbedder.ts
+++ b/packages/react-native-executorch/src/hooks/useImageEmbedder.ts
@@ -18,9 +18,9 @@ import {
  * @param config The image embedder model configuration.
  * See {@link ImageEmbedderModel}.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createImageEmbedder} (without `dispose`),
+ * @returns The same object as {@link ImageEmbedder} (without `dispose`),
  * combined with loading state and download progress.
- * @see {@link createImageEmbedder}
+ * @see {@link ImageEmbedder}
  */
 export function useImageEmbedder(config: ImageEmbedderModel, options?: ResourceOptions) {
   const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);

--- a/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
+++ b/packages/react-native-executorch/src/hooks/useInstanceSegmenter.ts
@@ -21,9 +21,9 @@ import type { BoxFormat } from '../extensions/cv/ops/box';
  * @param config The instance segmentation model configuration.
  * See {@link InstanceSegmenterModel}.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createInstanceSegmenter} (without `dispose`),
+ * @returns The same object as {@link InstanceSegmenter} (without `dispose`),
  * combined with loading state, download progress, and labels.
- * @see {@link createInstanceSegmenter}
+ * @see {@link InstanceSegmenter}
  */
 export function useInstanceSegmenter<F extends BoxFormat, L>(
   config: InstanceSegmenterModel<F, L>,

--- a/packages/react-native-executorch/src/hooks/useKeypointDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useKeypointDetector.ts
@@ -21,9 +21,9 @@ import type { BoxFormat } from '../extensions/cv/ops/box';
  * @param config The keypoint detection model configuration.
  * See {@link KeypointDetectorModel}.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createKeypointDetector} (without `dispose`),
+ * @returns The same object as {@link KeypointDetector} (without `dispose`),
  * combined with loading state, download progress, and landmarks.
- * @see {@link createKeypointDetector}
+ * @see {@link KeypointDetector}
  */
 export function useKeypointDetector<F extends BoxFormat, L extends PropertyKey>(
   config: KeypointDetectorModel<F, L>,

--- a/packages/react-native-executorch/src/hooks/useLLMChatSession.ts
+++ b/packages/react-native-executorch/src/hooks/useLLMChatSession.ts
@@ -19,9 +19,9 @@ import {
  * @param config The LLM model configuration. See {@link LLMModel}.
  * @param options Chat session options and load/caching options.
  * See {@link LLMChatSessionOptions} & {@link ResourceOptions}.
- * @returns The same object as {@link createLLMChatSession} (without `dispose`),
+ * @returns The same object as {@link LLMChatSession} (without `dispose`),
  * combined with loading state and download progress.
- * @see {@link createLLMChatSession}
+ * @see {@link LLMChatSession}
  */
 export function useLLMChatSession(
   config: LLMModel,

--- a/packages/react-native-executorch/src/hooks/useObjectDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useObjectDetector.ts
@@ -21,9 +21,9 @@ import type { BoxFormat } from '../extensions/cv/ops/box';
  * @param config The object detection model configuration.
  * See {@link ObjectDetectorModel}.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createObjectDetector} (without `dispose`),
+ * @returns The same object as {@link ObjectDetector} (without `dispose`),
  * combined with loading state, download progress, and labels.
- * @see {@link createObjectDetector}
+ * @see {@link ObjectDetector}
  */
 export function useObjectDetector<F extends BoxFormat, L>(
   config: ObjectDetectorModel<F, L>,

--- a/packages/react-native-executorch/src/hooks/useOpticalCharacterRecognizer.ts
+++ b/packages/react-native-executorch/src/hooks/useOpticalCharacterRecognizer.ts
@@ -14,9 +14,9 @@ import { useModel } from './useModel';
  * @category Hooks
  * @param config OCR model configuration. Use a preset from `models.ocr.*`.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createPaddleOcr} (without `dispose`),
+ * @returns The same object as {@link PaddleOcr} (without `dispose`),
  * combined with loading state, download progress, and resource info.
- * @see {@link createPaddleOcr}
+ * @see {@link PaddleOcr}
  */
 export function useOpticalCharacterRecognizer(config: PaddleOcrModel, options?: ResourceOptions) {
   const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);

--- a/packages/react-native-executorch/src/hooks/usePrivacyFilter.ts
+++ b/packages/react-native-executorch/src/hooks/usePrivacyFilter.ts
@@ -20,9 +20,9 @@ import {
  * @param config The privacy filter model configuration.
  * See {@link PrivacyFilterModel}.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createPrivacyFilter} (without `dispose`),
+ * @returns The same object as {@link PrivacyFilter} (without `dispose`),
  * combined with loading state and download progress.
- * @see {@link createPrivacyFilter}
+ * @see {@link PrivacyFilter}
  */
 export function usePrivacyFilter<Label extends string>(
   config: PrivacyFilterModel<Label>,

--- a/packages/react-native-executorch/src/hooks/useSemanticSegmenter.ts
+++ b/packages/react-native-executorch/src/hooks/useSemanticSegmenter.ts
@@ -19,9 +19,9 @@ import {
  * @param config The semantic segmentation model configuration.
  * See {@link SemanticSegmenterModel}.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createSemanticSegmenter} (without `dispose`),
+ * @returns The same object as {@link SemanticSegmenter} (without `dispose`),
  * combined with loading state, download progress, and labels.
- * @see {@link createSemanticSegmenter}
+ * @see {@link SemanticSegmenter}
  */
 export function useSemanticSegmenter<L extends PropertyKey = string>(
   config: SemanticSegmenterModel<L>,

--- a/packages/react-native-executorch/src/hooks/useSpeechToText.ts
+++ b/packages/react-native-executorch/src/hooks/useSpeechToText.ts
@@ -19,9 +19,9 @@ import {
  * @param config The Whisper speech-to-text model configuration.
  * See {@link WhisperSttModel}.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createWhisperSpeechToText} (without `dispose`),
+ * @returns The same object as {@link WhisperSpeechToText} (without `dispose`),
  * combined with loading state and download progress.
- * @see {@link createWhisperSpeechToText}
+ * @see {@link WhisperSpeechToText}
  */
 export function useSpeechToText<L extends WhisperLanguage = WhisperLanguage>(
   config: WhisperSttModel<L>,

--- a/packages/react-native-executorch/src/hooks/useStyleTransfer.ts
+++ b/packages/react-native-executorch/src/hooks/useStyleTransfer.ts
@@ -15,9 +15,9 @@ import { createStyleTransfer, type StyleTransferModel } from '../extensions/cv/t
  * @param config The style transfer model configuration.
  * See {@link StyleTransferModel}.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createStyleTransfer} (without `dispose`),
+ * @returns The same object as {@link StyleTransfer} (without `dispose`),
  * combined with loading state and download progress.
- * @see {@link createStyleTransfer}
+ * @see {@link StyleTransfer}
  */
 export function useStyleTransfer(config: StyleTransferModel, options?: ResourceOptions) {
   const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);

--- a/packages/react-native-executorch/src/hooks/useTextEmbedder.ts
+++ b/packages/react-native-executorch/src/hooks/useTextEmbedder.ts
@@ -15,9 +15,9 @@ import { createTextEmbedder, type TextEmbedderModel } from '../extensions/nlp/ta
  * @param config The text embedder model configuration.
  * See {@link TextEmbedderModel}.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createTextEmbedder} (without `dispose`),
+ * @returns The same object as {@link TextEmbedder} (without `dispose`),
  * combined with loading state and download progress.
- * @see {@link createTextEmbedder}
+ * @see {@link TextEmbedder}
  */
 export function useTextEmbedder(config: TextEmbedderModel, options?: ResourceOptions) {
   const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);

--- a/packages/react-native-executorch/src/hooks/useTextToImage.ts
+++ b/packages/react-native-executorch/src/hooks/useTextToImage.ts
@@ -17,9 +17,9 @@ import {
  * @category Hooks
  * @param config The SDXS model configuration. See {@link SdxsTextToImageModel}.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createSdxsTextToImage} (without `dispose`),
+ * @returns The same object as {@link SdxsTextToImage} (without `dispose`),
  * combined with loading state and download progress.
- * @see {@link createSdxsTextToImage}
+ * @see {@link SdxsTextToImage}
  */
 export function useTextToImage(config: SdxsTextToImageModel, options?: ResourceOptions) {
   const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);

--- a/packages/react-native-executorch/src/hooks/useTextToSpeech.ts
+++ b/packages/react-native-executorch/src/hooks/useTextToSpeech.ts
@@ -24,9 +24,9 @@ import {
  * @typeParam K Voice keys record constraint.
  * @param config The Kokoro TTS model configuration. See {@link KokoroTtsModel}.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createKokoroTextToSpeech} (without `dispose`),
+ * @returns The same object as {@link KokoroTextToSpeech} (without `dispose`),
  * combined with loading state and download progress.
- * @see {@link createKokoroTextToSpeech}
+ * @see {@link KokoroTextToSpeech}
  */
 export function useTextToSpeech<K extends PropertyKey>(
   config: KokoroTtsModel<K>,
@@ -60,9 +60,9 @@ export function useTextToSpeech<K extends PropertyKey>(
  * @param config The Supertonic TTS model configuration.
  * See {@link SupertonicTtsModel}.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createSupertonicTextToSpeech} (without `dispose`),
+ * @returns The same object as {@link SupertonicTextToSpeech} (without `dispose`),
  * combined with loading state and download progress.
- * @see {@link createSupertonicTextToSpeech}
+ * @see {@link SupertonicTextToSpeech}
  */
 export function useTextToSpeech<K extends PropertyKey>(
   config: SupertonicTtsModel<K>,

--- a/packages/react-native-executorch/src/hooks/useTokenizer.ts
+++ b/packages/react-native-executorch/src/hooks/useTokenizer.ts
@@ -14,9 +14,9 @@ import { createTokenizer } from '../extensions/nlp/tasks/tokenization';
  * @category Hooks
  * @param tokenizerPath A remote URL or local path to a `tokenizer.json` file.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createTokenizer} (without `dispose`),
+ * @returns The same object as {@link Tokenizer} (without `dispose`),
  * combined with loading state and download progress.
- * @see {@link createTokenizer}
+ * @see {@link Tokenizer}
  */
 export function useTokenizer(tokenizerPath: string, options?: ResourceOptions) {
   const { resource, downloadProgress, downloadError } = useResourceDownload(tokenizerPath, options);

--- a/packages/react-native-executorch/src/hooks/useTokenizer.ts
+++ b/packages/react-native-executorch/src/hooks/useTokenizer.ts
@@ -14,9 +14,9 @@ import { createTokenizer } from '../extensions/nlp/tasks/tokenization';
  * @category Hooks
  * @param tokenizerPath A remote URL or local path to a `tokenizer.json` file.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link Tokenizer} (without `dispose`),
+ * @returns The same object as {@link nlp.Tokenizer} (without `dispose`),
  * combined with loading state and download progress.
- * @see {@link Tokenizer}
+ * @see {@link nlp.Tokenizer}
  */
 export function useTokenizer(tokenizerPath: string, options?: ResourceOptions) {
   const { resource, downloadProgress, downloadError } = useResourceDownload(tokenizerPath, options);

--- a/packages/react-native-executorch/src/hooks/useVoiceActivityDetector.ts
+++ b/packages/react-native-executorch/src/hooks/useVoiceActivityDetector.ts
@@ -17,9 +17,9 @@ import {
  * @category Hooks
  * @param config The VAD model configuration. See {@link FsmnVadModel}.
  * @param options Load and caching options. See {@link ResourceOptions}.
- * @returns The same object as {@link createFsmnVoiceActivityDetector} (without `dispose`),
+ * @returns The same object as {@link FsmnVoiceActivityDetector} (without `dispose`),
  * combined with loading state and download progress.
- * @see {@link createFsmnVoiceActivityDetector}
+ * @see {@link FsmnVoiceActivityDetector}
  */
 export function useVoiceActivityDetector(config: FsmnVadModel, options?: ResourceOptions) {
   const { resource, downloadProgress, downloadError } = useResourceDownload(config, options);

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -5,7 +5,6 @@
  * vision, speech synthesis/recognition, natural language processing, and large
  * language models (LLMs). Each entry includes verified remote `.pte` download
  * URLs, tokenizer/phonemizer files, preprocessing parameters, and label maps.
- * @module Models
  */
 
 import type { ClassifierModel } from './extensions/cv/tasks/classification';

--- a/packages/react-native-executorch/src/utils.ts
+++ b/packages/react-native-executorch/src/utils.ts
@@ -9,18 +9,6 @@ import type { ModelSpec, ConcreteDim } from './core/schema';
 import RNBlobUtil from 'react-native-blob-util';
 
 /**
- * Retrieves the names of all ExecuTorch backends compiled and registered in the
- * native binary.
- * @category Utils / Functions
- * @returns An array of registered backend name strings (e.g. 'XnnpackBackend',
- * 'CoreMLBackend').
- */
-export function getRegisteredBackends(): readonly string[] {
-  'worklet';
-  return rnexecutorchJsi.getExecuTorchRegisteredBackends();
-}
-
-/**
  * Options accepted by {@link useResourceDownload} and by every `use<Task>` hook
  * built on top of it.
  * @category Utils / Types
@@ -48,6 +36,18 @@ export type ModelInspection = {
   /** Map of method names to the backends each method was compiled for. */
   readonly backends: Record<string, readonly string[]>;
 };
+
+/**
+ * Retrieves the names of all ExecuTorch backends compiled and registered in the
+ * native binary.
+ * @category Utils / Functions
+ * @returns An array of registered backend name strings (e.g. 'XnnpackBackend',
+ * 'CoreMLBackend').
+ */
+export function getRegisteredBackends(): readonly string[] {
+  'worklet';
+  return rnexecutorchJsi.getExecuTorchRegisteredBackends();
+}
 
 /**
  * Inspects an ExecuTorch model file to fetch its metadata and signature info


### PR DESCRIPTION
## Description

Refines TypeDoc `@see` and `@returns` cross-links, symbol references, and JSDoc annotations across all React hooks and task pipeline definitions in `packages/react-native-executorch/src/`.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

N/A

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
