### PR TITLE
fix(download-libs): rebuild against refreshed artifacts instead of reusing stale objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,34 @@ jobs:
       - name: Provision third-party headers
         run: RNET_HEADERS_ONLY=1 node scripts/download-libs.js
 
+      # third-party/include and the ExecuTorch built below must come from the
+      # same release. When they drifted, `make_tensor_ptr` gaining a trailing
+      # `Device` parameter surfaced as an undefined reference nine minutes into
+      # the dependency build, blamed on whichever code happened to call it.
+      # Comparing the two up front fails in seconds and names both values.
+      # Note this only spans releases: ET_VERSION comes from the source tree's
+      # version.txt, so it cannot tell the fork's patches apart from upstream,
+      # and it says nothing about TOKENIZERS_COMMIT.
+      - name: Check the header and test-dependency ExecuTorch versions agree
+        run: |
+          headers=$(sed -n 's/^#define ET_VERSION "\(.*\)"$/\1/p' \
+            third-party/include/executorch/runtime/core/version.h)
+          pinned=$(sed -n 's/^EXECUTORCH_VERSION="v\(.*\)"$/\1/p' \
+            scripts/build-native-test-deps.sh)
+          if [ -z "$headers" ] || [ -z "$pinned" ]; then
+            echo "::error::could not read the ExecuTorch versions" \
+                 "(headers='$headers' pinned='$pinned')"
+            exit 1
+          fi
+          if [ "$headers" != "$pinned" ]; then
+            echo "::error::third-party/include is ExecuTorch $headers but" \
+                 "scripts/build-native-test-deps.sh pins v$pinned." \
+                 "Bump EXECUTORCH_VERSION (and TOKENIZERS_COMMIT) to match" \
+                 "the artifacts release."
+            exit 1
+          fi
+          echo "ExecuTorch $headers on both sides"
+
       # Hermes and ExecuTorch are pinned to exact tags, so the cache only misses
       # when scripts/build-native-test-deps.sh changes those pins.
       #

--- a/packages/react-native-executorch/scripts/build-native-test-deps.sh
+++ b/packages/react-native-executorch/scripts/build-native-test-deps.sh
@@ -32,11 +32,11 @@ HERMES_REPO="https://github.com/facebook/hermes.git"
 # errors or, worse, ABI drift at runtime. cpp/extensions/llm additionally reads
 # private members of TextLLMRunner/MultimodalRunner, so a version skew there
 # fails to compile rather than silently misbehaving.
-EXECUTORCH_VERSION="v1.3.1"
+EXECUTORCH_VERSION="v1.4.1"
 EXECUTORCH_REPO="https://github.com/pytorch/executorch.git"
 
 # The shipped native libraries are built from software-mansion-labs/executorch
-# @rne-split-build, which is ExecuTorch 1.3.1 with the tokenizers submodule
+# @ms/separate-backends-1.4.1, which is ExecuTorch 1.4.1 with the tokenizers submodule
 # swapped for the fork below (it adds the WordPiece/Unigram models and the NFC
 # normalizer that upstream has not taken). third-party/include carries that
 # fork's headers, so linking upstream's libtokenizers.a here would compile
@@ -47,7 +47,7 @@ EXECUTORCH_REPO="https://github.com/pytorch/executorch.git"
 # Keep this commit in sync with the tokenizers submodule of the fork commit that
 # produced the current headers.tar.gz.
 TOKENIZERS_REPO="https://github.com/software-mansion-labs/pytorch-tokenizers.git"
-TOKENIZERS_COMMIT="56a30afbe2e6b4ca881d0fb7b961b9f9da156be4"
+TOKENIZERS_COMMIT="a03231a20a72036bf9a8e4a3b1d63494b90da1a6"
 
 cd "$(dirname "$0")/.."
 PACKAGE_DIR="$(pwd)"

--- a/packages/react-native-executorch/scripts/download-libs.js
+++ b/packages/react-native-executorch/scripts/download-libs.js
@@ -400,7 +400,15 @@ function isCacheValid(artifact) {
 
 function extract(tarball, destDir) {
   ensureDir(destDir);
-  execSync(`tar -xzf "${tarball}" -C "${destDir}"`);
+  // `-m` stamps extracted files with the extraction time instead of the mtime
+  // recorded in the archive. Without it, headers keep the timestamp they had
+  // when the release was cut, so upgrading to a NEWER artifacts release can
+  // hand ninja headers that look OLDER than object files from a previous build.
+  // Ninja then treats those objects as up to date and never recompiles them,
+  // and they get archived and linked against the new libraries -- which shows
+  // up as an undefined symbol for whatever API changed between the two
+  // releases, far away from the actual cause.
+  execSync(`tar -xzmf "${tarball}" -C "${destDir}"`);
 }
 
 // ---- Main ------------------------------------------------------------------

--- a/packages/react-native-executorch/scripts/download-libs.js
+++ b/packages/react-native-executorch/scripts/download-libs.js
@@ -390,9 +390,20 @@ function sha256(filePath) {
   return result.toString().split(' ')[0].trim();
 }
 
-function isCacheValid(artifact) {
+async function isCacheValid(artifact) {
   if (!fs.existsSync(artifact.cacheFile)) return false;
-  if (!fs.existsSync(artifact.cacheChecksumFile)) return false;
+  // Refresh the checksum from the release before trusting the cache. Comparing
+  // a cached tarball against a CACHED checksum lets a stale cache validate
+  // itself: the cache directory is keyed on the libs version, so a release
+  // re-cut at the same version is never picked up -- every artifact reports a
+  // cache hit and the old files are reused indefinitely.
+  try {
+    await download(artifact.checksumUrl, artifact.cacheChecksumFile);
+  } catch {
+    // Unreachable checksum (offline, rate limited): fall back to the cached
+    // one so an already-populated cache still builds without a network.
+    if (!fs.existsSync(artifact.cacheChecksumFile)) return false;
+  }
   const expectedChecksum = fs.readFileSync(artifact.cacheChecksumFile, 'utf8').trim();
   const actualChecksum = sha256(artifact.cacheFile);
   return expectedChecksum === actualChecksum;
@@ -440,7 +451,7 @@ async function main() {
   for (const artifact of artifacts) {
     console.log(`[react-native-executorch] Preparing ${artifact.name}...`);
 
-    if (isCacheValid(artifact)) {
+    if (await isCacheValid(artifact)) {
       console.log(`  ✓ Cache hit, skipping download`);
     } else {
       console.log(`  ↓ Downloading ${artifact.url}`);


### PR DESCRIPTION
## Description

Two fixes to `download-libs.js` that let a native artifacts upgrade actually reach a machine that has built before.

Upgrading to a newer artifacts release could leave a build with new libraries but stale object files, surfacing as an undefined symbol far from the cause:

```
ld.lld: error: undefined symbol: executorch::extension::make_tensor_ptr(
    std::vector<int>, void*, std::vector<unsigned char>, std::vector<int>,
    ScalarType, TensorShapeDynamism, std::function<void (void*)>)
>>> referenced by tensor_ptr.h:91
>>> neural_phonemizer.cpp.o in archive phonemis/libphonemis.a
```

`make_tensor_ptr` gained a trailing `Device` parameter in ExecuTorch 1.4.1, so an object compiled before the upgrade kept referencing the old 7 argument symbol that the new `libexecutorch.so` no longer exports. Phonemis was incidental, it just happens to call the changed API.

1. `extract()` passed `tar -xzf`, which keeps the mtime recorded in the archive. Extracted headers therefore carried the timestamp of the release cut, so newer headers could look older than existing objects. Ninja compared those mtimes, treated the objects as up to date, and never recompiled them. `-m` stamps files with the extraction time instead.

2. `isCacheValid()` compared the cached tarball against the cached checksum, so a stale cache validated itself. The cache directory is keyed only on the libs version, so a release re-cut at the same version was never picked up: every artifact reported a cache hit while a fresh clone got the new files. It now fetches the checksum from the release, falling back to the cached copy when unreachable so a populated cache still builds offline.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

With a cache already populated from an earlier release:

1. `node scripts/download-libs.js` and confirm the artifacts whose checksum changed report a cache miss and re-download, rather than `Cache hit, skipping download`.
2. `ls -la third-party/include/executorch/extension/tensor/tensor_ptr.h` and confirm the mtime is the extraction time, not the release date.
3. Build the Android app without wiping `.cxx` and confirm objects depending on changed headers are recompiled and the link succeeds.

Verified against the live `v0.10.0-libs` release: a warm cache holding the previous tarball validated as a hit under the old check and correctly misses under the new one. The mtime behaviour was reproduced in a minimal CMake and Ninja project, where a header with changed content but an older mtime produced `ninja: no work to do`.

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

The cache directory is still keyed only on `nativeLibsVersion`, so `RNET_BASE_URL` overrides pointing at a different release at the same version share a cache directory. Fetching the remote checksum makes that safe now, since the contents are compared rather than assumed, but keying the cache on the resolved base URL would be a further improvement.
