### PR TITLE
fix(models): point Whisper small MLX at the published int8 build

### DIFF
--- a/packages/react-native-executorch/src/constants/modelUrls.ts
+++ b/packages/react-native-executorch/src/constants/modelUrls.ts
@@ -865,7 +865,7 @@ export const WHISPER_BASE_EN_MODEL_MLX = `${URL_PREFIX}-whisper-base.en/${VERSIO
 export const WHISPER_SMALL_EN_TOKENIZER = `${URL_PREFIX}-whisper-small.en/${VERSION_TAG}/tokenizer.json`;
 export const WHISPER_SMALL_EN_MODEL_XNNPACK = `${URL_PREFIX}-whisper-small.en/${VERSION_TAG}/xnnpack/whisper_small_en_xnnpack_fp32.pte`;
 export const WHISPER_SMALL_EN_MODEL_COREML = `${URL_PREFIX}-whisper-small.en/${VERSION_TAG}/coreml/whisper_small_en_coreml_fp16.pte`;
-export const WHISPER_SMALL_EN_MODEL_MLX = `${URL_PREFIX}-whisper-small.en/${VERSION_TAG}/mlx/whisper_small_en_mlx_bf16.pte`;
+export const WHISPER_SMALL_EN_MODEL_MLX = `${URL_PREFIX}-whisper-small.en/${VERSION_TAG}/mlx/whisper_small_en_mlx_int8.pte`;
 
 export const WHISPER_TINY_TOKENIZER = `${URL_PREFIX}-whisper-tiny/${VERSION_TAG}/tokenizer.json`;
 export const WHISPER_TINY_MODEL_XNNPACK = `${URL_PREFIX}-whisper-tiny/${VERSION_TAG}/xnnpack/whisper_tiny_xnnpack_fp32.pte`;
@@ -880,7 +880,7 @@ export const WHISPER_BASE_MODEL_MLX = `${URL_PREFIX}-whisper-base/${VERSION_TAG}
 export const WHISPER_SMALL_TOKENIZER = `${URL_PREFIX}-whisper-small/${VERSION_TAG}/tokenizer.json`;
 export const WHISPER_SMALL_MODEL_XNNPACK = `${URL_PREFIX}-whisper-small/${VERSION_TAG}/xnnpack/whisper_small_xnnpack_fp32.pte`;
 export const WHISPER_SMALL_MODEL_COREML = `${URL_PREFIX}-whisper-small/${VERSION_TAG}/coreml/whisper_small_coreml_fp16.pte`;
-export const WHISPER_SMALL_MODEL_MLX = `${URL_PREFIX}-whisper-small/${VERSION_TAG}/mlx/whisper_small_mlx_bf16.pte`;
+export const WHISPER_SMALL_MODEL_MLX = `${URL_PREFIX}-whisper-small/${VERSION_TAG}/mlx/whisper_small_mlx_int8.pte`;
 
 /**
  * @category Models - Speech To Text


### PR DESCRIPTION
## Description

`WHISPER_SMALL_MODEL_MLX` and `WHISPER_SMALL_EN_MODEL_MLX` point at `whisper_small_mlx_bf16.pte` and `whisper_small_en_mlx_bf16.pte`, which are not published on the `v0.10.0` tag. Both URLs return 404, so the MLX variant of Whisper small fails to download.

The bf16 small builds were withdrawn because they OOM on an iPhone 16 (roughly 7.9x resident set, past the jetsam per-process limit). `int8` is what `software-mansion/react-native-executorch-whisper-small` and `-whisper-small.en` actually publish under `mlx/`, so both constants now point there.

Only small and small.en were affected. tiny and base still publish bf16 and are unchanged.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

Confirm the old URLs 404 and the new ones resolve:

```
curl -sI -o /dev/null -w '%{http_code}\n' \
  https://huggingface.co/software-mansion/react-native-executorch-whisper-small/resolve/v0.10.0/mlx/whisper_small_mlx_bf16.pte
curl -sI -o /dev/null -w '%{http_code}\n' \
  https://huggingface.co/software-mansion/react-native-executorch-whisper-small/resolve/v0.10.0/mlx/whisper_small_mlx_int8.pte
```

Then run the speech example on an iOS device and transcribe with `WHISPER_SMALL` on the MLX backend.

### Related issues
