### PR TITLE
[RNE Rewrite] fix(models): drop the preview/ segment from the RF-DETR keypoint paths

### DIFF
--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -613,15 +613,15 @@ const RFDETR_KEYPOINT_OPTS = {
   landmarks: COCO_LANDMARKS,
 };
 const RFDETR_KEYPOINT_XNNPACK_FP32: KeypointDetectorModel<'xyxy', CocoLandmark> = {
-  modelPath: `${BASE_URL}-rfdetr-keypoint/${NEXT_VERSION_TAG}/preview/xnnpack/rfdetr_keypoint_preview_xnnpack_fp32.pte`,
+  modelPath: `${BASE_URL}-rfdetr-keypoint/${NEXT_VERSION_TAG}/xnnpack/rfdetr_keypoint_preview_xnnpack_fp32.pte`,
   modelOpts: RFDETR_KEYPOINT_OPTS,
 };
 const RFDETR_KEYPOINT_COREML_FP16: KeypointDetectorModel<'xyxy', CocoLandmark> = {
-  modelPath: `${BASE_URL}-rfdetr-keypoint/${NEXT_VERSION_TAG}/preview/coreml/rfdetr_keypoint_preview_coreml_fp16.pte`,
+  modelPath: `${BASE_URL}-rfdetr-keypoint/${NEXT_VERSION_TAG}/coreml/rfdetr_keypoint_preview_coreml_fp16.pte`,
   modelOpts: RFDETR_KEYPOINT_OPTS,
 };
 const RFDETR_KEYPOINT_MLX_FP32: KeypointDetectorModel<'xyxy', CocoLandmark> = {
-  modelPath: `${BASE_URL}-rfdetr-keypoint/${NEXT_VERSION_TAG}/preview/mlx/rfdetr_keypoint_preview_mlx_fp32.pte`,
+  modelPath: `${BASE_URL}-rfdetr-keypoint/${NEXT_VERSION_TAG}/mlx/rfdetr_keypoint_preview_mlx_fp32.pte`,
   modelOpts: RFDETR_KEYPOINT_OPTS,
 };
 


### PR DESCRIPTION
## Description

`react-native-executorch-rfdetr-keypoint` published its backend directories under a `preview/` prefix, which none of its siblings do: `rfdetr-nano-detector` and `rfdetr-nano-segmentation` put `coreml/`, `mlx/` and `xnnpack/` at the repository root. A top level directory in these repositories denotes a model size, and this repository publishes one variant.

The `preview/` directory has been flattened away on the `v0.10.0` tag, so the three registry URLs drop that segment. File names are unchanged. `main` pins this model at `v0.9.0`, which still has the old layout and is untouched.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

Verify this repo structure: https://huggingface.co/software-mansion/react-native-executorch-rfdetr-keypoint/tree/v0.10.0

### Related issues
