### PR TITLE
[RNE Rewrite] fix(fetcher): stop rejecting a download longer than the server advertised

### DIFF
--- a/packages/react-native-executorch/__tests__/fetcher/download.test.ts
+++ b/packages/react-native-executorch/__tests__/fetcher/download.test.ts
@@ -205,6 +205,57 @@ describe('download — failure handling', () => {
   });
 });
 
+describe('download — completeness check', () => {
+  it('rejects a body shorter than the advertised length', async () => {
+    // The check exists so a truncated `.pte` cannot be promoted into the cache,
+    // where the existence-only hit check would serve it forever and the failure
+    // would only surface much later, at load.
+    fakeNet.serve(URL_A, { body: 'short', headLength: 4096 });
+    await expect(download(URL_A)).rejects.toThrow(/incomplete/);
+    expect(cachedPath('model.pte')).toBeUndefined();
+  });
+
+  it('accepts a body longer than the advertised length', async () => {
+    // No transfer can produce more bytes than the resource holds, so an
+    // over-long result disproves the expectation rather than the transfer.
+    // Observed in the wild: a HEAD against a signed Xet CDN URL answered 26 for
+    // a 1,835,532-byte model, and every retry answered the same, so a complete
+    // and valid file was rejected three times out of three.
+    const whole = 'the-whole-file-'.repeat(8); // 120 bytes against an advertised 26
+    fakeNet.serve(URL_A, { body: whole, headLength: 26 });
+
+    const path = await download(URL_A);
+
+    expect(fakeFs.readText(path)).toBe(whole);
+  });
+
+  it('skips the check when the server will not give a length', async () => {
+    fakeNet.serve(URL_A, { body: 'model-bytes', headOk: false });
+
+    const path = await download(URL_A);
+
+    expect(path).toBe(cachedPath('model.pte'));
+    expect(fakeFs.readText(path)).toBe('model-bytes');
+  });
+
+  it('believes x-linked-size over a content-length describing the redirect', async () => {
+    // Hugging Face answers a model URL with a 302 to a CDN and reports the
+    // object's real size in `x-linked-size` on every hop; `content-length` on
+    // the redirect hop describes the redirect body instead. Reading the wrong
+    // one is what makes a complete file look over-long.
+    fakeNet.serve(URL_A, { body: 'a'.repeat(64), headLength: 1082, linkedSize: 64 });
+
+    const path = await download(URL_A);
+
+    expect(fakeFs.readText(path)).toBe('a'.repeat(64));
+  });
+
+  it('still rejects a short body when x-linked-size is the header in play', async () => {
+    fakeNet.serve(URL_A, { body: 'short', headLength: 1082, linkedSize: 4096 });
+    await expect(download(URL_A)).rejects.toThrow(/incomplete/);
+  });
+});
+
 describe('download — cancellation', () => {
   it('rejects with DOWNLOAD_ABORTED when the signal is already aborted', async () => {
     fakeNet.serve(URL_A);

--- a/packages/react-native-executorch/__tests__/support/blobUtilMock.ts
+++ b/packages/react-native-executorch/__tests__/support/blobUtilMock.ts
@@ -110,6 +110,14 @@ export type Route = {
   error?: Error;
   /** Whether a `HEAD` request reports a content length. Defaults to `true`. */
   headOk?: boolean;
+  /**
+   * Content length a `HEAD` reports, when it disagrees with the body. Real
+   * servers do this: a HEAD against a signed CDN URL has been seen to answer a
+   * two-digit length for a two-megabyte file.
+   */
+  headLength?: number;
+  /** Value for `x-linked-size`, the header Hugging Face uses for LFS objects. */
+  linkedSize?: number;
 };
 
 type Request = { method: string; url: string; headers: Record<string, string> };
@@ -176,10 +184,18 @@ export const fakeFetch = async (
   if (!route) throw new Error(`fakeNet: no route registered for ${url}`);
   if (route.error) throw route.error;
 
-  const length = route.headOk === false ? null : String(bodyOf(route).length);
+  const length = route.headOk === false ? null : String(route.headLength ?? bodyOf(route).length);
+  const linked = route.linkedSize === undefined ? null : String(route.linkedSize);
   return {
     status: route.status ?? 200,
-    headers: { get: (name: string) => (name.toLowerCase() === 'content-length' ? length : null) },
+    headers: {
+      get: (name: string) => {
+        const key = name.toLowerCase();
+        if (key === 'content-length') return length;
+        if (key === 'x-linked-size') return linked;
+        return null;
+      },
+    },
   };
 };
 

--- a/packages/react-native-executorch/src/fetcher/fetcher.ts
+++ b/packages/react-native-executorch/src/fetcher/fetcher.ts
@@ -94,6 +94,12 @@ async function remoteSize(url: string, signal?: AbortSignal): Promise<number> {
 
   try {
     const res = await fetch(url, { method: 'HEAD', signal: controller.signal });
+    // `x-linked-size` first: Hugging Face serves an LFS or Xet object by
+    // redirecting to a CDN, and only this header describes the object on every
+    // hop. `content-length` on the redirect hop describes the redirect body,
+    // and a client that stops following early reads that instead of the file.
+    const linked = res.headers.get('x-linked-size');
+    if (linked && Number(linked) > 0) return Number(linked);
     const len = res.headers.get('content-length');
     return len ? Number(len) : 0;
   } catch {
@@ -121,6 +127,19 @@ async function expectedBytesFor(
   if (resolved && resolved > 0) return resolved;
   return remoteSize(url, signal);
 }
+
+// Whether a finished transfer is genuinely short of what the server advertised.
+//
+// Only a file SHORTER than expected is evidence of a truncated transfer. A file
+// longer than expected disproves the expectation instead: no transfer can
+// produce more bytes than the resource holds, so an over-long result means the
+// length was wrong, and rejecting on it turns a flaky HEAD into a model that can
+// never be downloaded. That is not hypothetical — a HEAD against a signed Xet
+// CDN URL answered `26` for a 1,835,532-byte `.pte`, and the retry answered the
+// same, so all three attempts rejected a complete and valid file. It also covers
+// the legitimate case of a server reporting a compressed length for a body the
+// client stores decompressed.
+const isTruncated = (got: number, want: number) => want > 0 && got < want;
 
 // Raised when a transfer reported success but the bytes on disk don't match
 // what the server advertised.
@@ -386,7 +405,7 @@ async function downloadUrlViaAndroidDownloadManager(
   // its final name forever — the existence-only cache check can't tell the
   // difference, and a truncated .pte only fails much later, at load.
   const expected = await expectedBytesFor(url, cb.expectedBytes, cb.signal);
-  if (expected > 0 && size !== expected) {
+  if (isTruncated(size, expected)) {
     await RNBlobUtil.fs.unlink(tmp).catch(() => {});
     throw incompleteError(url, size, expected);
   }
@@ -552,7 +571,7 @@ async function downloadUrlViaBackgroundSession(
   // only fail much later, at load.
   const expected = await expectedBytesFor(url, cb.expectedBytes, cb.signal);
   const assembled = await fileSize(part);
-  if (expected > 0 && assembled !== expected) {
+  if (isTruncated(assembled, expected)) {
     throw incompleteError(url, assembled, expected);
   }
 
@@ -731,13 +750,15 @@ async function downloadUrlViaIosStream(
   // existence, not size) and the truncated .pte fails at load with
   // InvalidProgram.
   const assembled = await fileSize(part);
-  if (expected > 0 && assembled !== expected) {
-    if (assembled > expected && canResume) {
-      // More bytes than the file has: a resume appended onto an offset that had
-      // moved on. The partial is unusable, so start over rather than fail.
-      await RNBlobUtil.fs.unlink(part).catch(() => {});
-      return downloadUrlViaIosStream(url, dest, cb, false);
-    }
+  if (expected > 0 && assembled > expected && canResume) {
+    // More bytes than the file has, on a transfer that resumed: the resume
+    // appended onto an offset that had moved on. The partial is unusable, so
+    // start over rather than fail. A fresh transfer that overshoots is a wrong
+    // expectation instead, and falls through to be accepted.
+    await RNBlobUtil.fs.unlink(part).catch(() => {});
+    return downloadUrlViaIosStream(url, dest, cb, false);
+  }
+  if (isTruncated(assembled, expected)) {
     // Short: keep the partial so the next call resumes and finishes it.
     throw incompleteError(url, assembled, expected);
   }


### PR DESCRIPTION
## Description

A benchmark run failed all three attempts at a style-transfer model with

```
Download of .../style_transfer_mosaic_xnnpack_int8.pte is incomplete (1835532 of 26 bytes)
```

It had received the complete, valid 1,835,532-byte file. The HEAD had answered 26, and every retry answered 26 too, so the model was not merely flaky but permanently undownloadable on that device. The `.pte` is fine: its repo serves it correctly, and a sibling variant in the same repo downloaded without trouble minutes later.

Two things were wrong.

`remoteSize` read `content-length`, which on a Hugging Face URL describes whichever hop the client stopped at. HF answers a model URL with a 302 to a CDN and reports the object's real length in `x-linked-size` on every hop, so that header is now preferred and `content-length` is the fallback.

The completeness check then treated any mismatch as a truncated transfer. Only a short file is evidence of that. No transfer can produce more bytes than the resource holds, so an over-long result disproves the expectation rather than the transfer, and failing on it converts one bad HEAD into a model that can never be fetched. It also caught a legitimate case: a server reporting a compressed length for a body the client stores decompressed.

The iOS resume path already restarted rather than failed when a resume appended onto an offset that had moved. That is genuine corruption and stays. What changes is that a fresh transfer overshooting an advertised length is now accepted on all three paths rather than rejected on two of them.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

The original failure reproduces on a Galaxy S26 Ultra by downloading `models.styleTransfer.MOSAIC.XNNPACK_INT8`, though it depends on the HEAD misbehaving and so is not reliable to trigger on demand.

The unit tests cover it deterministically:

```bash
cd packages/react-native-executorch && yarn jest __tests__/fetcher
```

The new `download — completeness check` block has five cases: a short body is still rejected, an over-long body is now accepted (the 26-bytes-for-a-large-file scenario), a missing length still skips the check, `x-linked-size` wins over a `content-length` describing the redirect, and a short body is still rejected when `x-linked-size` is the header in play.

`__tests__/support/blobUtilMock.ts` gains `headLength` and `linkedSize` route options, since the mock previously could not express a HEAD that disagrees with the body.

### Related issues

None filed; found while benchmarking for v0.10.0.

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

Full package suite green: 3710 tests across 30 suites, typecheck and lint clean.

Only the Android DownloadManager path was exercised against the real failure. The iOS streaming path is covered by unit tests but has not been run against a device.
