### PR TITLE
fix(fetcher): stop reporting progress before file sizes are known

### DIFF
--- a/packages/react-native-executorch/src/fetcher/fetcher.ts
+++ b/packages/react-native-executorch/src/fetcher/fetcher.ts
@@ -902,12 +902,25 @@ export async function download<T>(source: T, options: DownloadOptions = {}): Pro
   // that is corrected the moment its transfer reports a real length.
   const weights = measured.map((m) => m.size);
   const fractions: number[] = measured.map((m) => (m.cached ? 1 : 0));
-  const known = weights.filter((weight) => weight > 0);
-  const fallbackWeight = known.length ? known.reduce((a, b) => a + b, 0) / known.length : 1;
+  // A length lookup still in flight is not the same as one that failed. While
+  // any is outstanding every unmeasured file weighs the fallback, so the first
+  // small file to finish reads as a large share of the job: a tokenizer landing
+  // before a 3 GB model's HEAD comes back reported half the download complete,
+  // and the monotonic guard below then pinned the bar there until the model
+  // genuinely caught up. Say nothing until the sizes are actually in.
+  const settled = measured.map((m) => !m.pending);
 
   let reported = 0;
   const report = () => {
     if (!options.onProgress) return;
+    if (!settled.every(Boolean)) return;
+    // Recomputed per report rather than once: a file measured mid-flight has to
+    // stop counting as the fallback, and only files that stayed unmeasurable
+    // keep it.
+    const known = weights.filter((weight) => weight > 0);
+    const fallbackWeight = known.length
+      ? known.reduce((a, b) => a + b, 0) / known.length
+      : 1;
     let done = 0;
     let total = 0;
     for (let i = 0; i < weights.length; i++) {
@@ -929,10 +942,12 @@ export async function download<T>(source: T, options: DownloadOptions = {}): Pro
   // the HEAD, for a file whose download has not started yet.
   measured.forEach((m, i) => {
     m.pending?.then((size) => {
-      if (size > 0 && weights[i] === 0) {
-        weights[i] = size;
-        report();
-      }
+      if (size > 0 && weights[i] === 0) weights[i] = size;
+      // Settles either way: a HEAD that came back empty has still answered, and
+      // holding every other file's progress hostage to it would be worse than
+      // weighting this one by the fallback.
+      settled[i] = true;
+      report();
     });
   });
 


### PR DESCRIPTION
## Description

Progress jumped to a large value in the first second of a download and then froze there. An LLM config fetches a model plus its tokenizer files. HEAD lookups are started but deliberately not awaited, so every uncached file begins at size 0 and falls back to an equal weight. The tokenizer finishes long before the model's HEAD returns, so its completion reported a big share of the job, and the monotonic guard held the bar there until the model genuinely caught up.

Wait for every length lookup to settle before reporting a ratio over them. A lookup that comes back empty still counts as settled, so a failed HEAD cannot stall the other files, and the fallback weight is now recomputed per report so a file measured mid-flight stops counting as an estimate.

Stacked on #1414.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

1. Build `apps/nlp` or similar and open it.
2. Download any LLM model.
3. The bar stays near 0 while the lengths resolve, then climbs. Before this it jumped to roughly 50 percent immediately and sat there.

### Related issues

Found while testing the example apps from #1414 on a Galaxy S26 Ultra.

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
