### PR TITLE
feat(models): add Llama 3.2 MLX variants, drop the keypoint MLX one

### DIFF
--- a/apps/computer-vision/app/keypoint/index.tsx
+++ b/apps/computer-vision/app/keypoint/index.tsx
@@ -31,11 +31,6 @@ const MODEL_OPTIONS: ModelOption[] = [
     value: models.keypointDetection.RFDETR_KEYPOINT.COREML_FP16,
     disabled: Platform.OS !== 'ios',
   },
-  {
-    label: 'RF-DETR Keypoint (MLX FP32)',
-    value: models.keypointDetection.RFDETR_KEYPOINT.MLX_FP32,
-    disabled: Platform.OS !== 'ios',
-  },
 ];
 
 const VIEW_WIDTH = Dimensions.get('window').width - 32;

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -620,10 +620,6 @@ const RFDETR_KEYPOINT_COREML_FP16: KeypointDetectorModel<'xyxy', CocoLandmark> =
   modelPath: `${BASE_URL}-rfdetr-keypoint/${NEXT_VERSION_TAG}/coreml/rfdetr_keypoint_preview_coreml_fp16.pte`,
   modelOpts: RFDETR_KEYPOINT_OPTS,
 };
-const RFDETR_KEYPOINT_MLX_FP32: KeypointDetectorModel<'xyxy', CocoLandmark> = {
-  modelPath: `${BASE_URL}-rfdetr-keypoint/${NEXT_VERSION_TAG}/mlx/rfdetr_keypoint_preview_mlx_fp32.pte`,
-  modelOpts: RFDETR_KEYPOINT_OPTS,
-};
 
 // =============================================================================
 // Instance Segmentation
@@ -1611,6 +1607,16 @@ const LLAMA3_2_1B_BF16: LLMModel = {
   tokenizerPath: `${LLAMA3_2_BASE_URL}/tokenizer.json`,
   tokenizerConfigPath: `${LLAMA3_2_BASE_URL}/tokenizer_config.json`,
 };
+const LLAMA3_2_1B_MLX_INT4: LLMModel = {
+  modelPath: `${LLAMA3_2_BASE_URL}/1b/mlx/llama_3_2_1b_mlx_int4.pte`,
+  tokenizerPath: `${LLAMA3_2_BASE_URL}/tokenizer.json`,
+  tokenizerConfigPath: `${LLAMA3_2_BASE_URL}/tokenizer_config.json`,
+};
+const LLAMA3_2_3B_MLX_INT4: LLMModel = {
+  modelPath: `${LLAMA3_2_BASE_URL}/3b/mlx/llama_3_2_3b_mlx_int4.pte`,
+  tokenizerPath: `${LLAMA3_2_BASE_URL}/tokenizer.json`,
+  tokenizerConfigPath: `${LLAMA3_2_BASE_URL}/tokenizer_config.json`,
+};
 
 const SMOLLM2_BASE_URL = `${BASE_URL}-smolLm-2/${NEXT_VERSION_TAG}`;
 
@@ -2145,14 +2151,25 @@ export const models = {
       {
         XNNPACK_FP32: RFDETR_KEYPOINT_XNNPACK_FP32,
         COREML_FP16: RFDETR_KEYPOINT_COREML_FP16,
-        MLX_FP32: RFDETR_KEYPOINT_MLX_FP32,
       },
-      // Core ML over MLX: 144.0 ms against 272.3 on an iPhone 16, at 263 MB
-      // against 1304 MB. fp16 matches the fp32 build it replaced (landmarks to
-      // 1.04 px over 13 photos) but only under the GPU-only compute unit and an
-      // iOS17 deployment target — every other combination degrades it, and a
-      // macOS check passes builds the device gets wrong. See export-scripts
-      // MR !18 before re-exporting.
+      // No MLX variant. Measured on an iPhone 16 over 20 iterations after 3
+      // warmups, same 640px image: Core ML fp16 at 141.6 ms and 248 MB peak
+      // against MLX fp32 at 382.2 ms and 1153 MB, so 2.70x slower on 4.6x the
+      // memory. Core ML lowers the convolutional backbone to the ANE, which is
+      // what this workload wants; MLX is a Metal GPU path whose win is LLM
+      // decode.
+      //
+      // Quantizing MLX would not close it: the delegate can quantize matrix
+      // multiplies but has no quantized convolution, so int4 or int8 would
+      // shrink only the decoder's linear layers and leave the backbone, which
+      // dominates at this resolution, in fp32. The build was unpublished rather
+      // than left as a slower option nobody should pick.
+      //
+      // fp16 matches the fp32 build it replaced (landmarks to 1.04 px over 13
+      // photos) but only under the GPU-only compute unit and an iOS17
+      // deployment target — every other combination degrades it, and a macOS
+      // check passes builds the device gets wrong. See export-scripts MR !18
+      // before re-exporting.
       { ios: 'COREML_FP16' }
     ),
   },
@@ -2509,6 +2526,7 @@ export const models = {
     LLAMA3_2_1B: variants({
       XNNPACK_SPINQUANT: LLAMA3_2_1B_SPINQUANT,
       XNNPACK_BF16: LLAMA3_2_1B_BF16,
+      MLX_INT4: LLAMA3_2_1B_MLX_INT4,
     }),
     /**
      * Meta Llama 3.2 3B instruction-tuned multilingual language model. Delivers
@@ -2519,6 +2537,7 @@ export const models = {
     LLAMA3_2_3B: variants({
       XNNPACK_SPINQUANT: LLAMA3_2_3B_SPINQUANT,
       XNNPACK_BF16: LLAMA3_2_3B_BF16,
+      MLX_INT4: LLAMA3_2_3B_MLX_INT4,
     }),
     /**
      * Hugging Face SmolLM2 135M ultra-compact language model. Engineered for

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -2152,24 +2152,6 @@ export const models = {
         XNNPACK_FP32: RFDETR_KEYPOINT_XNNPACK_FP32,
         COREML_FP16: RFDETR_KEYPOINT_COREML_FP16,
       },
-      // No MLX variant. Measured on an iPhone 16 over 20 iterations after 3
-      // warmups, same 640px image: Core ML fp16 at 141.6 ms and 248 MB peak
-      // against MLX fp32 at 382.2 ms and 1153 MB, so 2.70x slower on 4.6x the
-      // memory. Core ML lowers the convolutional backbone to the ANE, which is
-      // what this workload wants; MLX is a Metal GPU path whose win is LLM
-      // decode.
-      //
-      // Quantizing MLX would not close it: the delegate can quantize matrix
-      // multiplies but has no quantized convolution, so int4 or int8 would
-      // shrink only the decoder's linear layers and leave the backbone, which
-      // dominates at this resolution, in fp32. The build was unpublished rather
-      // than left as a slower option nobody should pick.
-      //
-      // fp16 matches the fp32 build it replaced (landmarks to 1.04 px over 13
-      // photos) but only under the GPU-only compute unit and an iOS17
-      // deployment target — every other combination degrades it, and a macOS
-      // check passes builds the device gets wrong. See export-scripts MR !18
-      // before re-exporting.
       { ios: 'COREML_FP16' }
     ),
   },


### PR DESCRIPTION
## Description

Adds `MLX_INT4` for Llama 3.2 1B and 3B, and removes the RF-DETR keypoint `MLX_FP32` variant from the registry and the computer vision example.

**Llama 3.2 MLX**, iPhone 16, against XNNPACK SpinQuant:

| size | prompt | MLX tok/s | SpinQuant tok/s | speedup | MLX peak | XNN peak |
| --- | --- | --- | --- | --- | --- | --- |
| 1B | short | 47.47 | 38.51 | 1.23x | 562 MB | 1718 MB |
| 1B | long | 24.21 | 9.24 | 2.62x | 1263 MB | 1720 MB |
| 3B | short | 18.25 | 12.40 | 1.47x | 1095 MB | 3119 MB |
| 3B | long | 8.70 | 2.92 | 2.98x | 1516 MB | 3177 MB |

**Keypoint MLX removal**, same phone, 20 iterations after 3 warmups, same 640px image:

| variant | median | peak |
| --- | --- | --- |
| Core ML fp16 | 141.6 ms | 248 MB |
| MLX fp32 | 382.2 ms | 1153 MB |

2.70x slower on 4.6x the memory. Quantization would not close it: the MLX delegate has no quantized convolution, so int4 or int8 would shrink only the decoder's linear layers and leave the backbone in fp32. Core ML was already the iOS default, so this only removes the slower option. The files are unpublished from Hugging Face with a note recording these numbers.

### Introduces a breaking change?

- [x] Yes
- [ ] No

`models.keypointDetection.RFDETR_KEYPOINT.MLX_FP32` is gone. It was never the iOS default, so callers on `DEFAULT` are unaffected.

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [ ] Android

MLX is iOS only.

### Testing instructions

1. Run `models.llm.LLAMA3_2_1B.MLX_INT4` through the LLM pipeline in the NLP example; it should download from `v0.10.0`, load, and generate.
2. Open keypoint detection in the computer vision example; the MLX option is gone and Core ML FP16 remains.

### Related issues

Depends on #1414.

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

Both Llama URLs were verified to resolve at `v0.10.0` before wiring. Targets `@bh/v0.10-rewrite-and-legacy`.
