### PR TITLE
chore(docs): switch gitRevision to main and update source links

### DIFF
--- a/docs/docs/02-extensions/computer-vision/02-image-classification.md
+++ b/docs/docs/02-extensions/computer-vision/02-image-classification.md
@@ -220,5 +220,5 @@ Models](../../03-core-and-advanced/07-exporting-custom-models.md#using-a-built-i
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/cv/tasks/classification.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/cv/tasks/classification.ts)
+- [`src/extensions/cv/tasks/classification.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/cv/tasks/classification.ts)
   :::

--- a/docs/docs/02-extensions/computer-vision/03-object-detection.md
+++ b/docs/docs/02-extensions/computer-vision/03-object-detection.md
@@ -233,5 +233,5 @@ The pipeline automatically verifies that the model's exported input and output s
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/cv/tasks/objectDetection.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts)
+- [`src/extensions/cv/tasks/objectDetection.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/cv/tasks/objectDetection.ts)
   :::

--- a/docs/docs/02-extensions/computer-vision/04-pose-and-keypoints.md
+++ b/docs/docs/02-extensions/computer-vision/04-pose-and-keypoints.md
@@ -239,5 +239,5 @@ The pipeline automatically verifies that the model's exported input and output s
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/cv/tasks/keypointDetection.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/cv/tasks/keypointDetection.ts)
+- [`src/extensions/cv/tasks/keypointDetection.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/cv/tasks/keypointDetection.ts)
   :::

--- a/docs/docs/02-extensions/computer-vision/05-optical-character-recognition.md
+++ b/docs/docs/02-extensions/computer-vision/05-optical-character-recognition.md
@@ -227,5 +227,5 @@ The pipeline automatically verifies that the model's exported input and output s
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/cv/tasks/paddleOcr.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/cv/tasks/paddleOcr.ts)
+- [`src/extensions/cv/tasks/paddleOcr.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/cv/tasks/paddleOcr.ts)
   :::

--- a/docs/docs/02-extensions/computer-vision/06-semantic-segmentation.md
+++ b/docs/docs/02-extensions/computer-vision/06-semantic-segmentation.md
@@ -215,5 +215,5 @@ The pipeline automatically verifies that the model's exported input and output s
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/cv/tasks/semanticSegmentation.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts)
+- [`src/extensions/cv/tasks/semanticSegmentation.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts)
   :::

--- a/docs/docs/02-extensions/computer-vision/07-instance-segmentation.md
+++ b/docs/docs/02-extensions/computer-vision/07-instance-segmentation.md
@@ -233,5 +233,5 @@ The pipeline automatically verifies that the model's exported input and output s
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/cv/tasks/instanceSegmentation.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts)
+- [`src/extensions/cv/tasks/instanceSegmentation.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/cv/tasks/instanceSegmentation.ts)
   :::

--- a/docs/docs/02-extensions/computer-vision/08-style-transfer.md
+++ b/docs/docs/02-extensions/computer-vision/08-style-transfer.md
@@ -196,5 +196,5 @@ The pipeline automatically verifies that the model's exported input and output s
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/cv/tasks/styleTransfer.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/cv/tasks/styleTransfer.ts)
+- [`src/extensions/cv/tasks/styleTransfer.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/cv/tasks/styleTransfer.ts)
   :::

--- a/docs/docs/02-extensions/computer-vision/09-image-embeddings.md
+++ b/docs/docs/02-extensions/computer-vision/09-image-embeddings.md
@@ -202,5 +202,5 @@ The pipeline automatically verifies that the model's exported input and output s
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/cv/tasks/imageEmbedding.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/cv/tasks/imageEmbedding.ts)
+- [`src/extensions/cv/tasks/imageEmbedding.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/cv/tasks/imageEmbedding.ts)
   :::

--- a/docs/docs/02-extensions/computer-vision/10-text-to-image.md
+++ b/docs/docs/02-extensions/computer-vision/10-text-to-image.md
@@ -194,5 +194,5 @@ The pipeline automatically verifies that the model's exported methods (`encode`,
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/cv/tasks/sdxsTextToImage.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/cv/tasks/sdxsTextToImage.ts)
+- [`src/extensions/cv/tasks/sdxsTextToImage.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/cv/tasks/sdxsTextToImage.ts)
   :::

--- a/docs/docs/02-extensions/natural-language/02-llm-chat-and-generation.md
+++ b/docs/docs/02-extensions/natural-language/02-llm-chat-and-generation.md
@@ -364,6 +364,6 @@ The pipeline automatically verifies that the model's exported methods and KV cac
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/llm/tasks/llmChatSession.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts)
-- [`src/extensions/llm/llmRunner.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/llm/llmRunner.ts)
+- [`src/extensions/llm/tasks/llmChatSession.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts)
+- [`src/extensions/llm/llmRunner.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/llm/llmRunner.ts)
   :::

--- a/docs/docs/02-extensions/natural-language/03-text-embeddings.md
+++ b/docs/docs/02-extensions/natural-language/03-text-embeddings.md
@@ -216,5 +216,5 @@ The pipeline automatically verifies that the model's exported input and output s
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/nlp/tasks/textEmbedding.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/nlp/tasks/textEmbedding.ts)
+- [`src/extensions/nlp/tasks/textEmbedding.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/nlp/tasks/textEmbedding.ts)
   :::

--- a/docs/docs/02-extensions/natural-language/04-privacy-filter.md
+++ b/docs/docs/02-extensions/natural-language/04-privacy-filter.md
@@ -234,5 +234,5 @@ The pipeline automatically verifies that the model exports `forward(input_ids, a
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/nlp/tasks/privacyFilter.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/nlp/tasks/privacyFilter.ts)
+- [`src/extensions/nlp/tasks/privacyFilter.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/nlp/tasks/privacyFilter.ts)
   :::

--- a/docs/docs/02-extensions/natural-language/05-tokenizers.md
+++ b/docs/docs/02-extensions/natural-language/05-tokenizers.md
@@ -153,5 +153,5 @@ The native tokenizer automatically handles the model type, vocabulary tables, re
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/nlp/tasks/tokenization.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/nlp/tasks/tokenization.ts)
+- [`src/extensions/nlp/tasks/tokenization.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/nlp/tasks/tokenization.ts)
   :::

--- a/docs/docs/02-extensions/speech/02-text-to-speech.md
+++ b/docs/docs/02-extensions/speech/02-text-to-speech.md
@@ -212,6 +212,6 @@ Because Text-to-Speech architectures require distinct multi-model orchestration 
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/speech/tasks/kokoroTextToSpeech.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/speech/tasks/kokoroTextToSpeech.ts)
-- [`src/extensions/speech/tasks/supertonicTextToSpeech.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/speech/tasks/supertonicTextToSpeech.ts)
+- [`src/extensions/speech/tasks/kokoroTextToSpeech.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/speech/tasks/kokoroTextToSpeech.ts)
+- [`src/extensions/speech/tasks/supertonicTextToSpeech.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/speech/tasks/supertonicTextToSpeech.ts)
   :::

--- a/docs/docs/02-extensions/speech/03-speech-to-text.md
+++ b/docs/docs/02-extensions/speech/03-speech-to-text.md
@@ -236,5 +236,5 @@ The library provides ready-to-use Whisper models from the [Software Mansion Hugg
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/speech/tasks/whisperSpeechToText.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/speech/tasks/whisperSpeechToText.ts)
+- [`src/extensions/speech/tasks/whisperSpeechToText.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/speech/tasks/whisperSpeechToText.ts)
   :::

--- a/docs/docs/02-extensions/speech/04-voice-activity-detection.md
+++ b/docs/docs/02-extensions/speech/04-voice-activity-detection.md
@@ -241,5 +241,5 @@ The library provides the optimized FSMN-VAD model from the [Software Mansion Hug
 :::info Source Code
 View the implementation on GitHub:
 
-- [`src/extensions/speech/tasks/fsmnVoiceActivityDetection.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/rne-rewrite/packages/react-native-executorch/src/extensions/speech/tasks/fsmnVoiceActivityDetection.ts)
+- [`src/extensions/speech/tasks/fsmnVoiceActivityDetection.ts` ↗](https://github.com/software-mansion/react-native-executorch/blob/main/packages/react-native-executorch/src/extensions/speech/tasks/fsmnVoiceActivityDetection.ts)
   :::

--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -1,6 +1,5 @@
 {
-  "_todo": "Switch back to main once the rne-rewrite branch is merged into main",
-  "gitRevision": "rne-rewrite",
+  "gitRevision": "main",
   "skipErrorChecking": true,
   "compilerOptions": {
     "skipLibCheck": true


### PR DESCRIPTION
## Description

 1. Switched "gitRevision" from "rne-rewrite" to "main" (and removed the temporary _todo).
 2. Docs markdown guides: Updated all GitHub source code links (/blob/rne-rewrite/... ➔ /blob/main/...) across all extension guides.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

N/A

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
