### PR TITLE
docs: remove stale gallery app link from README table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ To explore all on-device capabilities in an interactive showcase app, check out 
 - [Quickstart](#quickstart)
   - [1. Installation](#1-installation)
   - [2. Run the Model](#2-run-the-model)
-- [Interactive Gallery App](#interactive-gallery-app)
 - [Documentation](#documentation)
 - [Powered by React Native ExecuTorch](#powered-by-react-native-executorch)
 - [Created by Software Mansion](#created-by-software-mansion)


### PR DESCRIPTION
## Description

Removes stale gallery app link from README table of contents.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

N/A

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
