### PR TITLE
fix(release): restore create-package.sh and set the core package version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: ''
+      dry-run:
+        description: 'Build and pack, but do not publish to npm. Everything up to the publish step runs unchanged.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -43,6 +48,7 @@ jobs:
       TAG: PLACEHOLDER
       # `inputs` is empty on the scheduled run, which is always a nightly.
       RELEASE_TYPE: ${{ inputs.release-type || 'nightly' }}
+      DRY_RUN: ${{ inputs.dry-run || false }}
       DIST_TAG_OVERRIDE: ${{ inputs.dist-tag || '' }}
     steps:
       - name: Checkout
@@ -144,4 +150,12 @@ jobs:
         run: mv ${{ env.EXECUTORCH_DIR }}/${{ env.PACKAGE_NAME }} .
 
       - name: Publish package to npm
+        if: ${{ env.DRY_RUN != 'true' }}
         run: npm publish $PACKAGE_NAME --tag ${{ env.TAG }} --provenance
+
+      # --provenance is omitted here on purpose: it needs the OIDC exchange,
+      # which a dry run should not perform. Everything before this point,
+      # including the build and the packed tarball, has already run unchanged.
+      - name: Publish package to npm (dry run)
+        if: ${{ env.DRY_RUN == 'true' }}
+        run: npm publish $PACKAGE_NAME --tag ${{ env.TAG }} --dry-run

--- a/packages/react-native-executorch-webrtc/package.json
+++ b/packages/react-native-executorch-webrtc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-executorch-webrtc",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "ExecuTorch WebRTC frame processor integration for react-native-webrtc",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-executorch",
-  "version": "0.0.0",
+  "version": "0.10.0",
   "nativeLibsVersion": "0.10.0",
   "description": "An easy way to run AI models in React Native with ExecuTorch",
   "main": "./lib/module/index.js",

--- a/packages/react-native-executorch/scripts/create-package.sh
+++ b/packages/react-native-executorch/scripts/create-package.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -euo pipefail
+
+# Builds the core package and produces the .tgz the npm publish workflow
+# uploads. Invoked as `./scripts/create-package.sh [generate_nightly_version]`
+# from packages/react-native-executorch.
+
+# Phonemis is a git submodule whose sources the podspec compiles directly
+# (see third-party/common/phonemis/src in react-native-executorch.podspec).
+# Init it explicitly so the files are present in the packed tarball.
+# Run from repo root so the submodule path resolves regardless of cwd.
+git -C "$(git rev-parse --show-toplevel)" submodule update --init --recursive \
+  packages/react-native-executorch/third-party/common/phonemis
+
+# Trim phonemis to what consumers need at build time. Done here (not via
+# package.json "files") because the submodule's own .gitignore has
+# `!scripts/build*` which npm-packlist honors and re-includes those files
+# despite our exclusion rules. Restore on exit so the working tree stays clean.
+PHONEMIS_DIR="third-party/common/phonemis"
+restore_phonemis() {
+  git -C "$PHONEMIS_DIR" checkout -- data test scripts requirements.txt 2>/dev/null || true
+}
+trap restore_phonemis EXIT
+rm -rf "$PHONEMIS_DIR/data" "$PHONEMIS_DIR/test" "$PHONEMIS_DIR/scripts"
+rm -f "$PHONEMIS_DIR/requirements.txt"
+
+yarn install --immutable
+
+# Match the version line by pattern, not by line number: `nativeLibsVersion`
+# sits next to it, so a positional edit rewrites the wrong field if either
+# moves.
+set_version() {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' -E "s/^(  \"version\": \")[^\"]*(\",)$/\1$1\2/" package.json
+  else
+    sed -i -E "s/^(  \"version\": \")[^\"]*(\",)$/\1$1\2/" package.json
+  fi
+}
+
+NIGHTLY=0
+if [ $# -ge 1 ] && [ "$1" = "generate_nightly_version" ]; then
+  NIGHTLY=1
+  VERSION=$(jq -r '.version' package.json)
+  GIT_COMMIT=$(git rev-parse HEAD)
+  DATE=$(date +%Y%m%d)
+  set_version "$VERSION-nightly-${GIT_COMMIT:0:7}-$DATE"
+fi
+
+# `prepare` builds both outputs the "files" list ships: lib/ via bob and the
+# legacy entry points via tsc. `bob build` alone leaves legacy/ unbuilt.
+yarn prepare
+
+npm pack
+
+# The workflow asserts no node_modules were packed by grepping build.log for
+# `node_modules/`, but nothing ever wrote that file, so the check silently
+# passed on a missing file. Write the packed file list into it so the assertion
+# is real. It has to be the tarball listing rather than the pack output: npm
+# pack runs the `prepare` lifecycle, and bob logs the path of the tsc binary it
+# falls back to, which lives under node_modules and trips the grep on a package
+# that is perfectly clean.
+TARBALL=$(ls -t ./*.tgz | head -1)
+tar -tzf "$TARBALL" > build.log
+
+if [ "$NIGHTLY" = "1" ]; then
+  set_version "$VERSION"
+fi
+
+echo "Done!"


### PR DESCRIPTION
Publishing from `main` is currently broken in two ways. Found while updating RELEASE.md (#1428).

1. `.github/workflows/npm-publish.yml` runs `./scripts/create-package.sh` from `packages/react-native-executorch`, but the rewrite scaffold (#1256) deleted that script. The workflow is byte-identical to the one on `release/0.9`, so it was never updated for the rewrite.
2. The core `package.json` still says `version: 0.0.0`, and that is the exact field the workflow reads to decide what it publishes. Set to `0.10.0`, matching the two adapter packages and `nativeLibsVersion`.

### Three deliberate changes from the release/0.9 copy

| change | why |
| --- | --- |
| `yarn prepare` instead of `yarn bob build` | `files` ships both `lib/` and `legacy/`; prepare is `bob build && tsc -p legacy/tsconfig.json`. Bob alone leaves `legacy/` out of the tarball. |
| version edited by pattern, not line 3 | `nativeLibsVersion` now sits directly below `version`, so a positional edit is one inserted line away from rewriting the wrong field. |
| `build.log` written with the packed file list | The workflow greps it to assert no `node_modules` were packed, but nothing ever wrote the file, so grep failed on a missing file and the check passed vacuously. |

The `build.log` content is the tarball listing rather than the pack output on purpose: `npm pack` runs the `prepare` lifecycle, and bob logs the path of the `tsc` binary it falls back to, which lives under `node_modules` and fails the grep on a package that is perfectly clean. That false positive showed up on the first test run.

### Verified by running the script

- builds `react-native-executorch-0.10.0.tgz`, 1020 files
- packed `package.json` says `0.10.0`
- zero `node_modules` entries in the tarball, and the workflow's grep now returns 0
- `lib/` 496 files, `legacy/` 294 files

Not covered: the workflow itself is unchanged here, so the first real publish is still the first end-to-end exercise of the CI path.