### PR TITLE
chore: drop the stale tokenizers-cpp submodule entry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "tokenizers-cpp"]
-	path = third-party/tokenizers-cpp
-	url = https://github.com/software-mansion-labs/tokenizers-cpp
 [submodule "third-party/googletest"]
 	path = third-party/googletest
 	url = https://github.com/google/googletest.git


### PR DESCRIPTION
`.gitmodules` declares three submodules; the tree has two.

| entry | gitlink in tree |
| --- | --- |
| `third-party/tokenizers-cpp` | **absent** |
| `third-party/googletest` | present |
| `packages/react-native-executorch/third-party/common/phonemis` | present |

The tokenizers migration (#781) removed the gitlink but left the config entry behind.

Harmless in practice, since `git submodule update` walks the gitlinks in the index rather than the config, which is why nobody hit it. Still misleading to anyone reading the file to learn what a checkout needs, and `create-package.sh` relies on the phonemis entry being accurate.

Verified `git submodule update --init` for both remaining paths still checks out cleanly after the edit.

Found while auditing root files for staleness ahead of the 0.10 release. Everything else at the root checked out: `.yarnrc.yml`'s React 19 peer suppression is still needed (`@signalwire/docusaurus-theme-llms-txt` is still at `1.0.0-alpha.9` with `react: ^18.0.0` peers), and `CONTRIBUTING.md`'s paths all still exist.