### PR TITLE
chore: fix the cspell ignore paths

### DIFF
--- a/.agents/skills/add-api-tests/SKILL.md
+++ b/.agents/skills/add-api-tests/SKILL.md
@@ -146,7 +146,7 @@ When adding or changing code under `src/`, verify that:
       every code `src/` raises out of the source and checks it is listed.
 - [ ] A new export is reflected in the `api/apiSurface` snapshot, and the change
       is intentional (a removal or rename is a breaking change).
-- [ ] Any new fake behaviour in `__tests__/support/` is faithful where fidelity
+- [ ] Any new fake behavior in `__tests__/support/` is faithful where fidelity
       changes an assertion, and its simplifications are commented.
 - [ ] A new `create<Task>` allocates through `createResourceScope()` and is
       listed in `__tests__/tasks/constructionFailure.test.ts`.

--- a/.cspell-wordlist.txt
+++ b/.cspell-wordlist.txt
@@ -377,3 +377,10 @@ jsonrepair
 SRCROOT
 fbjni
 reactnative
+colormaps
+chunker
+hermesversion
+libtokenizers
+pretokenizer
+repoint
+repoints

--- a/.cspell.json
+++ b/.cspell.json
@@ -1,7 +1,7 @@
 {
   "version": "0.2",
   "language": "en",
-  "ignorePaths": ["**/node_modules", "**/Pods", "**/readmes/**"],
+  "ignorePaths": ["**/node_modules", "**/Pods", "docs/versioned_docs/**"],
   "dictionaryDefinitions": [
     {
       "name": "project-words",

--- a/packages/react-native-executorch/cpp/tests/README.md
+++ b/packages/react-native-executorch/cpp/tests/README.md
@@ -125,7 +125,7 @@ automatically; they land in `fixtures/` and are gitignored rather than committed
 The useful part is that this needs **no XNNPACK delegate**, even though the
 fixture is XNNPACK-delegated. `ModelHostObject`'s constructor only calls
 `Module::load()` and `Module::method_meta()`, and in ExecuTorch both parse the
-program without initialising delegates — only `load_method()` resolves backends
+program without initializing delegates — only `load_method()` resolves backends
 (it fails with error 32, `NotFound`, in this build). So the entire load path is
 testable on the host:
 


### PR DESCRIPTION
## Description

`**/readmes/**` stopped matching anything when the docs rewrite (#1388) removed the directory, so the ignore list had one dead entry and no cover for the content that actually needs it.

- Replaced it with `docs/versioned_docs/**`. Those are frozen snapshots of the released 0.1 to 0.3 docs and carry 5 typos that cannot be fixed without rewriting published pages.
- Added the domain terms that were never listed: `colormaps`, `chunker`, `hermesversion`, `libtokenizers`, `pretokenizer`, `repoint`, `repoints`.
- Changed `behaviour` and `initialising` to US spelling in two files, so the dictionary stays strict rather than admitting both spellings everywhere.

`cspell` now exits 0 across all 1812 tracked `md` and `css` files. Before this it reported 14 issues.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

```
git ls-files '*.md' '*.css' | xargs npx cspell --config .cspell.json --quiet --no-must-find-files
```

### Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
