### PR TITLE
fix(webrtc): point the header search paths at legacy/cpp

### DIFF
--- a/packages/react-native-executorch-webrtc/android/CMakeLists.txt
+++ b/packages/react-native-executorch-webrtc/android/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(react-native-executorch REQUIRED CONFIG)
 target_include_directories(
   ${CMAKE_PROJECT_NAME}
   PRIVATE
-  "${RN_EXECUTORCH_DIR}/common"
+  "${RN_EXECUTORCH_DIR}/legacy/cpp"
   "${RN_EXECUTORCH_THIRD_PARTY}"
 )
 

--- a/packages/react-native-executorch-webrtc/react-native-executorch-webrtc.podspec
+++ b/packages/react-native-executorch-webrtc/react-native-executorch-webrtc.podspec
@@ -2,36 +2,54 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
+# package.json carries the npm-style "git+https://....git" form; CocoaPods wants
+# a plain URL for the homepage and a bare git URL for the source.
+repo_url = package["repository"]["url"].sub(/\Agit\+/, "").sub(/\.git\z/, "")
+
 Pod::Spec.new do |s|
   s.name         = "react-native-executorch-webrtc"
   s.version      = package["version"]
   s.summary      = package["description"]
-  s.homepage     = package["repository"]["url"]
+  s.homepage     = repo_url
   s.license      = package["license"]
   s.authors      = "Software Mansion"
 
-  s.platforms    = { :ios => "13.0" }
-  s.source       = { :git => package["repository"]["url"], :tag => "#{s.version}" }
+  # Has to match react-native-executorch, which requires iOS 17 for ExecuTorch
+  # and MLX. A lower floor here fails to resolve against that dependency.
+  s.platforms    = { :ios => "17.0" }
+  s.source       = { :git => "#{repo_url}.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm}"
 
-  # react-native-executorch exposes rnexecutorch/* headers via its header_dir,
-  # but executorch SDK headers and internal headers don't propagate to dependent
-  # pods, so we add them here. Resolve via Node from the podspec dir so it works
-  # under any layout (hoisted, monorepo, or app-local node_modules).
+  # react-native-executorch keeps its header search paths in pod_target_xcconfig,
+  # which does not propagate to dependent pods, so we repeat the two we need.
+  #
+  # ios/ExecutorchFrameProcessor.mm includes rnexecutorch/host_objects and
+  # rnexecutorch/models/semantic_segmentation. Those live under legacy/cpp: the
+  # rewritten cpp/ tree carries no rnexecutorch namespace and no model classes,
+  # so the frame processor is still on the legacy C++ API and has to move before
+  # legacy/ is dropped. third-party/include covers the executorch headers they
+  # pull in; nothing in the closure needs the cpuinfo, pthreadpool or tokenizer
+  # paths the core pod also lists.
+  #
+  # Resolve the core package via Node from the podspec dir so it works under any
+  # layout (hoisted, monorepo, or app-local node_modules).
   rne_pkg = `node --print "require.resolve('react-native-executorch/package.json', { paths: ['#{__dir__}'] })"`.strip
   rne_path = File.dirname(rne_pkg)
 
   s.pod_target_xcconfig = {
     "USE_HEADERMAP" => "YES",
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
-    "HEADER_SEARCH_PATHS" => "\"#{rne_path}/third-party/include\" \"#{rne_path}/common\""
+    "HEADER_SEARCH_PATHS" => "\"#{rne_path}/legacy/cpp\" \"#{rne_path}/third-party/include\"",
+    # ExecuTorch ships no simulator x86_64 slice, so the core pod drops that
+    # arch. A dependent that keeps it has nothing to link against.
+    "EXCLUDED_ARCHS[sdk=iphonesimulator*]" => "x86_64"
   }
 
   s.dependency "React-Core"
   s.dependency "react-native-executorch"
   s.dependency "opencv-rne", "~> 4.11.0"
-  s.dependency 'FishjamReactNativeWebrtc'
+  s.dependency "FishjamReactNativeWebrtc"
 
   install_modules_dependencies(s)
 end


### PR DESCRIPTION
## Description

Right, `react-native-executorch/common` no longer exists. It went away when the pre-0.10 API moved to `react-native-executorch/legacy`; the webrtc package was not touched by that move and has not been updated since it landed in #1080. The Android `CMakeLists.txt` carried the same dead path.

`ExecutorchFrameProcessor.mm` includes `rnexecutorch/host_objects/JSTensorViewIn.h` and `rnexecutorch/models/semantic_segmentation/BaseSemanticSegmentation.h`. On `main` those exist only under `legacy/cpp`: the rewritten `cpp/` tree has no `rnexecutorch` namespace and no model classes. Walking the include closure by hand, `legacy/cpp` plus `third-party/include` resolves all 92 headers, so no further search path is needed.

| | Was | Now |
| --- | --- | --- |
| header search path | `common` | `legacy/cpp` |
| Android include dir | `${RN_EXECUTORCH_DIR}/common` | `${RN_EXECUTORCH_DIR}/legacy/cpp` |
| deployment target | 13.0 | 17.0, matching the core pod |
| simulator x86_64 | kept | excluded, matching the core pod |
| homepage / source URL | `git+https://...` | `https://...` |

Worth flagging: this pins the frame processor to the legacy C++ API, so it has to move before `legacy/` can be dropped.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

The paths were verified against `origin/main` and against an installed core package; the podspec passes `ruby -c`. This package is excluded from CI (`yarn lint` and the build job both skip it), so a real `pod install` plus an iOS build of a Fishjam app is the check that matters.

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
