### PR TITLE
fix(ci): resolve the satellite version from package.json

### DIFF
--- a/.github/workflows/npm-publish-satellites.yml
+++ b/.github/workflows/npm-publish-satellites.yml
@@ -17,7 +17,7 @@ on:
         options: [stable, nightly, beta, alpha, rc]
         default: stable
       version:
-        description: Explicit version in x.y.z format (leave empty to infer automatically).
+        description: Explicit version in x.y.z format (leave empty to use the version in the package's package.json).
         type: string
         required: false
         default: ''
@@ -57,6 +57,40 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org/
 
+      # The action infers a stable version from the branch name, matching
+      # /^(\d+)\.(\d+)-stable$/ (see version-utils.js). This repo names its
+      # release branches release/0.9, so inference throws "Failed to parse
+      # stable version from branch" on every branch it could run from, main
+      # included. Resolve it here instead: the package.json version is what
+      # RELEASE.md already tells you to set, and it is what the core publish
+      # workflow uses. An explicit input still wins.
+      - name: Resolve the version to publish
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          PACKAGE: ${{ inputs.package }}
+        run: |
+          case "$PACKAGE" in
+            react-native-executorch-bare-resource-fetcher) DIR=packages/bare-resource-fetcher ;;
+            react-native-executorch-expo-resource-fetcher) DIR=packages/expo-resource-fetcher ;;
+            react-native-executorch-webrtc)                DIR=packages/react-native-executorch-webrtc ;;
+            *) echo "::error::unknown package: $PACKAGE"; exit 1 ;;
+          esac
+
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+            echo "using the version input: $VERSION"
+          else
+            VERSION=$(jq -r .version "$DIR/package.json")
+            echo "using $DIR/package.json: $VERSION"
+          fi
+
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::expected x.y.z, got '$VERSION'"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Publish react-native-executorch-bare-resource-fetcher
         if: ${{ inputs.package == 'react-native-executorch-bare-resource-fetcher' }}
         uses: software-mansion/npm-package-publish@22b6e632b4310c5c061a047bccc99d0cea88d2bb
@@ -67,7 +101,7 @@ jobs:
           # declarations, so build it before packing the satellite.
           install-dependencies-command: 'yarn install --immutable && yarn workspace react-native-executorch prepare'
           release-type: ${{ inputs.release-type }}
-          version: ${{ inputs.version }}
+          version: ${{ steps.version.outputs.version }}
           perform-git-operations: ${{ inputs.perform-git-operations }}
           dry-run: ${{ inputs.dry-run }}
 
@@ -79,7 +113,7 @@ jobs:
           package-json-path: 'packages/expo-resource-fetcher/package.json'
           install-dependencies-command: 'yarn install --immutable && yarn workspace react-native-executorch prepare'
           release-type: ${{ inputs.release-type }}
-          version: ${{ inputs.version }}
+          version: ${{ steps.version.outputs.version }}
           perform-git-operations: ${{ inputs.perform-git-operations }}
           dry-run: ${{ inputs.dry-run }}
 
@@ -91,6 +125,6 @@ jobs:
           package-json-path: 'packages/react-native-executorch-webrtc/package.json'
           install-dependencies-command: 'yarn install --immutable && yarn workspace react-native-executorch prepare'
           release-type: ${{ inputs.release-type }}
-          version: ${{ inputs.version }}
+          version: ${{ steps.version.outputs.version }}
           perform-git-operations: ${{ inputs.perform-git-operations }}
           dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
## Description

Leaving the `version` input empty failed with `Failed to parse stable version from branch: main` ([run](https://github.com/software-mansion/react-native-executorch/actions/runs/34195019164)).

The shared action derives a stable version from the branch name (`version-utils.js`):

```js
const BRANCH_REGEX = /^(\d+)\.(\d+)-stable$/;
```

This repo names its release branches `release/0.4` … `release/0.9`, so the documented "leave empty to infer automatically" could never work, on `main` or on a release branch alike.

Resolved in the workflow instead, from the package's own `package.json`. That is the version RELEASE.md step 3 already tells you to set for all four published packages, and it is what the core publish workflow reads, so the two now agree. An explicit input still wins, and either way the result is checked against `x.y.z` before it is passed on.

Two side effects worth noting:

- `beta` / `alpha` / `rc` hit the same branch parsing when the input was empty, so they were broken too.
- `nightly` did not throw, but derived its base by bumping the minor of whatever npm had tagged `latest`. It now starts from the repo, which is deterministic.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

The resolution step was run locally against all three packages plus the edge cases:

| input | result |
| --- | --- |
| empty, each of the three packages | `0.10.0`, read from that package's `package.json` |
| `0.11.0` | `0.11.0`, input wins |
| `0.11` | fails, `expected x.y.z` |
| unknown package | fails, `unknown package` |

Confirm with a satellite dry run leaving `version` empty: it should resolve `0.10.0` rather than throwing.

### Related issues

Found while dry-running the 0.10.0 satellite publishes.

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
