### PR TITLE
fix(release): point the last model at v0.10.0 and stamp the real telemetry version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -82,8 +82,9 @@ The release process of new minor version consists of the following steps:
 9. Create the release notes on GitHub.
 10. Bump `main` to the next development cycle in a single PR:
    - Bump `version` in `package.json` to `{MAJOR}.{NEXT_MINOR}.0` for the core package and both adapter packages.
-   - In `models.ts`, set `VERSION_TAG` to `resolve/v{MAJOR}.{MINOR}.0` (the version just published) and `NEXT_VERSION_TAG` to `resolve/v{MAJOR}.{NEXT_MINOR}.0`.
-   - Leave individual model URLs alone: those that shipped this cycle now resolve through `VERSION_TAG`, and only models re-exported next cycle move to `NEXT_VERSION_TAG`.
+   - In `models.ts`, add `VERSION_TAG` back as `resolve/v{MAJOR}.{MINOR}.0` (the version just published) and set `NEXT_VERSION_TAG` to `resolve/v{MAJOR}.{NEXT_MINOR}.0`. `VERSION_TAG` is absent between releases: every model resolves through `NEXT_VERSION_TAG` by the time one ships, which leaves the constant with no reader, and `noUnusedLocals` rejects that.
+   - Rewrite `${NEXT_VERSION_TAG}` to `${VERSION_TAG}` in every model URL that shipped this cycle. They cannot be left alone: the URLs name the constant, not the tag, so bumping `NEXT_VERSION_TAG` alone would silently repoint every model at a release that does not exist yet. Only a model re-exported next cycle moves back to `${NEXT_VERSION_TAG}`.
+   - Bump `LIB_VERSION` in `packages/react-native-executorch/src/fetcher/telemetry.ts` to match. A unit test asserts it equals the package version, so a missed bump fails CI rather than mislabelling every download event for the release.
    - Commit with the message 'Bump version to v{MAJOR}.{NEXT_MINOR}.0'.
 11. Create versioned docs by running from repo root `(cd docs && yarn docs:version {MAJOR}.{MINOR}.x)` (the 'x' part is intentional and is not to be substituted). Also, make sure that all the links in `api-reference` are not broken.
 12. Create a PR with the updated docs.

--- a/packages/react-native-executorch/__tests__/fetcher/telemetry.test.ts
+++ b/packages/react-native-executorch/__tests__/fetcher/telemetry.test.ts
@@ -8,6 +8,7 @@ import {
 import { fakeJsi } from '../support/fakeJsi';
 import { flush } from '../support/async';
 import { fakeNet } from '../support/blobUtilMock';
+import pkg from '../../package.json';
 
 const ANALYTICS = 'https://ai.swmansion.com/telemetry/downloads/api/downloads';
 const SWM_MODEL = 'https://huggingface.co/software-mansion/whisper-tiny/resolve/v1/model.pte';
@@ -74,6 +75,17 @@ describe('triggerDownloadEvent', () => {
     await flush();
 
     expect(postedPayload().modelName).toBe('model');
+  });
+
+  // LIB_VERSION is a literal in telemetry.ts rather than an import: see the
+  // comment there for why. This is what keeps it honest, so a release that
+  // forgets to bump it fails CI instead of reporting the previous version for
+  // its whole lifetime.
+  it('reports the published package version', async () => {
+    triggerDownloadEvent(SWM_MODEL);
+    await flush();
+
+    expect(postedPayload().libVersion).toBe(pkg.version);
   });
 
   it('reports the platform and the emulator flag from the native installer', async () => {

--- a/packages/react-native-executorch/src/fetcher/telemetry.ts
+++ b/packages/react-native-executorch/src/fetcher/telemetry.ts
@@ -4,10 +4,13 @@ import { rnexecutorchJsi } from '../native/bridge';
 // Anonymous download analytics endpoint.
 const DOWNLOAD_EVENT_ENDPOINT = 'https://ai.swmansion.com/telemetry/downloads/api/downloads';
 
-// Informational only.
-// TODO: source this from the package version once version handling lands.
-// See https://github.com/software-mansion/react-native-executorch/issues/1291
-const LIB_VERSION = '0.0.0';
+// Informational only. Kept in step with package.json by a unit test rather than
+// imported from it: the emitted module sits under lib/module/, where a relative
+// path to the manifest resolves to bob's `{"type":"module"}` stub, and a
+// self-referencing import would need package `exports` support in the consuming
+// bundler to load at all. A wrong value here is analytics noise; a failed
+// import would break the bundle.
+const LIB_VERSION = '0.10.0';
 
 // Anonymous analytics are on by default; apps opt out via setTelemetryEnabled.
 let telemetryEnabled = true;

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -172,7 +172,10 @@ function family<V extends Record<string, { readonly DEFAULT: unknown }>>(
 }
 
 const BASE_URL = 'https://huggingface.co/software-mansion/react-native-executorch';
-const VERSION_TAG = 'resolve/v0.9.0';
+// Every model in this release resolves through NEXT_VERSION_TAG. The
+// previous-release constant is reintroduced by the post-release bump (RELEASE.md
+// step 10) for the models that do not get re-exported next cycle; it is absent
+// rather than unused because noUnusedLocals rejects a constant nothing reads.
 const NEXT_VERSION_TAG = 'resolve/v0.10.0';
 
 // =============================================================================
@@ -1442,7 +1445,7 @@ const PRIVACY_FILTER_NEMOTRON_MLX_INT8: PrivacyFilterModel<PrivacyFilterNemotron
 // =============================================================================
 // Tokenizers
 // =============================================================================
-const ALL_MINILM_L6_V2_TOKENIZER = `${BASE_URL}-all-MiniLM-L6-v2/${VERSION_TAG}/tokenizer.json`;
+const ALL_MINILM_L6_V2_TOKENIZER = `${BASE_URL}-all-MiniLM-L6-v2/${NEXT_VERSION_TAG}/tokenizer.json`;
 
 // =============================================================================
 // OCR


### PR DESCRIPTION
## Description

Two version bugs found while checking the release preconditions, plus the RELEASE.md step that would have reintroduced one of them.

**1. One model still pinned to the previous release.** `all-MiniLM-L6-v2`'s tokenizer resolved through `VERSION_TAG` (v0.9.0) while the same file is fetched from v0.10.0 by the three MiniLM model entries a few hundred lines above. It was the only such reference left, against 288 already on `NEXT_VERSION_TAG`. Both tags serve the file today, so nothing was broken, but it is a stray pin to a release we are moving off.

That leaves `VERSION_TAG` with no reader and `noUnusedLocals` rejects it, so it is removed until the post-release bump re-adds it. An eslint exclusion cannot help here: the error is `tsc` TS6133, and an underscore prefix does not exempt a module-level constant either (checked both).

**2. Telemetry reported `libVersion: "0.0.0"` on every download event.** Its TODO pointed at #1291, which is closed and about `RNET_BASE_URL` in clang-tidy, so the reference is gone rather than carried forward.

It stays a literal rather than an import, and the code says why: the emitted module sits under `lib/module/`, where a relative path to the manifest resolves to bob's `{"type":"module"}` stub, and a self-referencing `react-native-executorch/package.json` import would depend on the consuming bundler supporting package `exports`. A stale string is analytics noise; a failed import breaks the bundle. A unit test asserts the posted `libVersion` equals `package.json`, so a missed bump fails CI.

**3. RELEASE.md step 10 was wrong.** It said to leave model URLs alone after bumping the tags, because the shipped ones "now resolve through `VERSION_TAG`". They do not: the URLs name the constant, not the tag, so bumping `NEXT_VERSION_TAG` to the next minor would silently repoint all 288 models at a release that does not exist. The step now says to rewrite the shipped URLs, to re-add `VERSION_TAG`, and to bump `LIB_VERSION`.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

`yarn workspace react-native-executorch typecheck` is clean and the full suite passes: 3842 tests, 30 suites, 4 snapshots (the apiSurface snapshot is unchanged, so dropping `VERSION_TAG` did not alter the public surface).

Separately, every `resolve/v0.10.0` URL the registry can build was probed against Hugging Face: **309 unique artifacts across 47 repos, all 200**. The only non-200 was a literal `${name}` from `models.ts:1208`, which builds `voice_styles/${name}.json` from a loop variable, so it is an artefact of extracting URLs statically rather than a missing file.

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
