### PR TITLE
docs: fix gallery app source links in 0.10 versioned docs

### DIFF
--- a/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/02-image-classification.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/02-image-classification.md
@@ -97,7 +97,7 @@ function MyComponent() {
 ```
 
 :::tip Full Interactive Example in Gallery App
-See [`src/app/(screens)/image-classification.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/image-classification.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with photo picker, result overlays, and latency tracking.
+See [`src/app/(screens)/image-classification.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/image-classification.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with photo picker, result overlays, and latency tracking.
 :::
 
 ## Output Format

--- a/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/03-object-detection.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/03-object-detection.md
@@ -98,7 +98,7 @@ function MyComponent() {
 ```
 
 :::tip Full Interactive Example in Gallery App
-See [`src/app/(screens)/object-detection.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/object-detection.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with photo picker, bounding box overlays, and latency tracking.
+See [`src/app/(screens)/object-detection.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/object-detection.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with photo picker, bounding box overlays, and latency tracking.
 :::
 
 ## Output Format

--- a/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/04-pose-and-keypoints.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/04-pose-and-keypoints.md
@@ -98,7 +98,7 @@ function MyComponent() {
 ```
 
 :::tip Full Interactive Example in Gallery App
-See [`src/app/(screens)/keypoint-detection.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/keypoint-detection.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with photo picker, skeleton keypoint overlays, and latency tracking.
+See [`src/app/(screens)/keypoint-detection.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/keypoint-detection.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with photo picker, skeleton keypoint overlays, and latency tracking.
 :::
 
 ## Output Format

--- a/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/05-optical-character-recognition.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/05-optical-character-recognition.md
@@ -94,7 +94,7 @@ function MyComponent() {
 ```
 
 :::tip Full Interactive Example in Gallery App
-See [`src/app/(screens)/ocr.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/ocr.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with photo picker, oriented text bounding boxes, and latency tracking.
+See [`src/app/(screens)/ocr.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/ocr.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with photo picker, oriented text bounding boxes, and latency tracking.
 :::
 
 ## Output Format

--- a/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/06-semantic-segmentation.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/06-semantic-segmentation.md
@@ -95,7 +95,7 @@ function MyComponent() {
 ```
 
 :::tip Full Interactive Example in Gallery App
-See [`src/app/(screens)/semantic-segmentation.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/semantic-segmentation.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with photo picker, custom colormap blending, and latency tracking.
+See [`src/app/(screens)/semantic-segmentation.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/semantic-segmentation.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with photo picker, custom colormap blending, and latency tracking.
 :::
 
 ## Output Format

--- a/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/07-instance-segmentation.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/07-instance-segmentation.md
@@ -99,7 +99,7 @@ function MyComponent() {
 ```
 
 :::tip Full Interactive Example in Gallery App
-See [`src/app/(screens)/instance-segmentation.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/instance-segmentation.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with photo picker, colored instance polygon overlays, and latency tracking.
+See [`src/app/(screens)/instance-segmentation.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/instance-segmentation.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with photo picker, colored instance polygon overlays, and latency tracking.
 :::
 
 ## Output Format

--- a/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/08-style-transfer.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/08-style-transfer.md
@@ -96,7 +96,7 @@ function MyComponent() {
 ```
 
 :::tip Full Interactive Example in Gallery App
-See [`src/app/(screens)/style-transfer.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/style-transfer.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with photo picker, side-by-side style comparisons, and latency tracking.
+See [`src/app/(screens)/style-transfer.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/style-transfer.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with photo picker, side-by-side style comparisons, and latency tracking.
 :::
 
 ## Output Format

--- a/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/09-image-embeddings.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/09-image-embeddings.md
@@ -94,7 +94,7 @@ function MyComponent() {
 ```
 
 :::tip Full Interactive Example in Gallery App
-See [`src/app/(screens)/image-embeddings.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/image-embeddings.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen combining image and text embeddings for real-time zero-shot photo ranking.
+See [`src/app/(screens)/image-embeddings.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/image-embeddings.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen combining image and text embeddings for real-time zero-shot photo ranking.
 :::
 
 ## Output Format

--- a/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/10-text-to-image.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/10-text-to-image.md
@@ -94,7 +94,7 @@ function MyComponent() {
 ```
 
 :::tip Full Interactive Example in Gallery App
-See [`src/app/(screens)/text-to-image.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/text-to-image.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with prompt suggestions, generation progress, and Skia canvas rendering.
+See [`src/app/(screens)/text-to-image.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/text-to-image.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen with prompt suggestions, generation progress, and Skia canvas rendering.
 :::
 
 ## Output Format

--- a/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/11-camera-integration.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/computer-vision/11-camera-integration.md
@@ -193,7 +193,7 @@ Vision models predict spatial outputs—such as bounding boxes (object detection
 - **Coordinate Remapping**: Mapping normalized or pixel `(x, y)` coordinates from the cropped tensor space back onto the visible camera viewport coordinates.
 
 :::tip Reference Implementation in Gallery App
-See [`src/app/(screens)/realtime-object-detection.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/realtime-object-detection.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete reference implementation of viewport coordinate transforms, orientation normalization, and real-time visual overlays.
+See [`src/app/(screens)/realtime-object-detection.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/realtime-object-detection.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete reference implementation of viewport coordinate transforms, orientation normalization, and real-time visual overlays.
 :::
 
 ## Performance & Best Practices

--- a/docs/versioned_docs/version-0.10.0/02-extensions/natural-language/02-llm-chat-and-generation.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/natural-language/02-llm-chat-and-generation.md
@@ -114,7 +114,7 @@ function MyChatComponent() {
 ```
 
 :::tip Full Interactive Example in Gallery App
-See [`src/app/(screens)/llm-chat.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/llm-chat.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable chat UI with token streaming, token/sec benchmarking, and message history.
+See [`src/app/(screens)/llm-chat.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/llm-chat.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable chat UI with token streaming, token/sec benchmarking, and message history.
 :::
 
 ## Understanding the Output & Turn Result

--- a/docs/versioned_docs/version-0.10.0/02-extensions/natural-language/03-text-embeddings.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/natural-language/03-text-embeddings.md
@@ -95,7 +95,7 @@ function MyComponent() {
 ```
 
 :::tip Full Interactive Example in Gallery App
-See [`src/app/(screens)/image-embeddings.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/image-embeddings.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen combining text and image embeddings for real-time cross-modal search.
+See [`src/app/(screens)/image-embeddings.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/image-embeddings.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen combining text and image embeddings for real-time cross-modal search.
 :::
 
 ## Output Format

--- a/docs/versioned_docs/version-0.10.0/02-extensions/natural-language/04-privacy-filter.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/natural-language/04-privacy-filter.md
@@ -95,7 +95,7 @@ function MyComponent() {
 ```
 
 :::tip Full Interactive Example in Gallery App
-See [`src/app/(screens)/privacy-filter.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/privacy-filter.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for an interactive redaction demo with highlighted spans and entity replacement.
+See [`src/app/(screens)/privacy-filter.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/privacy-filter.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for an interactive redaction demo with highlighted spans and entity replacement.
 :::
 
 ## Output Format

--- a/docs/versioned_docs/version-0.10.0/02-extensions/speech/02-text-to-speech.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/speech/02-text-to-speech.md
@@ -109,7 +109,7 @@ function SpeechComponent() {
 ```
 
 :::tip Full Interactive Example in Gallery App
-See [`src/app/(screens)/text-to-speech.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/text-to-speech.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen featuring voice selection, buffer queue streaming, Time-to-First-Audio (TTFA) benchmarking, and live waveform visualization.
+See [`src/app/(screens)/text-to-speech.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/text-to-speech.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen featuring voice selection, buffer queue streaming, Time-to-First-Audio (TTFA) benchmarking, and live waveform visualization.
 :::
 
 ## Output Format

--- a/docs/versioned_docs/version-0.10.0/02-extensions/speech/03-speech-to-text.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/speech/03-speech-to-text.md
@@ -121,7 +121,7 @@ function TranscriptionComponent() {
 ```
 
 :::tip Full Interactive Example in Gallery App
-See [`src/app/(screens)/speech-to-text.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/speech-to-text.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen featuring microphone controls, live audio streaming, and animated transcription UI.
+See [`src/app/(screens)/speech-to-text.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/speech-to-text.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen featuring microphone controls, live audio streaming, and animated transcription UI.
 :::
 
 ## Output Format & Live Streaming

--- a/docs/versioned_docs/version-0.10.0/02-extensions/speech/04-voice-activity-detection.md
+++ b/docs/versioned_docs/version-0.10.0/02-extensions/speech/04-voice-activity-detection.md
@@ -119,7 +119,7 @@ function VadComponent() {
 ```
 
 :::tip Full Interactive Example in Gallery App
-See [`src/app/(screens)/voice-activity-detection.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/3f13b59a1822638b61c565b9a47fd48a19c45551/src/app/(screens)/voice-activity-detection.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen featuring microphone controls, real-time speech indicators, and live audio streaming.
+See [`src/app/(screens)/voice-activity-detection.tsx`](<https://github.com/software-mansion-labs/react-native-executorch-gallery/blob/main/src/app/(screens)/voice-activity-detection.tsx>) in the [React Native ExecuTorch Gallery](https://github.com/software-mansion-labs/react-native-executorch-gallery) for a complete, runnable screen featuring microphone controls, real-time speech indicators, and live audio streaming.
 :::
 
 ## Live Microphone Streaming


### PR DESCRIPTION
## Description

Fix gallery app source links in 0.10 versioned docs that were incorrectly pinned when freezing the docs.

### Introduces a breaking change?

- [ ] Yes
- [ ] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

- Build the documentation locally and check that the links to gallery app in task doc pages work.

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
