### PR TITLE
fix: backport the 0.10.0 setup fixes (#1448, #1449, #1450, #1452)

### DIFF
--- a/.cspell-wordlist.txt
+++ b/.cspell-wordlist.txt
@@ -385,3 +385,5 @@ pretokenizer
 repoint
 repoints
 basenames
+xcconfig
+toggleable

--- a/.cspell-wordlist.txt
+++ b/.cspell-wordlist.txt
@@ -384,3 +384,4 @@ libtokenizers
 pretokenizer
 repoint
 repoints
+basenames

--- a/docs/docs/01-fundamentals/01-getting-started.md
+++ b/docs/docs/01-fundamentals/01-getting-started.md
@@ -86,10 +86,12 @@ React Native ExecuTorch requires:
 - **New Architecture** enabled
 - **React Native 0.83+** or **Expo SDK 55+** with [Development Builds](https://docs.expo.dev/develop/development-builds/introduction/) (**Expo Go is not supported** due to custom C++ native libraries)
 - **`react-native-worklets` 0.10 or newer** (`>=0.10.0 <0.13.0`)
-- **iOS 17.0+** / **Android 13+**
+- **iOS 17.0+** / **Android 13+** (`minSdkVersion` >= 26)
 
 For supported React Native versions, see the [Compatibility
-table](../05-other/01-compatibility.mdx).
+table](../05-other/01-compatibility.mdx). If an install or a build fails, see
+[Troubleshooting](../05-other/02-troubleshooting.md) — most of it comes down to
+the package manager skipping the postinstall hook, or to `use_frameworks!`.
 :::
 
 :::caution Expo SDK 55 and 56

--- a/docs/docs/01-fundamentals/01-getting-started.md
+++ b/docs/docs/01-fundamentals/01-getting-started.md
@@ -84,11 +84,28 @@ pnpm add react-native-executorch react-native-worklets react-native-blob-util
 React Native ExecuTorch requires:
 
 - **New Architecture** enabled
-- **React Native 0.81+** or **Expo SDK 54+** with [Development Builds](https://docs.expo.dev/develop/development-builds/introduction/) (**Expo Go is not supported** due to custom C++ native libraries)
+- **React Native 0.83+** or **Expo SDK 55+** with [Development Builds](https://docs.expo.dev/develop/development-builds/introduction/) (**Expo Go is not supported** due to custom C++ native libraries)
+- **`react-native-worklets` 0.10 or newer** (`>=0.10.0 <0.13.0`)
 - **iOS 17.0+** / **Android 13+**
 
 For supported React Native versions, see the [Compatibility
 table](../05-other/01-compatibility.mdx).
+:::
+
+:::caution Expo SDK 55 and 56
+Both bundle a `react-native-worklets` older than 0.10 — 0.7.4 on SDK 55, 0.8.3
+on SDK 56 — and `npx expo install` will pick that one. Install the version this
+library needs instead:
+
+```bash
+npm install react-native-worklets@^0.10.0
+```
+
+Any other package in your app that uses worklets has to be moved to a release
+built against the same version; two of them asking for different worklets gives
+you two incompatible native runtimes. Our own example apps reconcile them this
+way. **Expo SDK 54 cannot be supported**: it is React Native 0.81, below what
+worklets 0.10 accepts.
 :::
 
 ### Selecting native libraries

--- a/docs/docs/03-core-and-advanced/08-native-libraries.md
+++ b/docs/docs/03-core-and-advanced/08-native-libraries.md
@@ -47,6 +47,22 @@ Add a `react-native-executorch` block to your `package.json`:
 
 The three lists are merged, so you can pair high-level `features` with specific `backends` or `libs`. Re-run your package manager install after editing.
 
+:::note Monorepos
+The block is read from the directory the install was run in, then from every
+`package.json` above the installed package. A hoisted workspace resolves to the
+**root** either way, so put the block there; an app that keeps its own
+`node_modules` (pnpm, nohoist) is found from its own `package.json`.
+`node_modules/react-native-executorch/rne-build-config.json` records what was
+actually resolved, and the install log names the manifest it read.
+:::
+
+:::caution pnpm
+pnpm 10 and later do not run dependency build scripts unless you allow them, so
+the download never happens and the native build fails later on a missing file.
+Run `pnpm approve-builds react-native-executorch` once. See
+[Troubleshooting](../05-other/02-troubleshooting.md).
+:::
+
 ### Backends
 
 Hardware backends provide optimized execution kernels for specific processors and platforms. See the [ExecuTorch Backends documentation](https://docs.pytorch.org/executorch/stable/backends-section.html) for details on lowering and delegate compilation:

--- a/docs/docs/05-other/01-compatibility.mdx
+++ b/docs/docs/05-other/01-compatibility.mdx
@@ -17,7 +17,7 @@ React Native ExecuTorch supports only the [New Architecture](https://reactnative
     <thead>
       <tr>
         <th rowSpan={2}>React Native ExecuTorch</th>
-        <th colSpan={8}>React Native version</th>
+        <th colSpan={9}>React Native version</th>
       </tr>
       <tr>
         <th>0.78</th>
@@ -28,6 +28,7 @@ React Native ExecuTorch supports only the [New Architecture](https://reactnative
         <th>0.83</th>
         <th>0.84</th>
         <th>0.85</th>
+        <th>0.86</th>
       </tr>
     </thead>
     <tbody>
@@ -41,6 +42,7 @@ React Native ExecuTorch supports only the [New Architecture](https://reactnative
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
+        <td><div className={styles.partial}>untested&#8224;</div></td>
       </tr>
       <tr>
         <td><div className={styles.version}>0.9.x</div></td>
@@ -52,13 +54,15 @@ React Native ExecuTorch supports only the [New Architecture](https://reactnative
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
+        <td><div className={styles.partial}>untested&#8224;</div></td>
       </tr>
       <tr>
         <td><div className={styles.version}>0.10.x</div></td>
         <td><div className={styles.notSupported}>no</div></td>
         <td><div className={styles.notSupported}>no</div></td>
         <td><div className={styles.notSupported}>no</div></td>
-        <td><div className={styles.supported}>yes</div></td>
+        <td><div className={styles.notSupported}>no*</div></td>
+        <td><div className={styles.notSupported}>no*</div></td>
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
         <td><div className={styles.supported}>yes</div></td>
@@ -66,4 +70,78 @@ React Native ExecuTorch supports only the [New Architecture](https://reactnative
       </tr>
     </tbody>
   </table>
+</div>
+
+<div className={styles.footnote}>
+
+**\*** `react-native-executorch` 0.10 needs `react-native-worklets`
+`>=0.10.0 <0.13.0`, and worklets 0.10 is the first release to serialize an
+`ArrayBufferView` natively ([reanimated
+#9475](https://github.com/software-mansion/react-native-reanimated/pull/9475));
+older ones rebuild the view over its whole backing buffer, losing `byteOffset`
+and `length`. Worklets 0.10 in turn requires React Native 0.83+, which is what
+rules out 0.81 and 0.82.
+
+**†** Not verified. 0.8.x and 0.9.x were released before React Native 0.86 and
+are maintained on the `legacy` dist-tag only.
+
+</div>
+
+## Expo SDK
+
+`npx expo install` picks the `react-native-worklets` an SDK bundles, which is
+older than this library needs on SDK 55 and 56. Both work once you ask for the
+versions below explicitly — Reanimated pins worklets exactly, so it moves with
+it.
+
+<div className={styles.compatibility}>
+  <table>
+    <thead>
+      <tr>
+        <th>Expo SDK</th>
+        <th>React Native</th>
+        <th>Bundled worklets</th>
+        <th>react-native-executorch 0.10.x</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><div className={styles.version}>54</div></td>
+        <td>0.81</td>
+        <td>0.5.1</td>
+        <td><div className={styles.notSupported}>no</div></td>
+      </tr>
+      <tr>
+        <td><div className={styles.version}>55</div></td>
+        <td>0.83</td>
+        <td>0.7.4</td>
+        <td><div className={styles.partial}>needs explicit versions</div></td>
+      </tr>
+      <tr>
+        <td><div className={styles.version}>56</div></td>
+        <td>0.85</td>
+        <td>0.8.3</td>
+        <td><div className={styles.partial}>needs explicit versions</div></td>
+      </tr>
+      <tr>
+        <td><div className={styles.version}>57</div></td>
+        <td>0.86</td>
+        <td>0.10.1</td>
+        <td><div className={styles.supported}>yes</div></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div className={styles.footnote}>
+
+On SDK 55 and 56, install both:
+
+```bash
+npm install react-native-worklets@^0.10.0 react-native-reanimated@^4.5.0
+```
+
+SDK 54 is React Native 0.81, below what worklets 0.10 accepts, so no
+combination of versions works there.
+
 </div>

--- a/docs/docs/05-other/02-troubleshooting.md
+++ b/docs/docs/05-other/02-troubleshooting.md
@@ -1,0 +1,166 @@
+---
+title: Troubleshooting
+slug: /other/troubleshooting
+description: 'Build and install failures caused by a project setup React Native ExecuTorch cannot control, and what to do about each.'
+keywords:
+  [react native executorch, troubleshooting, use_frameworks, pnpm, opencv, cocoapods, simulator]
+---
+
+Failures that come from how a project is set up rather than from the library
+itself. Each one is reproducible, so the symptom is quoted exactly — search
+this page for the error you got.
+
+## `Build input files cannot be found` after install
+
+```
+error: Build input files cannot be found:
+'.../XnnpackBackend.xcframework/ios-arm64-simulator/libXnnpackBackend.a'
+```
+
+The native artifacts are not in the npm tarball. They are downloaded by a
+**postinstall** hook, and your package manager skipped it:
+
+- **pnpm 10 and later block dependency build scripts by default** and print
+  `Ignored build scripts: react-native-executorch` during install.
+- `--ignore-scripts`, and `npm ci --ignore-scripts`, do the same.
+
+Nothing fails at that point — not even `pod install`, which does not check that
+a vendored framework exists — so the error only appears once Xcode goes looking
+for the file. Recent versions fail during `pod install` (and during the Android
+configure phase) with this fix in the message instead. Re-run the hook:
+
+```bash
+pnpm approve-builds react-native-executorch   # pnpm
+npm rebuild react-native-executorch           # npm
+node node_modules/react-native-executorch/scripts/download-libs.js
+```
+
+## `Multiple commands produce .../Headers/Types.h`
+
+An app built with `use_frameworks!` — directly, as Firebase requires, or through
+expo-build-properties' `"useFrameworks": "static"` — makes CocoaPods build the
+pod as a framework and flat-copy its public headers into one directory.
+Versions up to 0.10.0 published every header, and several share a basename, so
+the build fails while it is still being planned.
+
+Update the library. On 0.10.0 exactly, force the pod back to a static library:
+
+```ruby
+pre_install do |installer|
+  installer.pod_targets.each do |pod|
+    if pod.name == 'react-native-executorch'
+      def pod.build_type
+        Pod::BuildType.static_library
+      end
+    end
+  end
+end
+```
+
+Expo SDK 55 and later already do this for you: their autolinking downgrades
+every pod that vendors an `.xcframework` to a static library, which is why an
+Expo app usually never sees this. Setting `buildReactNativeFromSource: true`
+turns that off again.
+
+## `transitive dependencies that include statically linked binaries`
+
+```
+[!] The 'Pods-YourApp' target has transitive dependencies that include
+statically linked binaries: (.../opencv-rne/opencv2.xcframework)
+```
+
+`use_frameworks!` with no argument means **dynamic** linkage, which CocoaPods
+refuses to combine with a statically linked dependency. Ask for static
+frameworks instead:
+
+```ruby
+use_frameworks! :linkage => :static
+```
+
+## `frameworks with conflicting names: opencv2.xcframework`
+
+Another pod vendors OpenCV under the same framework name — `react-native-fast-opencv`
+(via `FastOpenCV-iOS`) is the common one — and CocoaPods installs only one
+framework called `opencv2`.
+
+Recent versions handle this for you: when `react-native-fast-opencv` is
+installed alongside this library, we depend on the OpenCV it vendors instead of
+our own, and compile against that copy's headers. `pod install` prints which one
+it chose. Nothing to configure, and both libraries work in the same app.
+
+To force the choice, name the pod that should provide OpenCV:
+
+```json
+{
+  "react-native-executorch": {
+    "opencvPod": "opencv-rne"
+  }
+}
+```
+
+`opencv-rne` is ours; any pod that vendors an `opencv2.xcframework` is accepted.
+We only use `opencv2/core.hpp` and `opencv2/imgproc.hpp`, so an OpenCV 4.x build
+serves. Forcing ours while another OpenCV is installed brings the conflict back,
+which is what the setting is for when you would rather drop the other library.
+
+If you do not use this library's vision tasks at all, drop its OpenCV instead:
+
+```json
+{
+  "react-native-executorch": {
+    "backends": ["xnnpack", "coreml", "mlx"],
+    "libs": ["phonemis"]
+  }
+}
+```
+
+Re-run your package manager's install afterwards. See
+[Native Libraries](../03-core-and-advanced/08-native-libraries.md) for what each
+entry covers — leaving `opencv` out disables every computer-vision task.
+
+## `None of the architectures in ARCHS (x86_64) are valid`
+
+The library ships `arm64` slices only, and the podspec excludes `x86_64` from
+simulator builds. **Intel Macs cannot build for the iOS simulator**, and neither
+can an Apple silicon Mac running Xcode under Rosetta, or an Intel macOS CI
+image. Use an Apple silicon machine, or a physical device.
+
+## `The platform of the target ... may not be compatible`
+
+```
+[!] The platform of the target `YourApp` (iOS 16.4) may not be compatible with
+`react-native-executorch (0.10.0)` which has a minimum requirement of iOS 17.0.
+```
+
+This is a **warning**, so `pod install` still succeeds and the failure surfaces
+later. The library needs iOS 17. In an Expo app, set it explicitly — the default
+is lower:
+
+```json
+[
+  "expo-build-properties",
+  { "ios": { "deploymentTarget": "17.0" } }
+]
+```
+
+## The `react-native-executorch` config block is ignored
+
+The postinstall hook reads the block from the directory where the install was
+invoked (`INIT_CWD`), then from every `package.json` above the installed
+package. In a hoisted monorepo both land on the **workspace root**, so a block
+in `apps/mobile/package.json` is never seen — put it in the root `package.json`
+instead. The install log names the manifest that won, and
+`node_modules/react-native-executorch/rne-build-config.json` records which flags
+were written.
+
+## An old Android device or emulator crashes on load
+
+Native code is shipped for `arm64-v8a` and `x86_64` only. A build that also
+produces `armeabi-v7a` or `x86` splits (React Native's default
+`reactNativeArchitectures` lists all four) will package those without the
+library's `.so`, and loading it fails at runtime on such a device. Restrict the
+app to the supported ABIs:
+
+```properties
+reactNativeArchitectures=arm64-v8a,x86_64
+```

--- a/docs/src/components/CompatibilityTable/styles.module.css
+++ b/docs/src/components/CompatibilityTable/styles.module.css
@@ -56,3 +56,22 @@
   background-color: var(--swm-red-dark-140);
   color: var(--swm-red-dark-80);
 }
+
+.partial {
+  background-color: var(--swm-yellow-light-40);
+  color: var(--swm-yellow-dark-120);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+[data-theme='dark'] .partial {
+  background-color: var(--swm-yellow-dark-140);
+  color: var(--swm-yellow-dark-80);
+}
+
+.footnote {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+}

--- a/packages/react-native-executorch/.gitignore
+++ b/packages/react-native-executorch/.gitignore
@@ -14,3 +14,4 @@ cpp/tests/build/
 
 # Model and tokenizer fixtures downloaded by scripts/fetch-test-fixtures.sh
 cpp/tests/fixtures/
+include-external-opencv

--- a/packages/react-native-executorch/__tests__/README.md
+++ b/packages/react-native-executorch/__tests__/README.md
@@ -79,7 +79,7 @@ because a factory that throws part-way now releases what it had allocated
 | `tasks/` | One suite per task pipeline, plus the shared construction-failure behavior. `remainingTasks.ts` holds the pipelines that only get schema acceptance and disposal |
 | `hooks/` | `useModel`, `useResourceDownload`, and the task hooks end to end |
 | `extensions/` | The pure-TypeScript helpers: box/point scaling, seeded generators |
-| `api/` | Export snapshot, model registry rules, label constants, source-level conventions |
+| `api/` | Export snapshot, model registry rules, label constants, source-level conventions, the podspec's public headers |
 | `support/` | The fake runtime, the mocks, and the fixtures |
 
 ## What is deliberately not covered

--- a/packages/react-native-executorch/__tests__/api/nativeLibsConfig.test.ts
+++ b/packages/react-native-executorch/__tests__/api/nativeLibsConfig.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Where `scripts/download-libs.js` looks for the `react-native-executorch`
+ * block.
+ *
+ * The block decides which native artifacts get downloaded, and it is read at
+ * install time from `INIT_CWD` — the directory the install was invoked in. In a
+ * workspace that is the repository root, so a block in `apps/mobile/package.json`
+ * used to be ignored silently: the install succeeded, every backend came down,
+ * and the app was simply larger than asked for. Worse, an app declaring
+ * `"libs": []` to dodge an OpenCV conflict got OpenCV anyway.
+ *
+ * So the lookup also walks up from the installed package, which lands on the app
+ * whenever it has its own `node_modules` (pnpm, nohoist). These suites pin both
+ * paths, and the precedence between them.
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const SCRIPT = '../../scripts/download-libs.js';
+
+/** npm's own fallback for `INIT_CWD`, spelled the way npm spells it. */
+const LOCAL_PREFIX = 'npm_config_local_prefix';
+
+/**
+ * Loads the script with `INIT_CWD` pointing at `initCwd`.
+ *
+ * The variable stays set until `afterEach` restores it: the lookup reads it
+ * when it is called, not when the module is loaded.
+ */
+function loadWith(initCwd: string | undefined) {
+  if (initCwd === undefined) delete process.env.INIT_CWD;
+  else process.env.INIT_CWD = initCwd;
+  jest.resetModules();
+  return require(SCRIPT);
+}
+
+function writeManifest(dir: string, block?: unknown) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify(
+      block === undefined ? { name: 'app' } : { 'name': 'app', 'react-native-executorch': block },
+      null,
+      2
+    )
+  );
+}
+
+describe('native libs user config', () => {
+  let root: string;
+  let outerInitCwd: string | undefined;
+  let outerLocalPrefix: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'rne-config-'));
+    outerInitCwd = process.env.INIT_CWD;
+    outerLocalPrefix = process.env[LOCAL_PREFIX];
+    // npm_config_local_prefix is the fallback for INIT_CWD; a stray one from the
+    // outer yarn process would leak into every case.
+    delete process.env[LOCAL_PREFIX];
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    if (outerInitCwd === undefined) delete process.env.INIT_CWD;
+    else process.env.INIT_CWD = outerInitCwd;
+    if (outerLocalPrefix === undefined) delete process.env[LOCAL_PREFIX];
+    else process.env[LOCAL_PREFIX] = outerLocalPrefix;
+  });
+
+  it('reads the block from the directory the install ran in', () => {
+    writeManifest(root, { backends: ['xnnpack'], libs: [] });
+    const { findUserConfig } = loadWith(root);
+
+    const { config, manifest } = findUserConfig();
+
+    expect(config).toEqual({ backends: ['xnnpack'], libs: [] });
+    expect(manifest).toBe(join(root, 'package.json'));
+  });
+
+  it('prefers the install directory over anything above the package', () => {
+    writeManifest(root, { backends: ['coreml'] });
+    const { findUserConfig } = loadWith(root);
+
+    expect(findUserConfig().config).toEqual({ backends: ['coreml'] });
+  });
+
+  it('reports no block when the manifest has none', () => {
+    writeManifest(root);
+    const { findUserConfig } = loadWith(root);
+
+    expect(findUserConfig().config).toBeUndefined();
+  });
+
+  it('falls back to enabling everything when there is no block', () => {
+    writeManifest(root);
+    const { readUserConfig, ALL_BACKENDS, ALL_LIBS } = loadWith(root);
+
+    const resolved = readUserConfig();
+
+    expect(new Set(resolved.backends)).toEqual(new Set(ALL_BACKENDS));
+    expect(new Set(resolved.libs)).toEqual(new Set(ALL_LIBS));
+  });
+
+  it('survives an unreadable manifest', () => {
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'package.json'), '{ not json');
+    const { findUserConfig } = loadWith(root);
+
+    expect(() => findUserConfig()).not.toThrow();
+  });
+
+  it('expands features into backends and libs', () => {
+    writeManifest(root, { features: ['textToSpeech'] });
+    const { readUserConfig } = loadWith(root);
+
+    const resolved = readUserConfig();
+
+    expect(resolved.libs).toContain('phonemis');
+    expect(resolved.backends).toContain('xnnpack');
+  });
+
+  it('rejects an unknown feature by name', () => {
+    writeManifest(root, { features: ['telepathy'] });
+    const { readUserConfig } = loadWith(root);
+
+    expect(() => readUserConfig()).toThrow(/telepathy/);
+  });
+
+  it('carries opencvPod through to the build config the podspec reads', () => {
+    // Which pod provides opencv2 is the app's call when it already carries an
+    // OpenCV: the podspec reads this key, and it only reaches the podspec if
+    // the config script writes it out.
+    writeManifest(root, { opencvPod: 'FastOpenCV-iOS' });
+    const { readUserConfig } = loadWith(root);
+
+    expect(readUserConfig().opencvPod).toBe('FastOpenCV-iOS');
+  });
+
+  it('leaves opencvPod unset when the app does not ask for one', () => {
+    // Absent means "decide for me", which is what lets the podspec prefer an
+    // OpenCV the app already has. Writing a default here would freeze that.
+    writeManifest(root, { backends: ['xnnpack'] });
+    const { readUserConfig } = loadWith(root);
+
+    expect(readUserConfig().opencvPod).toBeUndefined();
+  });
+});

--- a/packages/react-native-executorch/__tests__/api/podspecAttributes.test.ts
+++ b/packages/react-native-executorch/__tests__/api/podspecAttributes.test.ts
@@ -1,0 +1,171 @@
+/**
+ * The attributes the iOS podspec actually assigns, per build config.
+ *
+ * `react-native-executorch.podspec` is Ruby, and `pod install` is the only
+ * thing that ever runs it. Nothing in JS CI evaluates it, so a misplaced `end`
+ * type-checks, lints, spell-checks and reviews clean, then reaches users as a
+ * link error in an app we never built ourselves. That is exactly what happened
+ * in #1450: the `if enable_opencv` guard around the OpenCV pod selection was
+ * left open until the bottom of the spec, so an app that turned OpenCV off got
+ * a pod with no `HEADER_SEARCH_PATHS`, no `static_framework` and no
+ * `ExecutorchLib.xcframework`.
+ *
+ * The config matrix is the part that rots: `rne-build-config.json` is written
+ * by the postinstall hook from the consumer's `package.json` config block, and
+ * our own example apps all take one row of it. Every other row only exists on
+ * a user's machine.
+ *
+ * So this suite evaluates the real podspec under a stubbed `Pod::Spec` and
+ * asserts on what it assigned. The stub records attribute names rather than
+ * modelling CocoaPods: what breaks is an attribute going missing, not its
+ * value being subtly wrong.
+ */
+import { execFileSync } from 'child_process';
+import { join } from 'path';
+
+const PACKAGE_ROOT = join(__dirname, '..', '..');
+
+/**
+ * Evaluates the podspec with `rne-build-config.json` faked to `config`, or
+ * absent when `config` is `null`.
+ *
+ * `File.exist?` and `File.read` are intercepted for that one path instead of
+ * writing the file: a developer's real config sits there, and a test suite
+ * must not overwrite it. The vendored-artifact guard is satisfied the same
+ * way, through `File.directory?`, so the suite runs on a checkout that never
+ * downloaded the native libs (which CI is).
+ */
+function assignedAttributes(config: Record<string, boolean> | null): string[] {
+  // Ruby 2.6 syntax throughout: that is the system Ruby on macOS, and the one
+  // a contributor who has never installed a newer one runs CocoaPods with.
+  const harness = `
+    require "json"
+
+    $assigned = []
+    # nil stands for "the postinstall hook never wrote one".
+    $config_json = ARGV[0] == "" ? nil : ARGV[0]
+
+    module StubbedPaths
+      CONFIG_FILE = "rne-build-config.json".freeze
+
+      def exist?(path)
+        path.to_s.end_with?(CONFIG_FILE) ? !$config_json.nil? : super
+      end
+
+      def read(path, *args)
+        path.to_s.end_with?(CONFIG_FILE) ? $config_json : super
+      end
+
+      # Stands in for the artifacts the postinstall hook downloads; their
+      # absence is a separate check, covered by nativeLibsConfig.test.ts.
+      def directory?(path)
+        path.to_s.include?("third-party/ios") ? true : super
+      end
+    end
+    File.singleton_class.prepend(StubbedPaths)
+
+    module Pod
+      Informative = Class.new(StandardError)
+
+      class Spec
+        def self.new
+          spec = allocate
+          yield spec
+          spec
+        end
+
+        # Attribute writers arrive here as :name=. The platform proxies
+        # (s.ios.vendored_frameworks = ...) return self, so the chained
+        # assignment is recorded under its own name too.
+        def method_missing(name, *args)
+          $assigned << name.to_s.sub(/=$/, "")
+          self
+        end
+
+        def respond_to_missing?(*)
+          true
+        end
+
+        def ios
+          self
+        end
+      end
+    end
+
+    # Provided by react_native_pods.rb, a CocoaPods-time dependency.
+    def install_modules_dependencies(spec); end
+
+    Dir.chdir(${JSON.stringify(PACKAGE_ROOT)}) do
+      eval(File.read("react-native-executorch.podspec"), TOPLEVEL_BINDING, "podspec")
+    end
+    puts JSON.dump($assigned.uniq)
+  `;
+
+  let output: string;
+  try {
+    output = execFileSync('ruby', ['-e', harness, config === null ? '' : JSON.stringify(config)], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    const details = error instanceof Error ? (error as { stderr?: string }).stderr : undefined;
+    throw new Error(
+      `evaluating the podspec with ${JSON.stringify(config)} failed.\n` +
+        `A Ruby error here is a real podspec defect: this is what \`pod install\` runs.\n` +
+        `${details ?? String(error)}`
+    );
+  }
+  return JSON.parse(output.trim()) as string[];
+}
+
+/**
+ * Attributes that decide whether the pod compiles and links at all, so none of
+ * them may depend on a feature flag. `pod_target_xcconfig` carries every
+ * `HEADER_SEARCH_PATHS` entry, and `vendored_frameworks` carries ExecuTorch
+ * itself.
+ */
+const UNCONDITIONAL_ATTRIBUTES = [
+  'source_files',
+  'public_header_files',
+  'pod_target_xcconfig',
+  'static_framework',
+  'vendored_frameworks',
+  'libraries',
+  'frameworks',
+];
+
+/**
+ * One row per independently toggleable native library, plus the two shapes a
+ * default install takes. `enableOpencv: false` is the row #1450 broke, and
+ * `null` is the branch where it left `rne_build_config` unassigned, so reading
+ * `opencvPod` from it raised `NoMethodError` for nil.
+ */
+const CONFIGS: Record<string, Record<string, boolean> | null> = {
+  'no config file (manual provisioning)': null,
+  'empty config (every feature on)': {},
+  'opencv off': { enableOpencv: false },
+  'phonemis off': { enablePhonemis: false },
+  'xnnpack off': { enableXnnpack: false },
+  'coreml off': { enableCoreml: false },
+  'mlx off': { enableMlx: false },
+  'every optional library off': {
+    enableOpencv: false,
+    enablePhonemis: false,
+    enableXnnpack: false,
+    enableCoreml: false,
+    enableMlx: false,
+  },
+};
+
+describe('podspec attributes', () => {
+  describe.each(Object.entries(CONFIGS))('with %s', (_label, config) => {
+    it('evaluates and assigns every attribute the build depends on', () => {
+      const assigned = assignedAttributes(config);
+      const missing = UNCONDITIONAL_ATTRIBUTES.filter((name) => !assigned.includes(name));
+
+      // A name here means the attribute sits inside a conditional it does not
+      // belong in. The pod still installs; the app fails to compile or link.
+      expect(missing).toEqual([]);
+    });
+  });
+});

--- a/packages/react-native-executorch/__tests__/api/podspecPublicHeaders.test.ts
+++ b/packages/react-native-executorch/__tests__/api/podspecPublicHeaders.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The public headers the iOS podspec exposes.
+ *
+ * An app that sets `use_frameworks!` - directly, as Firebase requires, or
+ * through expo-build-properties' `useFrameworks: "static"` - makes CocoaPods
+ * build this pod as a framework instead of a static library. Xcode's Headers
+ * build phase then copies every *public* header into one flat
+ * `react_native_executorch.framework/Headers/`, so two public headers sharing
+ * a basename become two build commands writing the same file and the build
+ * dies while it is still being planned:
+ *
+ *     error: Multiple commands produce '.../Headers/Types.h'
+ *
+ * The source tree has 21 such basenames - `Types.h` sits in eleven task
+ * directories, `constants.h` in thirteen phonemis ones - so leaving every
+ * header public is not survivable. The podspec narrows the public set to the
+ * Objective-C entry points and reaches the C++ headers through
+ * HEADER_SEARCH_PATHS instead. See discussion #203.
+ *
+ * Nothing else notices when that narrowing is dropped or widened: the default
+ * setup builds the pod as a static library, where public headers are not
+ * copied into a framework at all, so every example app stays green while the
+ * release is broken for `use_frameworks!` users. The invariant is checked here
+ * instead, by reading the podspec.
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+const PACKAGE_ROOT = join(__dirname, '..', '..');
+const PODSPEC = join(PACKAGE_ROOT, 'react-native-executorch.podspec');
+
+/**
+ * The globs assigned to `public_header_files`, in declaration order.
+ *
+ * The podspec builds the list over several statements (a base list plus the
+ * legacy entry point), so every `public_header_files = [...]` and
+ * `public_header_files += [...]` contributes. The trailing
+ * `s.public_header_files = public_header_files` carries no array literal and
+ * is skipped by the same pattern.
+ */
+function declaredPublicHeaderGlobs(podspec: string): string[] {
+  const assignments = podspec.matchAll(/public_header_files\s*\+?=\s*\[([^\]]*)\]/g);
+  return [...assignments].flatMap((assignment) =>
+    [...assignment[1]!.matchAll(/"([^"]+)"/g)].map((quoted) => quoted[1]!)
+  );
+}
+
+/**
+ * A CocoaPods file glob as a `RegExp` over paths relative to the package root.
+ *
+ * Covers the constructs the podspec uses - `**` for any depth, `*` within one
+ * segment, `{h,mm}` alternatives - and throws on anything else rather than
+ * quietly matching nothing, which would turn a real collision into a passing
+ * test.
+ */
+function globToRegExp(glob: string): RegExp {
+  if (/[?[\]!]/.test(glob)) {
+    throw new Error(`unsupported glob syntax in podspec pattern: ${glob}`);
+  }
+  const segments = glob.split('/');
+  const pattern = segments.flatMap((segment, index) => {
+    // `**` stands for any number of directories, none included, so it brings
+    // its own trailing separator: `a/**/b.h` has to match `a/b.h` as well.
+    if (segment === '**') return ['(?:[^/]+/)*'];
+    const escaped = segment
+      .replace(/[.+^$()|\\]/g, '\\$&')
+      .replace(
+        /\{([^{}]*)\}/g,
+        (_, alternatives: string) => `(?:${alternatives.split(',').join('|')})`
+      )
+      .replace(/\*/g, '[^/]*');
+    return index < segments.length - 1 ? [escaped, '/'] : [escaped];
+  });
+  return new RegExp(`^${pattern.join('')}$`);
+}
+
+/** Every file under `directory`, as a path relative to the package root. */
+function filesUnder(directory: string, prefix: string): string[] {
+  return readdirSync(directory).flatMap((entry) => {
+    const full = join(directory, entry);
+    const relative = `${prefix}/${entry}`;
+    return statSync(full).isDirectory() ? filesUnder(full, relative) : [relative];
+  });
+}
+
+/**
+ * The files a glob matches. Only the top-level directory the glob names is
+ * walked, so the phonemis submodule is never read: it holds no public header,
+ * and CI installs without checking it out.
+ */
+function matches(glob: string): string[] {
+  const root = glob.split('/')[0]!;
+  const rootPath = join(PACKAGE_ROOT, root);
+  if (!existsSync(rootPath)) return [];
+  const regexp = globToRegExp(glob);
+  const candidates = statSync(rootPath).isDirectory() ? filesUnder(rootPath, root) : [root];
+  return candidates.filter((file) => regexp.test(file));
+}
+
+const globs = declaredPublicHeaderGlobs(readFileSync(PODSPEC, 'utf8'));
+const publicHeaders = new Map(globs.map((glob) => [glob, matches(glob)]));
+
+describe('podspec public headers', () => {
+  it('narrows the public set with public_header_files', () => {
+    // Without the attribute CocoaPods promotes every header in `source_files`,
+    // which is the state that broke `use_frameworks!` builds in 0.10.0.
+    expect(globs).not.toHaveLength(0);
+  });
+
+  it('declares no glob that matches nothing', () => {
+    // A moved or renamed entry point would otherwise leave the framework with
+    // no importable header, and no failing build until an app tried to use it.
+    const empty = [...publicHeaders]
+      .filter(([, files]) => files.length === 0)
+      .map(([glob]) => glob);
+    expect(empty).toEqual([]);
+  });
+
+  it('gives every public header a unique basename', () => {
+    const byBasename = new Map<string, string[]>();
+    for (const file of [...publicHeaders.values()].flat()) {
+      const basename = file.split('/').pop()!;
+      byBasename.set(basename, [...(byBasename.get(basename) ?? []), file]);
+    }
+
+    // Each entry here is one `Multiple commands produce` error in an app built
+    // with `use_frameworks!`. Rename the header, or drop it from
+    // `public_header_files` when nothing outside the pod imports it.
+    const collisions = Object.fromEntries([...byBasename].filter(([, files]) => files.length > 1));
+    expect(collisions).toEqual({});
+  });
+});

--- a/packages/react-native-executorch/__tests__/api/workletsVersionRange.test.ts
+++ b/packages/react-native-executorch/__tests__/api/workletsVersionRange.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The supported `react-native-worklets` range, and the documentation of it.
+ *
+ * This range is not a formality. Worklets 0.10.0 is the first release to
+ * serialize an `ArrayBufferView` natively ([reanimated
+ * #9475](https://github.com/software-mansion/react-native-reanimated/pull/9475));
+ * before it, a view was rebuilt on the target runtime over its whole backing
+ * buffer, so a window into a larger one — a slice of a recording, a pooled
+ * camera frame — reached the model silently widened. Measured on a simulator,
+ * `new Uint8Array(buffer, 64, 16)` arrives with `length` 1024 on worklets 0.8.3
+ * and 16 on 0.10.4.
+ *
+ * Worklets 0.10 in turn requires React Native 0.83+, so the peer range is also
+ * what decides which React Native versions this library supports. That is
+ * exactly the pair that drifted before: the requirements page claimed React
+ * Native 0.81+ while the peer ruled it out, and nothing noticed.
+ *
+ * So the range is checked against three things at once: the version actually
+ * installed here, the React Native floor it implies, and the number written in
+ * the docs.
+ */
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { satisfies, minVersion, subset } from 'semver';
+
+const PACKAGE_ROOT = join(__dirname, '..', '..');
+const DOCS = join(PACKAGE_ROOT, '..', '..', 'docs', 'docs');
+
+const manifest = JSON.parse(readFileSync(join(PACKAGE_ROOT, 'package.json'), 'utf8'));
+const range: string = manifest.peerDependencies['react-native-worklets'];
+
+/** The worklets copy this repo installs, i.e. what the suites run against. */
+const installed = JSON.parse(
+  readFileSync(
+    require.resolve('react-native-worklets/package.json', {
+      paths: [PACKAGE_ROOT],
+    }),
+    'utf8'
+  )
+);
+
+describe('react-native-worklets peer range', () => {
+  it('starts at 0.10.0, where native ArrayBufferView serialization landed', () => {
+    expect(satisfies('0.9.3', range)).toBe(false);
+    expect(satisfies('0.10.0', range)).toBe(true);
+  });
+
+  it('covers the releases published since', () => {
+    // A range that stops below the current release leaves anyone installing
+    // `react-native-worklets` with an unmet peer warning for no reason.
+    for (const version of ['0.10.4', '0.11.4', '0.12.2']) {
+      expect(satisfies(version, range)).toBe(true);
+    }
+  });
+
+  it('is bounded, so an unreleased major cannot be assumed to work', () => {
+    expect(subset(range, '>=0.10.0 <0.13.0')).toBe(true);
+  });
+
+  it('is satisfied by the version installed in this repo', () => {
+    expect(satisfies(installed.version, range)).toBe(true);
+  });
+
+  it('matches the React Native floor the docs promise', () => {
+    // Worklets declares which React Native versions it accepts; ours cannot be
+    // lower than what the oldest worklets we allow will run on.
+    const oldest = minVersion(range)!.version;
+    const workletsRnRange: string = installed.peerDependencies['react-native'];
+    const rnFloor = minVersion(workletsRnRange)!.version;
+
+    const gettingStarted = readFileSync(
+      join(DOCS, '01-fundamentals', '01-getting-started.md'),
+      'utf8'
+    );
+
+    expect(oldest).toBe('0.10.0');
+    // e.g. "React Native 0.83+"
+    expect(gettingStarted).toContain(`React Native ${rnFloor.split('.').slice(0, 2).join('.')}+`);
+  });
+
+  it('is written into the requirements the same way', () => {
+    const gettingStarted = readFileSync(
+      join(DOCS, '01-fundamentals', '01-getting-started.md'),
+      'utf8'
+    );
+    expect(gettingStarted).toContain(range);
+  });
+});

--- a/packages/react-native-executorch/android/build.gradle.kts
+++ b/packages/react-native-executorch/android/build.gradle.kts
@@ -54,6 +54,44 @@ val rneConfig = rneBuildConfig()
 fun rneFlag(key: String): String = if (rneConfig[key] != false) "ON" else "OFF"
 
 /**
+ * The prebuilt ExecuTorch runtime is not in the npm tarball - `package.json`
+ * excludes it and `scripts/download-libs.js` fetches it from the matching
+ * GitHub release in a postinstall hook. When a package manager skips that hook
+ * the install still looks clean and the failure surfaces much later, out of
+ * CMake, blamed on a missing library rather than on the install. Fail here with
+ * the fix instead.
+ */
+fun requireNativeArtifacts() {
+    val libsDir = file("../third-party/android/libs/executorch")
+    val present = libsDir.listFiles()
+        ?.filter { it.isDirectory && it.resolve("libexecutorch.so").exists() }
+        .orEmpty()
+    if (present.isNotEmpty()) return
+
+    throw GradleException(
+        """
+        react-native-executorch is missing its native artifacts:
+
+          ${libsDir.absolutePath}
+
+        They are downloaded by this package's postinstall hook, which your
+        package manager did not run. pnpm 10 and later block dependency build
+        scripts by default ("Ignored build scripts"), and so do
+        `--ignore-scripts` and `npm ci --ignore-scripts`. Re-run the hook:
+
+          pnpm approve-builds react-native-executorch   # pnpm
+          npm rebuild react-native-executorch           # npm
+          node node_modules/react-native-executorch/scripts/download-libs.js
+
+        If you provision the libraries yourself, put them under
+        third-party/android/libs/executorch/<abi>/ before building.
+        """.trimIndent()
+    )
+}
+
+requireNativeArtifacts()
+
+/**
  * ExecuTorch only supports these ABIs. Honor the app's `reactNativeArchitectures`
  * (e.g. Expo passes `-PreactNativeArchitectures=arm64-v8a` for device builds) so
  * we only build/provision the ABIs the app actually needs; default to both.
@@ -70,7 +108,12 @@ android {
     compileSdk = (getExtOrDefault("compileSdkVersion", 34) as Number).toInt()
 
     defaultConfig {
-        minSdk = (getExtOrDefault("minSdkVersion", 21) as Number).toInt()
+        // The prebuilt ExecuTorch runtime is compiled against Android API 26 -
+        // `.note.android.ident` in libexecutorch.so, libxnnpack_executorch_backend.so
+        // and libvulkan_executorch_backend.so all read 26 - so an app below that
+        // ships a library its linker is not guaranteed to be able to load. The
+        // default was 21, which let such a build through to fail on the device.
+        minSdk = (getExtOrDefault("minSdkVersion", 26) as Number).toInt()
         targetSdk = (getExtOrDefault("targetSdkVersion", 34) as Number).toInt()
         consumerProguardFiles("consumer-proguard-rules.pro")
 

--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -142,7 +142,7 @@
     "react": "*",
     "react-native": "*",
     "react-native-blob-util": "^0.24.0",
-    "react-native-worklets": "^0.10.0"
+    "react-native-worklets": ">=0.10.0 <0.13.0"
   },
   "peerDependenciesMeta": {
     "@kesha-antonov/react-native-background-downloader": {

--- a/packages/react-native-executorch/react-native-executorch.podspec
+++ b/packages/react-native-executorch/react-native-executorch.podspec
@@ -7,20 +7,17 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 # Falls back to all features enabled if the file doesn't exist (e.g. a fresh
 # checkout where the native libs were provisioned manually).
 rne_build_config_path = File.join(__dir__, "rne-build-config.json")
-if File.exist?(rne_build_config_path)
-  rne_build_config = JSON.parse(File.read(rne_build_config_path))
-  enable_opencv   = rne_build_config["enableOpencv"]   != false
-  enable_phonemis = rne_build_config["enablePhonemis"] != false
-  enable_xnnpack  = rne_build_config["enableXnnpack"]  != false
-  enable_coreml   = rne_build_config["enableCoreml"]   != false
-  enable_mlx      = rne_build_config["enableMlx"]      != false
-else
-  enable_opencv   = true
-  enable_phonemis = true
-  enable_xnnpack  = true
-  enable_coreml   = true
-  enable_mlx      = true
-end
+rne_build_config =
+  File.exist?(rne_build_config_path) ? JSON.parse(File.read(rne_build_config_path)) : {}
+
+# Every flag reads `!= false`, so an absent file and an absent key both mean
+# enabled. Keep the hash rather than branching on the file: `opencvPod` below
+# is read from it too, and a nil `rne_build_config` there is a NoMethodError.
+enable_opencv   = rne_build_config["enableOpencv"]   != false
+enable_phonemis = rne_build_config["enablePhonemis"] != false
+enable_xnnpack  = rne_build_config["enableXnnpack"]  != false
+enable_coreml   = rne_build_config["enableCoreml"]   != false
+enable_mlx      = rne_build_config["enableMlx"]      != false
 
 # The native artifacts are not in the npm tarball - `package.json` excludes
 # them and `scripts/download-libs.js` fetches them from the matching GitHub
@@ -249,6 +246,7 @@ Pod::Spec.new do |s|
       s.dependency opencv_pod
       external_opencv = true
     end
+  end
 
   # Our own OpenCV headers ship under third-party/include and are newer than
   # what another OpenCV pod vendors: react-native-fast-opencv carries 4.9, and
@@ -335,8 +333,6 @@ Pod::Spec.new do |s|
   # preserve __attribute__((constructor)) backend registrations). Only
   # ExecutorchLib goes in vendored_frameworks to avoid duplicate symbol errors.
   s.ios.vendored_frameworks = ["third-party/ios/ExecutorchLib.xcframework"]
-
-  end
 
   install_modules_dependencies(s)
 end

--- a/packages/react-native-executorch/react-native-executorch.podspec
+++ b/packages/react-native-executorch/react-native-executorch.podspec
@@ -97,6 +97,34 @@ Pod::Spec.new do |s|
   exclude_files += phonemis_source_files unless enable_phonemis
   s.exclude_files = exclude_files
 
+  # --- Public headers ---
+  # `use_frameworks!` - set directly for Firebase, or through
+  # expo-build-properties' `useFrameworks: "static"` - makes CocoaPods build
+  # this pod as a framework, and Xcode's Headers build phase copies every
+  # *public* header into one flat `Headers/` directory. With no
+  # `public_header_files` every header in `source_files` is public, and the
+  # tree has 21 basenames that occur more than once (`Types.h` in eleven task
+  # directories, `constants.h` in thirteen phonemis ones), so the build fails
+  # at planning with `Multiple commands produce .../Headers/Types.h` before a
+  # single file compiles. See discussion #203.
+  #
+  # Only the Objective-C entry points have to be visible to the app. The C++
+  # headers are reached through the HEADER_SEARCH_PATHS below, so narrowing the
+  # public set costs nothing, and `__tests__/api/podspecPublicHeaders.test.ts`
+  # keeps it collision-free.
+  public_header_files = [
+    "ios/**/*.h",
+  ]
+  # ==============================================================================
+  # LEGACY SUPPORT: include the legacy entry point
+  # (Remove when react-native-executorch/legacy is dropped)
+  # ==============================================================================
+  public_header_files += [
+    "legacy/ios/**/*.h",
+  ]
+  # ==============================================================================
+  s.public_header_files = public_header_files
+
   # --- Preprocessor flags ---
   extra_compiler_flags = []
   extra_compiler_flags << "-DRNE_ENABLE_OPENCV"   if enable_opencv
@@ -188,6 +216,19 @@ Pod::Spec.new do |s|
   # app's main executable, the metallib has to land in the app bundle's main
   # resource path. `s.ios.resource` achieves that via CocoaPods' resource copy.
   s.ios.resource = "third-party/ios/libs/executorch/mlx.metallib" if enable_mlx
+
+  # An app that turns on `use_frameworks!` without naming a linkage gets the
+  # default, dynamic - which is what Firebase's own setup instructions show.
+  # CocoaPods then refuses to install at all, because a dynamic framework may
+  # not carry statically linked binaries and opencv-rne vendors one:
+  #
+  #   [!] The 'Pods-YourApp' target has transitive dependencies that include
+  #   statically linked binaries: (.../opencv-rne/opencv2.xcframework)
+  #
+  # Declaring the pod a static framework resolves that without the app having
+  # to spell out `:linkage => :static`, and is inert when the pod is built as a
+  # static library, which is what happens with no `use_frameworks!` at all.
+  s.static_framework = true
 
   # Backend xcframeworks are linked via force_load in OTHER_LDFLAGS (needed to
   # preserve __attribute__((constructor)) backend registrations). Only

--- a/packages/react-native-executorch/react-native-executorch.podspec
+++ b/packages/react-native-executorch/react-native-executorch.podspec
@@ -1,3 +1,4 @@
+require "fileutils"
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
@@ -19,6 +20,49 @@ else
   enable_xnnpack  = true
   enable_coreml   = true
   enable_mlx      = true
+end
+
+# The native artifacts are not in the npm tarball - `package.json` excludes
+# them and `scripts/download-libs.js` fetches them from the matching GitHub
+# release in a postinstall hook. When a package manager skips that hook the
+# install still looks clean, and so does `pod install`: CocoaPods never checks
+# that a vendored framework exists. The build then fails minutes later with
+#
+#   error: Build input files cannot be found:
+#   '.../XnnpackBackend.xcframework/ios-arm64-simulator/libXnnpackBackend.a'
+#
+# which names neither the cause nor the fix. Fail here instead, while the user
+# is still looking at the install that caused it.
+required_artifacts = { "ExecutorchLib.xcframework" => true }
+required_artifacts["XnnpackBackend.xcframework"] = enable_xnnpack
+required_artifacts["CoreMLBackend.xcframework"]  = enable_coreml
+required_artifacts["MLXBackend.xcframework"]     = enable_mlx
+
+missing = required_artifacts
+  .select { |_, required| required }
+  .keys
+  .map    { |name| File.join(__dir__, "third-party/ios", name) }
+  .reject { |path| File.directory?(path) }
+
+unless missing.empty?
+  # Pod::Informative renders as a plain `[!]` message rather than a backtrace.
+  raise(defined?(Pod::Informative) ? Pod::Informative : StandardError, <<~MESSAGE)
+    react-native-executorch is missing its native artifacts:
+
+    #{missing.map { |path| "  #{path}" }.join("\n")}
+
+    They are downloaded by this package's postinstall hook, which your package
+    manager did not run. pnpm 10 and later block dependency build scripts by
+    default ("Ignored build scripts"), and so do `--ignore-scripts` and
+    `npm ci --ignore-scripts`. Re-run the hook, then `pod install` again:
+
+      pnpm approve-builds react-native-executorch   # pnpm
+      npm rebuild react-native-executorch           # npm
+      node node_modules/react-native-executorch/scripts/download-libs.js
+
+    If you provision the libraries yourself, put them under
+    third-party/ios/ before installing pods.
+  MESSAGE
 end
 
 Pod::Spec.new do |s|
@@ -171,6 +215,63 @@ Pod::Spec.new do |s|
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'x86_64',
   }
 
+  # iOS OpenCV is provided by a CocoaPod (not a downloaded tarball), normally
+  # our own opencv-rne.
+  #
+  # An app can already carry OpenCV through another library, and CocoaPods
+  # refuses to install two vendored frameworks with the same name:
+  #
+  #   [!] The 'Pods-YourApp' target has frameworks with conflicting names:
+  #   opencv2.xcframework
+  #
+  # react-native-fast-opencv is the one this happens with, and wanting both is
+  # reasonable: our inference API with their image transformations. So when it
+  # is installed alongside us we depend on the pod it vendors instead of our
+  # own, which leaves exactly one opencv2 in the project. We only use
+  # `opencv2/core.hpp` and `opencv2/imgproc.hpp`, so any OpenCV 4.x build
+  # serves. Set "opencvPod" in the package.json config block to override the
+  # choice in either direction.
+  external_opencv = false
+  if enable_opencv
+    detected_opencv_pod =
+      if Dir.exist?(File.join(__dir__, "..", "react-native-fast-opencv"))
+        "FastOpenCV-iOS"
+      else
+        "opencv-rne"
+      end
+    opencv_pod = rne_build_config["opencvPod"] || detected_opencv_pod
+
+    if opencv_pod == "opencv-rne"
+      s.dependency "opencv-rne", "~> 4.11.0"
+    else
+      Pod::UI.puts "[react-native-executorch] using #{opencv_pod} for OpenCV " \
+                   "instead of opencv-rne, so the project holds one opencv2" if defined?(Pod::UI)
+      s.dependency opencv_pod
+      external_opencv = true
+    end
+
+  # Our own OpenCV headers ship under third-party/include and are newer than
+  # what another OpenCV pod vendors: react-native-fast-opencv carries 4.9, and
+  # compiling against ours while linking against theirs fails at link time on
+  # any signature that moved since (cvtColor gained an AlgorithmHint parameter
+  # in 4.10). Whoever provides the binary has to provide the headers, so with
+  # an external OpenCV the include root becomes a mirror of ours with opencv2
+  # left out, and `#include <opencv2/...>` resolves through their framework.
+  mirror_without_opencv = lambda do
+    source = File.join(__dir__, "third-party/include")
+    mirror = File.join(__dir__, "third-party/include-external-opencv")
+    FileUtils.rm_rf(mirror)
+    FileUtils.mkdir_p(mirror)
+    Dir.children(source).each do |entry|
+      next if entry == "opencv2"
+      FileUtils.ln_s(File.join(source, entry), File.join(mirror, entry))
+    end
+    "third-party/include-external-opencv"
+  end
+
+  third_party_include =
+    external_opencv ? mirror_without_opencv.call : "third-party/include"
+
   s.pod_target_xcconfig = {
     "USE_HEADERMAP" => "YES",
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
@@ -186,7 +287,7 @@ Pod::Spec.new do |s|
       # ==============================================================================
       "\"$(PODS_TARGET_SRCROOT)/legacy/cpp\"",
       # ==============================================================================
-      "\"$(PODS_TARGET_SRCROOT)/third-party/include\"",
+      "\"$(PODS_TARGET_SRCROOT)/#{third_party_include}\"",
       "\"$(PODS_TARGET_SRCROOT)/third-party/include/cpuinfo\"",
       "\"$(PODS_TARGET_SRCROOT)/third-party/include/pthreadpool\"",
       "\"$(PODS_TARGET_SRCROOT)/third-party/include/executorch/extension/llm/tokenizers/include\"",
@@ -235,8 +336,7 @@ Pod::Spec.new do |s|
   # ExecutorchLib goes in vendored_frameworks to avoid duplicate symbol errors.
   s.ios.vendored_frameworks = ["third-party/ios/ExecutorchLib.xcframework"]
 
-  # iOS OpenCV is provided by the opencv-rne CocoaPod (not a downloaded tarball).
-  s.dependency "opencv-rne", "~> 4.11.0" if enable_opencv
+  end
 
   install_modules_dependencies(s)
 end

--- a/packages/react-native-executorch/scripts/download-libs.js
+++ b/packages/react-native-executorch/scripts/download-libs.js
@@ -172,32 +172,67 @@ const FEATURE_MAP = {
   tokenizer: { backends: [], libs: [] },
 };
 
+/**
+ * The `react-native-executorch` block, and the package.json it came from.
+ *
+ * Two places are tried, in order:
+ *
+ *   1. INIT_CWD - where the install was invoked. For a single-app project that
+ *      is the app itself.
+ *   2. Each package.json above this package. In a workspace, `yarn install` is
+ *      run at the root, so INIT_CWD points there and a block in
+ *      `apps/mobile/package.json` would never be seen. When the app keeps its
+ *      own node_modules (pnpm, nohoist), walking up from here lands on the app.
+ *
+ * A hoisted workspace resolves to the root either way, which is where the block
+ * has to live in that layout - there is no way to tell which of several apps a
+ * root install was meant for.
+ * @returns The block and the path of the package.json holding it, or both
+ * `undefined` when no manifest declares one.
+ */
+function findUserConfig() {
+  const candidates = [];
+  const initCwd = process.env.INIT_CWD || process.env.npm_config_local_prefix;
+  if (initCwd) candidates.push(initCwd);
+
+  // `__dirname` is <somewhere>/node_modules/react-native-executorch/scripts.
+  let dir = path.resolve(__dirname, '..', '..', '..');
+  for (let i = 0; i < 6; i++) {
+    if (!candidates.includes(dir)) candidates.push(dir);
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  for (const root of candidates) {
+    const manifest = path.join(root, 'package.json');
+    let parsed;
+    try {
+      parsed = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+    } catch {
+      continue;
+    }
+    if (parsed['react-native-executorch'] !== undefined) {
+      return { config: parsed['react-native-executorch'], manifest };
+    }
+  }
+  return { config: undefined, manifest: undefined };
+}
+
 function readUserConfig() {
-  const allOn = () => ({ backends: [...ALL_BACKENDS], libs: [...ALL_LIBS] });
+  const allOn = () => ({ backends: [...ALL_BACKENDS], libs: [...ALL_LIBS], opencvPod: undefined });
 
-  // npm/yarn set INIT_CWD to the directory where install was invoked (project root)
-  const projectRoot = process.env.INIT_CWD || process.env.npm_config_local_prefix;
-  if (!projectRoot) {
-    console.warn(
-      '[react-native-executorch] Could not determine project root, enabling all backends + libs.'
+  const { config: rneConfig, manifest } = findUserConfig();
+
+  if (rneConfig === undefined) {
+    console.log(
+      '[react-native-executorch] No `react-native-executorch` block found; enabling all backends + libs.'
     );
     return allOn();
   }
-
-  let rneConfig;
-  try {
-    const userPackageJson = JSON.parse(
-      fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8')
-    );
-    rneConfig = userPackageJson['react-native-executorch'];
-  } catch {
-    console.warn(
-      '[react-native-executorch] Could not read app package.json, enabling all backends + libs.'
-    );
-    return allOn();
-  }
-
-  if (rneConfig === undefined) return allOn();
+  // Which manifest won matters when it is not the one the user edited - the
+  // usual monorepo surprise.
+  console.log(`[react-native-executorch] Read build config from ${manifest}`);
 
   if (rneConfig.extras !== undefined) {
     throw new Error(
@@ -236,10 +271,10 @@ function readUserConfig() {
     }
   }
 
-  return { backends: [...backends], libs: [...libs] };
+  return { backends: [...backends], libs: [...libs], opencvPod: rneConfig.opencvPod };
 }
 
-function writeBuildConfig({ backends, libs }) {
+function writeBuildConfig({ backends, libs, opencvPod }) {
   const config = {
     enableOpencv: libs.includes('opencv'),
     enablePhonemis: libs.includes('phonemis'),
@@ -248,6 +283,10 @@ function writeBuildConfig({ backends, libs }) {
     enableMlx: backends.includes('mlx'),
     enableVulkan: backends.includes('vulkan'),
   };
+  // Which pod provides opencv2 on iOS. Only set when the app asks for a
+  // specific one; otherwise the podspec picks, preferring an OpenCV the app
+  // already carries so two frameworks named opencv2 never meet.
+  if (opencvPod !== undefined) config.opencvPod = opencvPod;
   fs.writeFileSync(
     path.join(PACKAGE_ROOT, 'rne-build-config.json'),
     JSON.stringify(config, null, 2)
@@ -497,4 +536,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { ALL_BACKENDS, ALL_LIBS, FEATURE_MAP };
+module.exports = { ALL_BACKENDS, ALL_LIBS, FEATURE_MAP, findUserConfig, readUserConfig };

--- a/yarn.lock
+++ b/yarn.lock
@@ -16506,7 +16506,7 @@ __metadata:
     react: "*"
     react-native: "*"
     react-native-blob-util: ^0.24.0
-    react-native-worklets: ^0.10.0
+    react-native-worklets: ">=0.10.0 <0.13.0"
   peerDependenciesMeta:
     "@kesha-antonov/react-native-background-downloader":
       optional: true


### PR DESCRIPTION
## Description

Backports the three 0.10.0 setup fixes from `main` to `release/0.10`, plus the follow-up that fixes two defects in the third one. Cherry-picked with `-x`, no manual edits to any of them.

| commit | PR |
| --- | --- |
| `12ce3bb` | #1448 fix(ios): narrow the podspec's public headers |
| `c51f76a` | #1449 fix(deps): require worklets >=0.10.0 <0.13.0 and document it |
| `a1ff6c9` | #1450 fix(build): fail with the cause when the setup is wrong |
| `080e764` | #1452 fix(ios): keep the podspec's build attributes out of the OpenCV branch |

All four are now on `main`; #1452 merged as `c8f44f6`.

Only conflict was `docs/versioned_docs/version-0.10.0/**`: that snapshot exists on `main` only, since on this branch `docs/docs` **is** the 0.10 documentation. Those three hunks were dropped and the equivalent `docs/docs` changes came across in the same commits.

`packages/react-native-executorch/package.json` keeps `0.10.0`; only the worklets peer range changed.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

`yarn workspace react-native-executorch test` passes, 3868 tests across 34 suites.

The podspec, `android/build.gradle.kts`, `scripts/download-libs.js` and the new podspec test on this branch are byte-identical to `main`:

```bash
git fetch origin main
git diff origin/main HEAD -- packages/react-native-executorch/react-native-executorch.podspec \
  packages/react-native-executorch/android/build.gradle.kts \
  packages/react-native-executorch/scripts/download-libs.js \
  packages/react-native-executorch/__tests__/api/podspecAttributes.test.ts
```

### Related issues

#1448, #1449, #1450, #1452
