### PR TITLE
chore: Release v0.10.1

### DIFF
--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-executorch",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "nativeLibsVersion": "0.10.0",
   "description": "An easy way to run AI models in React Native with ExecuTorch",
   "main": "./lib/module/index.js",

--- a/packages/react-native-executorch/src/fetcher/telemetry.ts
+++ b/packages/react-native-executorch/src/fetcher/telemetry.ts
@@ -10,7 +10,7 @@ const DOWNLOAD_EVENT_ENDPOINT = 'https://ai.swmansion.com/telemetry/downloads/ap
 // self-referencing import would need package `exports` support in the consuming
 // bundler to load at all. A wrong value here is analytics noise; a failed
 // import would break the bundle.
-const LIB_VERSION = '0.10.0';
+const LIB_VERSION = '0.10.1';
 
 // Anonymous analytics are on by default; apps opt out via setTelemetryEnabled.
 let telemetryEnabled = true;


### PR DESCRIPTION
## Description

Patch release **v0.10.1**. The fixes are already on `release/0.10` via #1451 (backports of #1448, #1449, #1450, #1452); this PR only bumps the version.

- `packages/react-native-executorch/package.json`: `0.10.0` -> `0.10.1`. `nativeLibsVersion` stays `0.10.0`; the native artifacts release is unchanged.
- `src/fetcher/telemetry.ts`: `LIB_VERSION` -> `0.10.1`, asserted equal to the package version by `__tests__/fetcher/telemetry.test.ts`.

Satellites (`bare-resource-fetcher`, `expo-resource-fetcher`, `webrtc`) are untouched by the backports, so their versions stay at `0.10.0`. `models.ts` stays on `resolve/v0.10.0`; no model files moved.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

CI runs `yarn workspace react-native-executorch test`; the telemetry version assertion covers the bump.

### Related issues

#1451

### Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
