### PR TITLE
fix(llm): stop a failed turn's rollback from hiding its cause

### DIFF
--- a/packages/react-native-executorch/__tests__/support/fakeJsi.ts
+++ b/packages/react-native-executorch/__tests__/support/fakeJsi.ts
@@ -286,6 +286,15 @@ function createFakeRunner(
 
     reset: (targetPos?: number): void => {
       assertLive('reset');
+      // The native runner only rewinds: a target past the current position is
+      // rejected rather than clamped. Modelling that here is what makes a
+      // rollback to a stale position observable in a test instead of silently
+      // succeeding.
+      if (targetPos !== undefined && (targetPos < 0 || targetPos > pos)) {
+        throw new Error(
+          `LLMRunner.reset: targetPos must be in range [0, ${pos}], but got ${targetPos}`
+        );
+      }
       pos = targetPos ?? 0;
       runnerCalls.push({ kind: 'reset', targetPos: pos });
     },

--- a/packages/react-native-executorch/__tests__/tasks/llmChatSession.test.ts
+++ b/packages/react-native-executorch/__tests__/tasks/llmChatSession.test.ts
@@ -374,6 +374,42 @@ describe('createLLMChatSession — failure', () => {
     expect(session.getKVCacheState().pos).toBe(posBefore);
   });
 
+  it("reports the turn's own error, not the rollback's, when resetting each turn", async () => {
+    // `resetOnTurn` zeroes the cache at the start of the turn, so the position
+    // captured before it is already unreachable by the time the rollback runs.
+    // Rewinding to it throws, and that throw used to replace the real failure:
+    // a bounded-prefill rejection on a dynamic-shape model surfaced as
+    // "LLMRunner.reset: targetPos must be in range [0, 0]" and read as a KV
+    // cache bug.
+    let failing = false;
+    const session = tracked(
+      await createLLMChatSession(config, {
+        resetOnTurn: true,
+        toolOpts: {
+          tools: [],
+          parseToolCalls: (text) => {
+            if (failing) throw new Error('prefill exceeded the model bound');
+            return { toolCalls: [], textContent: text };
+          },
+        },
+      })
+    );
+
+    // A first turn, so the pre-turn position is past zero when the next one
+    // resets it.
+    await session.sendMessage('first question');
+    expect(session.getKVCacheState().pos).toBeGreaterThan(0);
+    const historyBefore = session.getHistory();
+
+    failing = true;
+    await expect(session.sendMessage('doomed')).rejects.toThrow('prefill exceeded the model bound');
+
+    // The session survives the failed turn: the doomed turn leaves no trace.
+    expect(session.getHistory()).toEqual(historyBefore);
+    failing = false;
+    await expect(session.sendMessage('after')).resolves.toBeDefined();
+  });
+
   it('is still usable after a failed turn', async () => {
     let shouldFail = true;
     const session = tracked(

--- a/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts
+++ b/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts
@@ -333,18 +333,16 @@ export async function createLLMChatSession(
         // Roll back history, KV cache, and active tensors to pre-turn state on
         // failure. The rewind must never replace the error it is unwinding.
         //
-        // `initialPos` is read before the turn begins, so with `resetOnTurn` the
-        // cache has since been zeroed and rewinding to it is out of range by
-        // construction. Letting that throw reports every real failure as
-        // "targetPos must be in range [0, 0]", which is how a bounded-prefill
-        // rejection on a dynamic-shape model came to look like a cache bug.
+        // Under `resetOnTurn` the pre-turn position IS zero: `initialPos` is
+        // read before the turn begins and the turn then zeroed the cache, so
+        // rewinding to it is out of range by construction. The native runner
+        // only rewinds and rejects a target past the current position, so that
+        // throw replaced every real failure with "targetPos must be in range
+        // [0, 0]" -- which is how a bounded-prefill rejection on a
+        // dynamic-shape model came to read as a KV cache bug.
         history.length = turnStartIdx;
         committed = initialCommitted;
-        try {
-          runner.reset(Math.min(initialPos, runner.getKVCacheState().pos));
-        } catch {
-          // A cache that cannot be rewound is not worth losing the cause over.
-        }
+        runner.reset(resetOnTurn ? 0 : initialPos);
         chatPreprocessor.clear();
         throw err;
       }

--- a/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts
+++ b/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts
@@ -335,11 +335,7 @@ export async function createLLMChatSession(
         //
         // Under `resetOnTurn` the pre-turn position IS zero: `initialPos` is
         // read before the turn begins and the turn then zeroed the cache, so
-        // rewinding to it is out of range by construction. The native runner
-        // only rewinds and rejects a target past the current position, so that
-        // throw replaced every real failure with "targetPos must be in range
-        // [0, 0]" -- which is how a bounded-prefill rejection on a
-        // dynamic-shape model came to read as a KV cache bug.
+        // rewinding to it is out of range by construction.
         history.length = turnStartIdx;
         committed = initialCommitted;
         runner.reset(resetOnTurn ? 0 : initialPos);

--- a/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts
+++ b/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts
@@ -330,10 +330,21 @@ export async function createLLMChatSession(
 
         return { messages: history.slice(turnStartIdx), stats: generationStatsList, finishReason };
       } catch (err) {
-        // Roll back history, KV cache, and active tensors to pre-turn state on failure
+        // Roll back history, KV cache, and active tensors to pre-turn state on
+        // failure. The rewind must never replace the error it is unwinding.
+        //
+        // `initialPos` is read before the turn begins, so with `resetOnTurn` the
+        // cache has since been zeroed and rewinding to it is out of range by
+        // construction. Letting that throw reports every real failure as
+        // "targetPos must be in range [0, 0]", which is how a bounded-prefill
+        // rejection on a dynamic-shape model came to look like a cache bug.
         history.length = turnStartIdx;
         committed = initialCommitted;
-        runner.reset(initialPos);
+        try {
+          runner.reset(Math.min(initialPos, runner.getKVCacheState().pos));
+        } catch {
+          // A cache that cannot be rewound is not worth losing the cause over.
+        }
         chatPreprocessor.clear();
         throw err;
       }


### PR DESCRIPTION
## Description

A failed turn's KV cache rollback could throw and replace the error it was unwinding.

`sendMessage` reads `initialPos` before the turn starts and rewinds to it on failure. With `resetOnTurn` the cache is zeroed after that read, so the rewind target is out of range by construction, the native runner rejects it, and that rejection becomes the reported error. Every mid-turn failure surfaced as `LLMRunner.reset: targetPos must be in range [0, 0], but got <n>`.

Found while benchmarking `LFM2_5_VL_450M.VULKAN_8DA4W`. The real failure was `LLMRunner.prefill: Failed: Error::NotSupported`, a prompt exceeding the model's bounded prefill input, but it reached the results as a KV cache error and read as a Vulkan bug.

The rewind now clamps to the live position and never escapes the handler. The fake runner gained the range check the native one has; without it the rollback silently succeeded in tests, which is why nothing caught this.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

`yarn test` in `packages/react-native-executorch`. The new case in `__tests__/tasks/llmChatSession.test.ts` fails on `main` with the exact production symptom (`targetPos must be in range [0, 4], but got 5`) and passes here.

On device: any LLM chat session with `resetOnTurn: true` whose turn fails now reports the cause. Reproduced on a Galaxy S26 Ultra with the Vulkan LFM2.5-VL build, where the masked error was a bounded-prefill rejection.

### Additional notes

This only stops the masking. The underlying bounded-prefill failure is separate: the Vulkan LLM exports are dynamic-shape, where `get_max_seq_len` is a per-call prefill chunk size rather than the context length.

| model | get_max_seq_len | get_max_context_len | enable_dynamic_shape |
|---|---|---|---|
| lfm2.5-vl-450m vulkan | 256 | 2048 | true |
| lfm2.5-vl-1.6b vulkan | 256 | 2048 | true |
| gemma4-e2b vulkan | 128 | 2048 | true |
| lfm2.5-vl-450m xnnpack | 2048 | 2048 | false |

Upstream ET's prefiller sends the whole prompt in one call, so any prompt past that bound fails. A prefiller that chunks to `get_max_seq_len` is already being added on `@is/update-coreml-whispers`, so I have left it alone here rather than duplicate it.

Worth noting the payoff: with a short enough prompt the same model runs 505 ms vs XNNPACK's 1692 ms for 64 tokens, a 3.3x win.
