### PR TITLE
feat(llm): split a prefill that exceeds the model's per-call window

### DIFF
--- a/packages/react-native-executorch/__tests__/support/fakeJsi.ts
+++ b/packages/react-native-executorch/__tests__/support/fakeJsi.ts
@@ -181,6 +181,11 @@ export type FakeRunnerProgram = {
   /** Context window the runner reports. Defaults to `128`. */
   maxSeqLen?: number;
   /**
+   * Per-call prefill window, as a dynamic-shape export declares. Defaults to
+   * `0`, meaning the model declares none and a prompt goes in one call.
+   */
+  maxPrefillLen?: number;
+  /**
    * Responses handed out in order, one per `generate` call. A runner that runs
    * past the end of the list repeats the last entry, so a test only has to
    * script the turns it cares about.
@@ -207,6 +212,17 @@ const promptText = (prompt: unknown): string =>
       ? prompt.filter((part) => typeof part === 'string').join('')
       : '';
 
+/** Token ids carried by a prompt's `tokens` parts, which text parts do not cover. */
+const promptTokenCount = (prompt: unknown): number =>
+  Array.isArray(prompt)
+    ? prompt.reduce(
+        (sum, part) =>
+          sum +
+          (part && typeof part === 'object' && part.kind === 'tokens' ? part.tokens.length : 0),
+        0
+      )
+    : 0;
+
 /**
  * Builds a fake LLM runner.
  *
@@ -228,6 +244,7 @@ function createFakeRunner(
   program: FakeRunnerProgram
 ) {
   const maxSeqLen = program.maxSeqLen ?? 128;
+  const maxPrefillLen = program.maxPrefillLen ?? 0;
   let disposed = false;
   let pos = 0;
   let generationIndex = 0;
@@ -249,7 +266,16 @@ function createFakeRunner(
     prefill: (prompt: unknown): void => {
       assertLive('prefill');
       const text = promptText(prompt);
-      pos = Math.min(maxSeqLen, pos + countTokens(text));
+      const tokens = countTokens(text) + promptTokenCount(prompt);
+      // A dynamic-shape export bounds the prefill tensor to its per-call window
+      // and the runtime rejects a longer prompt outright, so a fake that quietly
+      // accepts one cannot show whether the caller stayed inside it.
+      if (maxPrefillLen > 0 && tokens > maxPrefillLen) {
+        throw new Error(
+          `LLMRunner.prefill: Failed: Error::NotSupported (${tokens} tokens over the ${maxPrefillLen} window)`
+        );
+      }
+      pos = Math.min(maxSeqLen, pos + tokens);
       runnerCalls.push({ kind: 'prefill', text, pos });
     },
 
@@ -307,6 +333,7 @@ function createFakeRunner(
     getKVCacheState: () => ({
       pos,
       maxSeqLen,
+      maxPrefillLen,
       remainingTokens: maxSeqLen - pos,
       usageRatio: pos / maxSeqLen,
     }),

--- a/packages/react-native-executorch/__tests__/support/fakeJsi.ts
+++ b/packages/react-native-executorch/__tests__/support/fakeJsi.ts
@@ -286,6 +286,15 @@ function createFakeRunner(
 
     reset: (targetPos?: number): void => {
       assertLive('reset');
+      // The native runner only rewinds: a target past the current position is
+      // rejected rather than clamped. Modelling that here is what makes a
+      // rollback to a stale position observable in a test instead of silently
+      // succeeding.
+      if (targetPos !== undefined && (targetPos < 0 || targetPos > pos)) {
+        throw new Error(
+          `LLMRunner.reset: targetPos must be in range [0, ${pos}], but got ${targetPos}`
+        );
+      }
       pos = targetPos ?? 0;
       runnerCalls.push({ kind: 'reset', targetPos: pos });
     },

--- a/packages/react-native-executorch/__tests__/tasks/llmChatSession.test.ts
+++ b/packages/react-native-executorch/__tests__/tasks/llmChatSession.test.ts
@@ -374,6 +374,42 @@ describe('createLLMChatSession — failure', () => {
     expect(session.getKVCacheState().pos).toBe(posBefore);
   });
 
+  it("reports the turn's own error, not the rollback's, when resetting each turn", async () => {
+    // `resetOnTurn` zeroes the cache at the start of the turn, so the position
+    // captured before it is already unreachable by the time the rollback runs.
+    // Rewinding to it throws, and that throw used to replace the real failure:
+    // a bounded-prefill rejection on a dynamic-shape model surfaced as
+    // "LLMRunner.reset: targetPos must be in range [0, 0]" and read as a KV
+    // cache bug.
+    let failing = false;
+    const session = tracked(
+      await createLLMChatSession(config, {
+        resetOnTurn: true,
+        toolOpts: {
+          tools: [],
+          parseToolCalls: (text) => {
+            if (failing) throw new Error('prefill exceeded the model bound');
+            return { toolCalls: [], textContent: text };
+          },
+        },
+      })
+    );
+
+    // A first turn, so the pre-turn position is past zero when the next one
+    // resets it.
+    await session.sendMessage('first question');
+    expect(session.getKVCacheState().pos).toBeGreaterThan(0);
+    const historyBefore = session.getHistory();
+
+    failing = true;
+    await expect(session.sendMessage('doomed')).rejects.toThrow('prefill exceeded the model bound');
+
+    // The session survives the failed turn: the doomed turn leaves no trace.
+    expect(session.getHistory()).toEqual(historyBefore);
+    failing = false;
+    await expect(session.sendMessage('after')).resolves.toBeDefined();
+  });
+
   it('is still usable after a failed turn', async () => {
     let shouldFail = true;
     const session = tracked(

--- a/packages/react-native-executorch/__tests__/tasks/llmChatSession.test.ts
+++ b/packages/react-native-executorch/__tests__/tasks/llmChatSession.test.ts
@@ -347,6 +347,68 @@ describe('createLLMChatSession — tool calling', () => {
   });
 });
 
+describe('createLLMChatSession — bounded prefill window', () => {
+  // A dynamic-shape export bounds one prefill call to a window well below the
+  // context it advertises: the Vulkan LFM2.5-VL builds ship 256 against 2048,
+  // Gemma4 128. A conversation comfortably inside its context therefore still
+  // overflows a single call, which the runtime rejects outright.
+  const WINDOW = 4;
+
+  // The session tokenizes only to split, so any vocabulary that yields one id
+  // per word is enough; unknown words already map to 0.
+  beforeEach(() => {
+    fakeJsi.registerTokenizer(TOKENIZER_PATH, { tokens: [] });
+  });
+
+  it('splits a prompt that overflows the window across several calls', async () => {
+    fakeJsi.registerLLMRunner(MODEL_PATH, {
+      maxPrefillLen: WINDOW,
+      generations: [{ response: 'ok ' }],
+    });
+    const session = tracked(await createLLMChatSession(config));
+
+    // Long enough that the rendered prompt cannot fit one call.
+    await expect(
+      session.sendMessage('one two three four five six seven eight nine ten')
+    ).resolves.toBeDefined();
+
+    const prefills = fakeJsi.runnerCalls().filter((call) => call.kind === 'prefill');
+    expect(prefills.length).toBeGreaterThan(1);
+  });
+
+  it('keeps the conversation going past the window across turns', async () => {
+    // With `resetOnTurn` every turn re-prefills the whole conversation, so the
+    // prompt grows turn on turn and crosses the window partway through. That is
+    // how this failed on device: three turns fine, the fourth rejected.
+    fakeJsi.registerLLMRunner(MODEL_PATH, {
+      maxPrefillLen: WINDOW,
+      generations: [{ response: 'ok ' }],
+    });
+    const session = tracked(await createLLMChatSession(config, { resetOnTurn: true }));
+
+    for (const message of [
+      'first question here',
+      'second question here',
+      'third question here',
+      'fourth question here',
+    ]) {
+      await expect(session.sendMessage(message)).resolves.toBeDefined();
+    }
+  });
+
+  it('sends a prompt in one call when the model declares no window', async () => {
+    // Every model whose window covers its context keeps today's exact path, and
+    // pays for no tokenizer.
+    const session = tracked(await createLLMChatSession(config));
+
+    await session.sendMessage('one two three four five six seven eight nine ten');
+
+    // Text, not token chunks: a chunked call carries no text at all.
+    const prefills = fakeJsi.runnerCalls().filter((call) => call.kind === 'prefill');
+    expect(prefills.every((call) => (call as { text: string }).text.length > 0)).toBe(true);
+  });
+});
+
 describe('createLLMChatSession — failure', () => {
   it('rolls the history and the KV cache back when a turn fails', async () => {
     const session = tracked(await createLLMChatSession(config));

--- a/packages/react-native-executorch/__tests__/tasks/prefillChunking.test.ts
+++ b/packages/react-native-executorch/__tests__/tasks/prefillChunking.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Splitting a prompt to fit a model's per-call prefill window.
+ *
+ * The window is not the context: a dynamic-shape export declares a decoder
+ * chunk size well below the conversation budget it advertises, and one prefill
+ * call may not exceed it. These suites pin what gets split, what is left alone,
+ * and that a split never changes the token stream the model sees.
+ */
+import { chunkPrompt } from '../../src/extensions/llm/utils/prefillChunking';
+import type { Prompt, TokensInput } from '../../src/extensions/llm/llmRunner';
+
+/** One id per whitespace-separated word, so a token count is readable in a test. */
+const encode = (text: string) =>
+  Int32Array.from(
+    text
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((word) => word.length)
+  );
+
+const tokensOf = (prompt: Prompt): number[] => {
+  const parts = typeof prompt === 'string' ? [prompt] : prompt;
+  return parts.flatMap((part) =>
+    typeof part === 'object' && 'kind' in part && part.kind === 'tokens'
+      ? [...(part as TokensInput).tokens]
+      : []
+  );
+};
+
+const IMAGE = { kind: 'image', image: {} } as never;
+
+describe('chunkPrompt', () => {
+  it('leaves a prompt that fits in one piece', () => {
+    // Not merely equivalent: the same value, so a model whose window covers its
+    // context stays on the exact path it uses today.
+    const prompt = 'four words go here';
+    expect(chunkPrompt(prompt, 8, encode)).toEqual([prompt]);
+  });
+
+  it('leaves every prompt alone when the model declares no window', () => {
+    const prompt = 'a b c d e f g h i j';
+    expect(chunkPrompt(prompt, 0, encode)).toEqual([prompt]);
+    expect(chunkPrompt(prompt, -1, encode)).toEqual([prompt]);
+  });
+
+  it('splits a prompt that overflows into calls that each fit', () => {
+    const calls = chunkPrompt('a b c d e f g', 3, encode);
+
+    expect(calls).toHaveLength(3);
+    for (const call of calls) {
+      expect(tokensOf(call).length).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it('preserves the token stream exactly across the split', () => {
+    // The whole point: the model must see what one call would have given it.
+    const prompt = 'alpha be see dee ee eff gee aitch';
+    const whole = [...encode(prompt)];
+
+    expect(chunkPrompt(prompt, 3, encode).flatMap(tokensOf)).toEqual(whole);
+  });
+
+  it('sends each media part as its own call', () => {
+    // Media costs soft tokens the tokenizer cannot count, and the exports size
+    // the window so one image fits one call.
+    const calls = chunkPrompt(['a b', IMAGE, 'c d'], 1, encode);
+
+    expect(calls.filter((call) => tokensOf(call).length === 0)).toHaveLength(1);
+    expect(calls.flatMap(tokensOf)).toEqual([1, 1, 1, 1]);
+  });
+
+  it('splits a prompt carrying media even when its text would fit', () => {
+    // Assuming the soft tokens fit is exactly what fails on device.
+    expect(chunkPrompt(['a', IMAGE], 64, encode).length).toBeGreaterThan(1);
+  });
+
+  it('copies each chunk instead of viewing the encoded prompt', () => {
+    // A subarray shares its buffer, and a worklet runtime that rebuilds the view
+    // over the whole buffer would widen a chunk back to the entire prompt.
+    const calls = chunkPrompt('a b c d', 2, encode);
+    const first = (calls[0] as readonly TokensInput[])[0]!.tokens;
+
+    expect(first.buffer.byteLength).toBe(first.byteLength);
+  });
+});

--- a/packages/react-native-executorch/cpp/extensions/llm/llm_runner.cpp
+++ b/packages/react-native-executorch/cpp/extensions/llm/llm_runner.cpp
@@ -143,6 +143,40 @@ int64_t getRunnerMaxSeqLen(executorch::extension::llm::IRunner *runner, bool isM
     return 0;
 }
 
+/**
+ * The longest prompt one prefill call may carry, or 0 when the model does not
+ * say.
+ *
+ * This is `get_max_seq_len`, and it is deliberately not what `getRunnerMaxSeqLen`
+ * reports. On a dynamic-shape export the two differ: `get_max_context_len` is the
+ * KV budget for the whole conversation, while `get_max_seq_len` is the decoder's
+ * per-call window, and the prefill tensor is bounded to it. A prompt longer than
+ * this must be split across calls, so a caller that cannot see the smaller number
+ * has no way to stay inside it.
+ */
+int64_t getRunnerMaxPrefillLen(executorch::extension::llm::IRunner *runner, bool isMultimodal) {
+    if (runner == nullptr) {
+        return 0;
+    }
+    const std::unordered_map<std::string, int64_t> *meta = nullptr;
+    if (isMultimodal) {
+        auto *r = dynamic_cast<MultimodalRunner *>(runner);
+        if (r != nullptr) {
+            meta = &(r->*getPrivateMember(MMRunnerMetadataTag{}));
+        }
+    } else {
+        auto *r = dynamic_cast<TextLLMRunner *>(runner);
+        if (r != nullptr) {
+            meta = &(r->*getPrivateMember(TextRunnerMetadataTag{}));
+        }
+    }
+    if (meta == nullptr) {
+        return 0;
+    }
+    auto it = meta->find(executorch::extension::llm::kMaxSeqLen);
+    return it != meta->end() ? it->second : 0;
+}
+
 void setRunnerPos(executorch::extension::llm::IRunner *runner, bool isMultimodal, int64_t targetPos) {
     if (runner == nullptr) {
         return;
@@ -200,6 +234,26 @@ std::vector<executorch::extension::llm::MultimodalInput> parsePrompt(
         }
         auto mediaObj = conversions::asType<jsi::Object>(rt, itemCtx, elem);
         auto kind = conversions::getRequiredProperty<std::string>(rt, itemCtx, mediaObj, "kind");
+
+        // Already-encoded text, not a modality: every runner accepts it, so this
+        // is checked before the modality gate. It exists so a caller that must
+        // split a prompt can split it on token boundaries. Re-encoding decoded
+        // text is not equivalent: BPE merges across a cut, so the pieces need
+        // not sum back to the same ids, or the same count.
+        if (kind == "tokens") {
+            auto tokensJs = conversions::getRequiredProperty<jsi::Value>(rt, itemCtx, mediaObj, "tokens");
+            auto ids = conversions::fromJsiTypedArray<int32_t>(rt, itemCtx, tokensJs);
+            std::vector<uint64_t> tokens;
+            tokens.reserve(ids.size());
+            for (auto id : ids) {
+                if (id < 0) {
+                    throw error::InvalidArgument(std::format("{}: token id {} is negative", itemCtx, id));
+                }
+                tokens.push_back(static_cast<uint64_t>(id));
+            }
+            inputs.emplace_back(std::move(tokens));
+            continue;
+        }
 
         if (std::ranges::find(supportedModalities, kind) == supportedModalities.end()) {
             throw error::InvalidArgument(std::format("{}: Modality '{}' is not supported "
@@ -427,6 +481,7 @@ jsi::Value LLMRunnerHostObject::get(jsi::Runtime &rt, const jsi::PropNameID &nam
             jsi::Object obj(rt);
             obj.setProperty(rt, "pos", static_cast<double>(pos));
             obj.setProperty(rt, "maxSeqLen", static_cast<double>(maxSeqLen));
+            obj.setProperty(rt, "maxPrefillLen", static_cast<double>(getRunnerMaxPrefillLen(self->runner_.get(), isMultimodal)));
             obj.setProperty(rt, "remainingTokens", static_cast<double>(remaining));
             obj.setProperty(rt, "usageRatio", usageRatio);
             return obj;

--- a/packages/react-native-executorch/src/extensions/llm/llmRunner.ts
+++ b/packages/react-native-executorch/src/extensions/llm/llmRunner.ts
@@ -68,7 +68,30 @@ export type Modality = MediaInput['kind'];
  * @experimental This API is experimental and might change in future releases.
  * @category LLM / Types
  */
-export type Prompt = string | readonly (string | MediaInput)[];
+export type Prompt = string | readonly PromptPart[];
+
+/**
+ * One element of an interleaved prompt: text, already-encoded text, or media.
+ * @experimental This API is experimental and might change in future releases.
+ * @category LLM / Types
+ */
+export type PromptPart = string | MediaInput | TokensInput;
+
+/**
+ * Already-encoded text.
+ *
+ * Text and tokens describe the same input, so a runner accepts this whatever
+ * its modalities. It exists for callers that must split a prompt across several
+ * prefill calls: a split is only faithful on token boundaries, because BPE
+ * merges across a cut in the string.
+ * @experimental This API is experimental and might change in future releases.
+ * @category LLM / Types
+ */
+export type TokensInput = {
+  readonly kind: 'tokens';
+  /** Token ids, as returned by a {@link Tokenizer}'s `encode`. */
+  readonly tokens: Int32Array;
+};
 
 /**
  * Current KV cache state and capacity metrics for an LLM runner.
@@ -80,6 +103,16 @@ export type LLMKVCacheState = {
   readonly pos: number;
   /** Maximum token capacity (context window) supported by the model. */
   readonly maxSeqLen: number;
+  /**
+   * Longest prompt a single `prefill` call may carry, in tokens, or 0 when the
+   * model does not declare one.
+   *
+   * On a dynamic-shape export this is smaller than {@link maxSeqLen}: the
+   * context is the KV budget for the conversation, while this is the decoder's
+   * per-call window, and the prefill tensor is bounded to it. A longer prompt
+   * has to be delivered as several calls.
+   */
+  readonly maxPrefillLen: number;
   /** Remaining token capacity before the context window is full. */
   readonly remainingTokens: number;
   /** Fraction of the context window currently occupied (0.0 to 1.0). */

--- a/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts
+++ b/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts
@@ -330,10 +330,21 @@ export async function createLLMChatSession(
 
         return { messages: history.slice(turnStartIdx), stats: generationStatsList, finishReason };
       } catch (err) {
-        // Roll back history, KV cache, and active tensors to pre-turn state on failure
+        // Roll back history, KV cache, and active tensors to pre-turn state on
+        // failure. The rewind must never replace the error it is unwinding.
+        //
+        // `initialPos` is read before the turn begins, so with `resetOnTurn` the
+        // cache has since been zeroed and rewinding to it is out of range by
+        // construction. Letting that throw reports every real failure as
+        // "targetPos must be in range [0, 0]", which is how a bounded-prefill
+        // rejection on a dynamic-shape model came to look like a cache bug.
         history.length = turnStartIdx;
         committed = initialCommitted;
-        runner.reset(initialPos);
+        try {
+          runner.reset(Math.min(initialPos, runner.getKVCacheState().pos));
+        } catch {
+          // A cache that cannot be rewound is not worth losing the cause over.
+        }
         chatPreprocessor.clear();
         throw err;
       }

--- a/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts
+++ b/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts
@@ -18,6 +18,8 @@ import {
   type Prompt,
 } from '../llmRunner';
 import { parseTokenizerConfig } from '../utils/tokenizerConfig';
+import { chunkPrompt } from '../utils/prefillChunking';
+import { loadTokenizer } from '../../nlp/tokenizer';
 import {
   createChatPreprocessor,
   type ChatMessageContent,
@@ -206,7 +208,24 @@ export async function createLLMChatSession(
     const runner = scope.track(
       await wrapAsync(createLLMRunner, runtime)(modelPath, tokenizerPath, modalities)
     );
-    const prefill = wrapAsync(runner.prefill, runtime);
+    const prefillOnce = wrapAsync(runner.prefill, runtime);
+
+    // A dynamic-shape export bounds one prefill call to a window smaller than
+    // its context, so a prompt that fits the conversation can still overflow a
+    // single call. Splitting needs the tokenizer, which is only loaded if a
+    // model actually declares such a window.
+    const maxPrefillLen = runner.getKVCacheState().maxPrefillLen;
+    const tokenizer = maxPrefillLen > 0 ? scope.track(loadTokenizer(tokenizerPath)) : undefined;
+
+    const prefill = async (prompt: Prompt): Promise<void> => {
+      if (!tokenizer) {
+        await prefillOnce(prompt);
+        return;
+      }
+      for (const call of chunkPrompt(prompt, maxPrefillLen, (text) => tokenizer.encode(text))) {
+        await prefillOnce(call);
+      }
+    };
 
     const history: ChatMessage[] = [];
 

--- a/packages/react-native-executorch/src/extensions/llm/utils/prefillChunking.ts
+++ b/packages/react-native-executorch/src/extensions/llm/utils/prefillChunking.ts
@@ -1,0 +1,74 @@
+/**
+ * Splitting a prompt so no single prefill call exceeds the model's window.
+ *
+ * A dynamic-shape export bounds the prefill tensor to `get_max_seq_len`, which
+ * is the decoder's per-call window and not the conversation's KV budget
+ * (`get_max_context_len`). The Vulkan LFM2.5-VL builds ship 256 against a
+ * context of 2048, and Gemma4 128, so a conversation well inside its context
+ * can still hand one call more tokens than the graph can hold. The runtime
+ * reports that as `Error::NotSupported` from a tensor resize.
+ *
+ * Prefill already appends at the runner's current position, so the fix needs no
+ * new native capability: the same prompt, delivered as several calls, builds the
+ * identical cache.
+ *
+ * The split has to happen on token boundaries. Cutting the string and letting
+ * the runtime re-encode each piece is not equivalent, because BPE merges across
+ * the cut: the pieces need not sum back to the same ids, or even to the same
+ * count, so a chunk could still overflow the window it was cut to fit.
+ */
+
+import type { Prompt, PromptPart } from '../llmRunner';
+
+/**
+ * Splits `prompt` into prefill calls that each stay within `limit` tokens.
+ *
+ * Text is encoded once and sliced, so the token stream reaching the model is
+ * exactly the one a single call would have produced. Media parts are passed
+ * through untouched and each take a call of their own: their cost is in soft
+ * tokens the tokenizer cannot count, and the exports size their window so one
+ * image fits one call.
+ *
+ * A prompt that already fits is returned as-is, in one piece. That keeps every
+ * model whose window covers its context on the exact path it uses today, and
+ * confines this splitting to prompts that would otherwise fail outright.
+ * @param prompt The prompt to split.
+ * @param limit The model's per-call prefill window, in tokens. Values of 0 or
+ * less mean the model did not declare one, and the prompt is left alone.
+ * @param encode Tokenizer encode, used only when a split is actually needed.
+ * @returns The prompts to prefill, in order.
+ */
+export function chunkPrompt(
+  prompt: Prompt,
+  limit: number,
+  encode: (text: string) => Int32Array
+): Prompt[] {
+  if (limit <= 0) return [prompt];
+
+  const parts: readonly PromptPart[] = typeof prompt === 'string' ? [prompt] : prompt;
+
+  // Encoding is not free, so establish that a split is needed before paying for
+  // it. Only text can be measured; a prompt carrying media is split regardless,
+  // since its soft tokens are uncounted and assuming they fit is what fails.
+  const hasMedia = parts.some((part) => typeof part !== 'string');
+  if (!hasMedia) {
+    const total = parts.reduce((sum, part) => sum + encode(part as string).length, 0);
+    if (total <= limit) return [prompt];
+  }
+
+  const calls: Prompt[] = [];
+  for (const part of parts) {
+    if (typeof part !== 'string') {
+      calls.push([part]);
+      continue;
+    }
+    const ids = encode(part);
+    for (let start = 0; start < ids.length; start += limit) {
+      // Copied, not a view: a subarray shares its backing buffer, and a worklet
+      // runtime that rebuilds the view over the whole buffer would widen the
+      // chunk back to the full prompt.
+      calls.push([{ kind: 'tokens', tokens: Int32Array.from(ids.subarray(start, start + limit)) }]);
+    }
+  }
+  return calls;
+}


### PR DESCRIPTION
## Description

Stacked on #1454, which it needs to see the real error. Draft: the native half is unverified on device, see below.

A dynamic-shape export bounds one prefill call to `get_max_seq_len`, the decoder's per-call window. That is not the conversation budget the model advertises as `get_max_context_len`, so a conversation well inside its context can still hand one call more tokens than the graph holds. The runtime rejects it:

```
LLMRunner.prefill: Failed: Error::NotSupported
Attempted to resize a bounded tensor with a maximum capacity of 262144 elements to 274432 elements
```

262144 is 256x1024 and 274432 is 268x1024: the call carried 268 tokens into a 256 window.

| model | get_max_seq_len | get_max_context_len | enable_dynamic_shape |
|---|---|---|---|
| lfm2.5-vl-450m vulkan | 256 | 2048 | true |
| lfm2.5-vl-1.6b vulkan | 256 | 2048 | true |
| gemma4-e2b vulkan | 128 | 2048 | true |
| lfm2.5-vl-450m xnnpack | 2048 | 2048 | false |

Prefill already appends at the runner's current position, so the same prompt delivered as several calls builds the identical cache. **Nothing in the upstream ExecuTorch runner changes.** The split is driven from TypeScript over two additions to our own binding:

- `getKVCacheState` gains `maxPrefillLen`. `maxSeqLen` resolves to the context, so a caller could not otherwise see the smaller number it must stay inside.
- `parsePrompt` accepts `{ kind: 'tokens' }`. A split is only faithful on token boundaries: cutting the string and letting the runtime re-encode the pieces is not equivalent when BPE merges across the cut, and a chunk could still overflow the window it was cut to fit. `MultimodalInput::Type::TOKENS` already exists upstream, so this is a passthrough.

A prompt that fits is sent in one call, byte for byte as today, and a model that declares no window loads no tokenizer. Every model currently working is on its existing path.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

`yarn test` in `packages/react-native-executorch`. Two suites, both verified to fail without the change:

- `__tests__/tasks/prefillChunking.test.ts` pins the split itself, including that the token stream is identical across it.
- `__tests__/tasks/llmChatSession.test.ts` drives a session against a runner that rejects an over-long call, which is the device failure. Reverting the chunking makes it fail with `Error::NotSupported (10 tokens over the 4 window)`.

The fake runner gained the window and enforces it; without that it accepted any prompt and could not show whether the caller stayed inside.

### Additional notes

**Why this is a draft.** The TS half is covered by tests, but the two C++ additions have not run on device: I have not rebuilt the native library against a Vulkan LLM and replayed the original failure. That is the check I would want before merge. The reproduction is a Galaxy S26 Ultra with `LFM2_5_VL_450M.VULKAN_8DA4W` and any conversation past 256 tokens.

**One judgement call worth review.** Tokenizing in TS means the ids come from our tokenizer rather than the one inside the runner, so a prompt could in principle encode differently. I confined that to prompts that would otherwise fail outright: a prompt that fits still goes down the text path untouched. If we would rather not have two tokenizers at all, the alternative is doing the same loop in C++ with the runner's own tokenizer, at the cost of moving the policy into the binding.

**Not addressed here.** `resetOnTurn` clears the KV cache but not `history`, so each turn re-prefills a longer conversation and grows the prompt (measured +85 tokens per turn on device). That is what pushed this model past its window on the fourth turn. Worth a separate look, since it also means a benchmark iteration is not a fixed workload.
