### PR TITLE
fix(speech-example): fix audio playback not stopping at end of speech

### DIFF
--- a/apps/speech/app/kokoro-text-to-speech/index.tsx
+++ b/apps/speech/app/kokoro-text-to-speech/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TextInput, Platform } from 'react-native';
 import {
   useTextToSpeech,
@@ -6,12 +6,12 @@ import {
   KOKORO_SAMPLE_RATE,
   type KokoroTtsModel,
 } from 'react-native-executorch';
-import { AudioContext, type AudioBufferQueueSourceNode } from 'react-native-audio-api';
 
 import ScreenWrapper from '../../components/ScreenWrapper';
 import { ModelPicker } from '../../components/ModelPicker';
 import { ModelStatus } from '../../components/ModelStatus';
 import { Button } from '../../components/Button';
+import { useAudioPlayer } from '../../hooks/useAudioPlayer';
 import { theme } from '../../theme';
 
 const LANGUAGE_OPTIONS = [
@@ -50,7 +50,7 @@ const SAMPLE_TEXTS: Record<KokoroLanguage, string> = {
     'converting text into phonemes before synthesising the waveform.',
   ES: 'Kokoro es un modelo de síntesis de voz que funciona completamente en tu dispositivo, sin conexión a internet.',
   FR: 'Kokoro est un modèle de synthèse vocale qui fonctionne entièrement sur votre appareil, sans connexion internet.',
-  IT: 'Kokoro è un modello di sintesi vocale che funziona interamente sul tuo dispositivo, senza connessione a internet.',
+  IT: 'Kokoro è un modello di sintesi vocale che funciona interamente sul tuo dispositivo, senza connessione a internet.',
   PT: 'Kokoro é um modelo de síntese de voz que funciona inteiramente no seu dispositivo, sem ligação à internet.',
   HI: 'कोकोरो एक छोटा टेक्स्ट-टू-स्पीच मॉडल है जो पूरी तरह से आपके डिवाइस पर चलता है।',
   PL: 'Kokoro to niewielki model syntezy mowy, który działa w całości na twoim urządzeniu, bez połączenia z internetem.',
@@ -71,7 +71,6 @@ function KokoroContent() {
   const [text, setText] = useState(SAMPLE_TEXTS.EN_US);
   const [speed, setSpeed] = useState(1.0);
   const [isSynthesizing, setIsSynthesizing] = useState(false);
-  const [isPlaying, setIsPlaying] = useState(false);
   const [chunkProgress, setChunkProgress] = useState<string | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
   const [totalDuration, setTotalDuration] = useState<number | null>(null);
@@ -82,8 +81,8 @@ function KokoroContent() {
   const voiceNames = Object.keys(model.voices);
   const [voice, setVoice] = useState(voiceNames[0]!);
 
-  const audioCtxRef = useRef<AudioContext | null>(null);
-  const queueSourceRef = useRef<AudioBufferQueueSourceNode | null>(null);
+  const player = useAudioPlayer(KOKORO_SAMPLE_RATE);
+  const startTimeRef = useRef<number>(0);
 
   const { isReady, downloadProgress, error, synthesize, synthesizeStop } = useTextToSpeech(model);
 
@@ -92,78 +91,45 @@ function KokoroContent() {
     setText(SAMPLE_TEXTS[language]);
   }, [language]);
 
-  const getAudioContext = useCallback(async () => {
-    if (!audioCtxRef.current || audioCtxRef.current.state === 'closed') {
-      audioCtxRef.current = new AudioContext({ sampleRate: KOKORO_SAMPLE_RATE });
-    }
-    if (audioCtxRef.current.state === 'suspended') {
-      await audioCtxRef.current.resume();
-    }
-    return audioCtxRef.current;
-  }, []);
-
-  const stopAudioQueue = useCallback(() => {
-    if (queueSourceRef.current) {
-      queueSourceRef.current.clearBuffers();
-      queueSourceRef.current.stop();
-      queueSourceRef.current = null;
-    }
-    setIsPlaying(false);
-  }, []);
-
   useEffect(() => {
     return () => {
       synthesizeStop?.();
-      stopAudioQueue();
-      if (audioCtxRef.current) {
-        audioCtxRef.current.close().catch(() => {});
-        audioCtxRef.current = null;
-      }
+      player.stop();
     };
-  }, [stopAudioQueue, synthesizeStop]);
-
-  const preparePlaybackSource = useCallback(async () => {
-    stopAudioQueue();
-    const ctx = await getAudioContext();
-
-    const source = ctx.createBufferQueueSource();
-    source.connect(ctx.destination);
-    source.onBufferEnded = (event) => {
-      if (event.isLastBufferInQueue) setIsPlaying(false);
-    };
-    queueSourceRef.current = source;
-    return { ctx, source };
-  }, [getAudioContext, stopAudioQueue]);
+  }, [player, synthesizeStop]);
 
   const handleSynthesize = async () => {
-    if (!synthesize || isSynthesizing || !text.trim()) return;
+    if (!synthesize || isSynthesizing || player.isPlaying || !text.trim()) return;
 
     setRunError(null);
     setChunkProgress(null);
     setTotalDuration(null);
     setIsSynthesizing(true);
+    startTimeRef.current = performance.now();
+    let ttfa: number | null = null;
 
     try {
-      const { ctx, source } = await preparePlaybackSource();
       let durationSum = 0;
-      let started = false;
+      const chunks = synthesize(text, { voice, speed });
 
-      for await (const chunk of synthesize(text, { voice, speed })) {
-        setChunkProgress(
-          `Chunk ${chunk.chunkIndex + 1}/${chunk.totalChunks} (${chunk.duration.toFixed(1)}s)`
-        );
-        durationSum += chunk.duration;
-
-        const buffer = ctx.createBuffer(1, chunk.audio.length, KOKORO_SAMPLE_RATE);
-        buffer.copyToChannel(chunk.audio as Float32Array<ArrayBuffer>, 0);
-        source.enqueueBuffer(buffer);
-
-        if (!started) {
-          started = true;
-          setIsPlaying(true);
-          source.start(0, 0);
+      await player.playStream(
+        chunks,
+        (chunk) => {
+          setChunkProgress(
+            `Chunk ${chunk.chunkIndex + 1}/${chunk.totalChunks} (${chunk.duration.toFixed(1)}s)`
+          );
+          durationSum += chunk.duration;
+        },
+        () => {
+          ttfa = (performance.now() - startTimeRef.current) / 1000;
         }
-      }
+      );
+
+      const synthMs = performance.now() - startTimeRef.current;
+      const rtf = durationSum > 0 ? synthMs / 1000 / durationSum : 0;
+      console.log(
+        `[Kokoro TTS] TTFA ${(ttfa as number | null)?.toFixed(2)}s, synth ${(synthMs / 1000).toFixed(2)}s, audio ${durationSum.toFixed(2)}s, RTF ${rtf.toFixed(3)}`
+      );
 
       setTotalDuration(durationSum);
       setChunkProgress(null);
@@ -176,11 +142,11 @@ function KokoroContent() {
 
   const handleStopPlayback = () => {
     synthesizeStop?.();
-    stopAudioQueue();
+    player.stop();
     setIsSynthesizing(false);
   };
 
-  const isBusy = isSynthesizing || isPlaying;
+  const isBusy = isSynthesizing || player.isPlaying;
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
@@ -249,7 +215,7 @@ function KokoroContent() {
 
       <View style={styles.card}>
         <View style={styles.buttonRow}>
-          {!isPlaying ? (
+          {!player.isPlaying ? (
             <Button
               title={isSynthesizing ? 'Synthesizing...' : 'Synthesize & Play'}
               onPress={handleSynthesize}
@@ -272,6 +238,13 @@ function KokoroContent() {
             <Text style={styles.resultText}>
               Generated {totalDuration.toFixed(1)}s of audio at {KOKORO_SAMPLE_RATE} Hz
             </Text>
+          </View>
+        )}
+
+        {player.isPlaying && (
+          <View style={styles.playingContainer}>
+            <View style={styles.playingIndicator} />
+            <Text style={styles.playingText}>Playing audio...</Text>
           </View>
         )}
       </View>
@@ -356,6 +329,25 @@ const styles = StyleSheet.create({
     color: '#2e7d32',
     fontWeight: '500',
     textAlign: 'center',
+  },
+  playingContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 12,
+    padding: 10,
+  },
+  playingIndicator: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: '#22c55e',
+    marginRight: 8,
+  },
+  playingText: {
+    fontSize: 14,
+    color: '#22c55e',
+    fontWeight: '600',
   },
   errorContainer: {
     backgroundColor: theme.colors.errorBackground,

--- a/apps/speech/app/text-to-speech/index.tsx
+++ b/apps/speech/app/text-to-speech/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Platform, View, Text, StyleSheet, ScrollView, TextInput } from 'react-native';
 import {
   useTextToSpeech,
@@ -8,12 +8,12 @@ import {
   SUPERTONIC_DEFAULT_VOICE_NAMES,
   type SupertonicDefaultVoiceName,
 } from 'react-native-executorch';
-import { AudioContext, type AudioBufferQueueSourceNode } from 'react-native-audio-api';
 
 import ScreenWrapper from '../../components/ScreenWrapper';
 import { ModelPicker } from '../../components/ModelPicker';
 import { ModelStatus } from '../../components/ModelStatus';
 import { Button } from '../../components/Button';
+import { useAudioPlayer } from '../../hooks/useAudioPlayer';
 import { theme } from '../../theme';
 
 const SAMPLE_TEXT =
@@ -66,116 +66,60 @@ function TTSContent() {
   const [speed, setSpeed] = useState(1.05);
   const [totalSteps, setTotalSteps] = useState(8);
   const [isSynthesizing, setIsSynthesizing] = useState(false);
-  const [isPlaying, setIsPlaying] = useState(false);
   const [chunkProgress, setChunkProgress] = useState<string | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
   const [totalDuration, setTotalDuration] = useState<number | null>(null);
 
-  const audioCtxRef = useRef<AudioContext | null>(null);
-  const queueSourceRef = useRef<AudioBufferQueueSourceNode | null>(null);
-  const isPlayingRef = useRef(false);
+  const player = useAudioPlayer(SUPERTONIC_SAMPLE_RATE);
+  const startTimeRef = useRef<number>(0);
 
   const { isReady, downloadProgress, error, synthesize, synthesizeStop } = useTextToSpeech(
     models.textToSpeech.SUPERTONIC[selectedModel]
   );
 
-  const getAudioContext = useCallback(async () => {
-    if (!audioCtxRef.current || audioCtxRef.current.state === 'closed') {
-      audioCtxRef.current = new AudioContext({ sampleRate: SUPERTONIC_SAMPLE_RATE });
-    }
-    if (audioCtxRef.current.state === 'suspended') {
-      await audioCtxRef.current.resume();
-    }
-    return audioCtxRef.current;
-  }, []);
-
-  const stopAudioQueue = useCallback(() => {
-    if (queueSourceRef.current) {
-      queueSourceRef.current.clearBuffers();
-      queueSourceRef.current.stop();
-      queueSourceRef.current = null;
-    }
-    isPlayingRef.current = false;
-    setIsPlaying(false);
-  }, []);
-
   useEffect(() => {
     return () => {
       synthesizeStop?.();
-      stopAudioQueue();
-      if (audioCtxRef.current) {
-        audioCtxRef.current.close().catch(() => {});
-        audioCtxRef.current = null;
-      }
+      player.stop();
     };
-  }, [stopAudioQueue, synthesizeStop]);
-
-  const preparePlaybackSource = useCallback(async () => {
-    stopAudioQueue();
-    const ctx = await getAudioContext();
-
-    const source = ctx.createBufferQueueSource();
-    source.connect(ctx.destination);
-    source.onBufferEnded = (event) => {
-      if (event.isLastBufferInQueue) {
-        isPlayingRef.current = false;
-        setIsPlaying(false);
-      }
-    };
-    queueSourceRef.current = source;
-    return { ctx, source };
-  }, [getAudioContext, stopAudioQueue]);
-
-  const enqueueChunk = useCallback(
-    (ctx: AudioContext, source: AudioBufferQueueSourceNode, audio: Float32Array) => {
-      const buffer = ctx.createBuffer(1, audio.length, SUPERTONIC_SAMPLE_RATE);
-      buffer.copyToChannel(audio as Float32Array<ArrayBuffer>, 0);
-      source.enqueueBuffer(buffer);
-    },
-    []
-  );
+  }, [player, synthesizeStop]);
 
   const handleSynthesize = async () => {
-    if (!synthesize || isSynthesizing || !text.trim()) return;
+    if (!synthesize || isSynthesizing || player.isPlaying || !text.trim()) return;
 
     setRunError(null);
     setChunkProgress(null);
     setTotalDuration(null);
     setIsSynthesizing(true);
+    startTimeRef.current = performance.now();
+    let ttfa: number | null = null;
 
     try {
-      const { ctx, source } = await preparePlaybackSource();
       let durationSum = 0;
-      let started = false;
-      let ttfa: number | null = null;
-      const t0 = performance.now();
-
-      for await (const chunk of synthesize(text, {
+      const chunks = synthesize(text, {
         voiceStyle: selectedVoice,
         speed,
         lang: selectedLang,
         totalSteps,
-      })) {
-        setChunkProgress(
-          `Chunk ${chunk.chunkIndex + 1}/${chunk.totalChunks} (${chunk.duration.toFixed(1)}s)`
-        );
-        durationSum += chunk.duration;
+      });
 
-        enqueueChunk(ctx, source, chunk.audio);
-
-        if (!started) {
-          ttfa = (performance.now() - t0) / 1000;
-          started = true;
-          isPlayingRef.current = true;
-          setIsPlaying(true);
-          source.start(0, 0);
+      await player.playStream(
+        chunks,
+        (chunk) => {
+          setChunkProgress(
+            `Chunk ${chunk.chunkIndex + 1}/${chunk.totalChunks} (${chunk.duration.toFixed(1)}s)`
+          );
+          durationSum += chunk.duration;
+        },
+        () => {
+          ttfa = (performance.now() - startTimeRef.current) / 1000;
         }
-      }
+      );
 
-      const synthMs = performance.now() - t0;
-      const rtf = synthMs / 1000 / durationSum;
+      const synthMs = performance.now() - startTimeRef.current;
+      const rtf = durationSum > 0 ? synthMs / 1000 / durationSum : 0;
       console.log(
-        `[TTS] TTFA ${ttfa?.toFixed(2)}s, synth ${(synthMs / 1000).toFixed(2)}s, audio ${durationSum.toFixed(2)}s, RTF ${rtf.toFixed(3)}`
+        `[TTS] TTFA ${(ttfa as number | null)?.toFixed(2)}s, synth ${(synthMs / 1000).toFixed(2)}s, audio ${durationSum.toFixed(2)}s, RTF ${rtf.toFixed(3)}`
       );
 
       setTotalDuration(durationSum);
@@ -190,11 +134,11 @@ function TTSContent() {
 
   const handleStopPlayback = () => {
     synthesizeStop?.();
-    stopAudioQueue();
+    player.stop();
     setIsSynthesizing(false);
   };
 
-  const isBusy = isSynthesizing || isPlaying;
+  const isBusy = isSynthesizing || player.isPlaying;
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
@@ -288,7 +232,7 @@ function TTSContent() {
       {/* Synthesis Controls */}
       <View style={styles.card}>
         <View style={styles.buttonRow}>
-          {!isPlaying ? (
+          {!player.isPlaying ? (
             <Button
               title={isSynthesizing ? 'Synthesizing...' : 'Synthesize & Play'}
               onPress={handleSynthesize}
@@ -314,7 +258,7 @@ function TTSContent() {
           </View>
         )}
 
-        {isPlaying && (
+        {player.isPlaying && (
           <View style={styles.playingContainer}>
             <View style={styles.playingIndicator} />
             <Text style={styles.playingText}>Playing audio...</Text>

--- a/apps/speech/hooks/useAudioPlayer.ts
+++ b/apps/speech/hooks/useAudioPlayer.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AudioContext, type AudioBufferQueueSourceNode } from 'react-native-audio-api';
+
+/**
+ * An audio chunk yielded by a speech synthesis stream.
+ */
+export interface AudioChunk {
+  /** Float32 PCM audio samples for this chunk, normalized in `[-1, 1]`. */
+  readonly audio: Float32Array;
+  /** Audio sampling rate in Hz. */
+  readonly sampleRate: number;
+}
+
+/**
+ * Controller methods and state for playing streaming TTS audio chunks.
+ */
+export interface AudioPlayerState {
+  /** Whether audio is currently playing or enqueuing. */
+  isPlaying: boolean;
+  /**
+   * Consumes an async generator of TTS chunks, enqueuing and playing them in real-time.
+   * Resolves once all chunks have finished playing.
+   * @param chunks Async iterable stream of audio chunks.
+   * @param onChunk Optional callback invoked when each chunk is received.
+   * @param onFirstAudio Optional callback invoked when the first audio buffer starts.
+   */
+  playStream: <T extends AudioChunk>(
+    chunks: AsyncIterable<T>,
+    onChunk?: (chunk: T) => void,
+    onFirstAudio?: () => void
+  ) => Promise<void>;
+  /** Immediately stops audio playback, clears remaining buffers, and resets state. */
+  stop: () => void;
+}
+
+/**
+ * React hook managing streamed audio buffer queue playback via `react-native-audio-api`.
+ *
+ * Encapsulates the `AudioContext` and `AudioBufferQueueSourceNode` lifecycle,
+ * streams incoming audio chunk buffers directly to native audio output, and
+ * guarantees cleanup on unmount or cancellation.
+ * @param sampleRate The target audio sampling rate in Hz (e.g. 44100 for Supertonic, 24000 for Kokoro).
+ * @returns Audio playback state and controller methods.
+ */
+export function useAudioPlayer(sampleRate: number): AudioPlayerState {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const queueSourceRef = useRef<AudioBufferQueueSourceNode | null>(null);
+  const completionResolverRef = useRef<(() => void) | null>(null);
+  const lastEnqueuedBufferIdRef = useRef<string | null>(null);
+  const streamDoneRef = useRef(false);
+
+  const getAudioContext = useCallback(async () => {
+    if (!audioCtxRef.current || audioCtxRef.current.state === 'closed') {
+      audioCtxRef.current = new AudioContext({ sampleRate });
+    }
+    if (audioCtxRef.current.state === 'suspended') {
+      await audioCtxRef.current.resume();
+    }
+    return audioCtxRef.current;
+  }, [sampleRate]);
+
+  const stop = useCallback(() => {
+    if (queueSourceRef.current) {
+      queueSourceRef.current.clearBuffers();
+      queueSourceRef.current.stop();
+      queueSourceRef.current = null;
+    }
+    setIsPlaying(false);
+    lastEnqueuedBufferIdRef.current = null;
+    streamDoneRef.current = false;
+    if (completionResolverRef.current) {
+      completionResolverRef.current();
+      completionResolverRef.current = null;
+    }
+  }, []);
+
+  const playStream = useCallback(
+    async <T extends AudioChunk>(
+      chunks: AsyncIterable<T>,
+      onChunk?: (chunk: T) => void,
+      onFirstAudio?: () => void
+    ) => {
+      stop();
+      const ctx = await getAudioContext();
+      const source = ctx.createBufferQueueSource();
+      source.connect(ctx.destination);
+      queueSourceRef.current = source;
+      lastEnqueuedBufferIdRef.current = null;
+      streamDoneRef.current = false;
+
+      let started = false;
+
+      const playbackFinished = new Promise<void>((resolve) => {
+        completionResolverRef.current = resolve;
+        source.onBufferEnded = (event) => {
+          if (
+            streamDoneRef.current &&
+            event.bufferId != null &&
+            event.bufferId === lastEnqueuedBufferIdRef.current
+          ) {
+            setIsPlaying(false);
+            completionResolverRef.current = null;
+            resolve();
+          }
+        };
+      });
+
+      try {
+        for await (const chunk of chunks) {
+          if (queueSourceRef.current !== source) break;
+          const buffer = ctx.createBuffer(1, chunk.audio.length, chunk.sampleRate);
+          buffer.copyToChannel(chunk.audio as Float32Array<ArrayBuffer>, 0);
+          const bufferId = source.enqueueBuffer(buffer);
+          lastEnqueuedBufferIdRef.current = bufferId;
+
+          onChunk?.(chunk);
+
+          if (!started) {
+            started = true;
+            setIsPlaying(true);
+            source.start(0, 0);
+            onFirstAudio?.();
+          }
+        }
+        streamDoneRef.current = true;
+      } catch (e) {
+        stop();
+        throw e;
+      }
+
+      await playbackFinished;
+    },
+    [getAudioContext, stop]
+  );
+
+  useEffect(() => {
+    return () => {
+      stop();
+      if (audioCtxRef.current) {
+        audioCtxRef.current.close().catch(() => {});
+        audioCtxRef.current = null;
+      }
+    };
+  }, [stop]);
+
+  return {
+    isPlaying,
+    playStream,
+    stop,
+  };
+}


### PR DESCRIPTION
## Description

Investigated the issue where TTS playback in the speech example app sometimes would not stop or would misreport playback state at the end of speech.

This was **not a bug in ExecuTorch or the synthesis task pipelines**, but an audio API wiring issue in the example app:
1. Both the SuperTonic and Kokoro screens relied solely on `event.isLastBufferInQueue` inside `source.onBufferEnded` to flip `isPlaying` to `false`.
2. When streaming audio chunks via an async generator (`for await (const chunk of synthesize(...))`), if synthesis of a chunk took longer than the duration of preceding chunks, the buffer queue would momentarily underrun. This caused `event.isLastBufferInQueue` to fire `true` prematurely while the synthesis loop was still actively generating more chunks.
3. If new buffers were enqueued while playback was underway, relying on `isLastBufferInQueue` without correlating to the final enqueued chunk produced race conditions where playback termination was never properly signaled to the UI.

### Solution
We adopted the streaming audio player pattern from the `react-native-executorch-gallery` app.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

- [ ] Run the speech example app. The bug described in issue triggers more frequently on lower-end devices.

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

Closes #1420 

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
