### PR TITLE
docs: update requirements in README to match getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,13 @@ pnpm add react-native-executorch react-native-worklets react-native-blob-util
 ```
 
 > [!IMPORTANT]
-> React Native ExecuTorch requires the **New React Native Architecture**, **React Native 0.81+** or **Expo SDK 54+** (using development builds), **iOS 17.0+**, and **Android 13+**.
+> React Native ExecuTorch requires:
+> - **New Architecture** enabled
+> - **React Native 0.83+** or **Expo SDK 55+** with [Development Builds](https://docs.expo.dev/develop/development-builds/introduction/) (**Expo Go is not supported** due to custom C++ native libraries)
+> - **`react-native-worklets` 0.10 or newer** (`>=0.10.0 <0.13.0`)
+> - **iOS 17.0+** / **Android 13+** (`minSdkVersion` >= 26)
+>
+> See the [Getting Started Guide](https://docs.swmansion.com/react-native-executorch/docs/fundamentals/getting-started) and [Compatibility table](https://docs.swmansion.com/react-native-executorch/docs/other/compatibility) for more details.
 
 ### 2. Run the Model
 


### PR DESCRIPTION
## Description

The requirements listed in the root `README.md` were outdated (they stated React Native 0.81+ / Expo SDK 54+ without detailing worklets or Android `minSdkVersion`). This PR aligns the requirements in `README.md` with [`docs/docs/01-fundamentals/01-getting-started.md`](https://docs.swmansion.com/react-native-executorch/docs/fundamentals/getting-started) and the [Compatibility table](https://docs.swmansion.com/react-native-executorch/docs/other/compatibility).

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [ ] Android

### Testing instructions

N/A

### Screenshots

<!-- Add screenshots here, if applicable -->

### Related issues

<!-- Link related issues here using #issue-number -->

### Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings

### Additional notes

<!-- Include any additional information, assumptions, or context that reviewers might need to understand this PR. -->
