### PR TITLE
feat(segmentation): accept an index-map output from Core ML models

### DIFF
--- a/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
@@ -253,18 +253,14 @@ export async function createSemanticSegmenter<L extends PropertyKey = string>(
 
         const colormapData = modelOpts.labels.map((l) => returnColormap![l]);
 
-        if (indexMap) {
-          // The graph already did the argmax, so there is nothing to reduce:
-          // reshape the (1,H,W) index map to the (H,W,1) the colormap wants.
-          // This also skips the toChannelsLast transpose over H*W*K floats.
-          tOutput.copyTo(tMask).through(applyColormap, tRgba, colormapData);
-        } else {
-          tOutput
-            .copyTo(tReshape)
-            .through(toChannelsLast, tChanLast)
-            .through(argmax, tMask, -1)
-            .through(applyColormap, tRgba, colormapData);
-        }
+        // An index-map model already did the argmax in the graph, so both the
+        // transpose over H*W*K floats and the reduction are skipped and the
+        // (1,H,W) indices go straight into the (H,W,1) the colormap wants.
+        tOutput
+          .copyTo(indexMap ? tMask : tReshape)
+          .throughIf(!indexMap, toChannelsLast, tChanLast)
+          .throughIf(!indexMap, argmax, tMask, -1)
+          .through(applyColormap, tRgba, colormapData);
       } else {
         tOutput
           .copyTo(tReshape)

--- a/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
+++ b/packages/react-native-executorch/src/extensions/cv/tasks/semanticSegmentation.ts
@@ -7,7 +7,7 @@ import type { WorkletRuntime } from 'react-native-worklets';
 
 import { tensor } from '../../../core/tensor';
 import { loadModel } from '../../../core/model';
-import { validateSpec, method, f32 } from '../../../core/schema';
+import { validateSpec, method, f32, i32 } from '../../../core/schema';
 import { wrapAsync } from '../../../core/runtime';
 
 import type { ImageBuffer } from '../image';
@@ -168,11 +168,40 @@ export async function createSemanticSegmenter<L extends PropertyKey = string>(
         [f32(3, 'H', 'W')],
         [f32('K', 'H', 'W')]
       ),
+      // Models that run the argmax inside the graph return the class index per
+      // pixel instead of a logit per class: (1,H,W) int32 rather than
+      // (1,K,H,W) float32, which is 22.71 MB -> 1.08 MB on the 21-class models.
+      // K cannot be read off the shape here, so it comes from the labels.
+      batchedIndex: method(
+        'forward', // prettier-ignore
+        [f32(1, 3, 'H', 'W')],
+        [i32(1, 'H', 'W')]
+      ),
+      unbatchedIndex: method(
+        'forward', // prettier-ignore
+        [f32(3, 'H', 'W')],
+        [i32('H', 'W')]
+      ),
     });
 
-    const [nClasses, H, W] = dims.constant('K', 'H', 'W');
-    const inpShape = { batched: [1, 3, H, W], unbatched: [3, H, W] }[variant];
-    const outShape = { batched: [1, nClasses, H, W], unbatched: [nClasses, H, W] }[variant];
+    // An index-map model has no K in its output shape, so the class count comes
+    // from the labels the caller configured. The logit models keep reading it
+    // off the shape, which also keeps the labels/classes guard meaningful.
+    const indexMap = variant === 'batchedIndex' || variant === 'unbatchedIndex';
+    const [H, W] = dims.constant('H', 'W');
+    const nClasses = indexMap ? modelOpts.labels.length : dims.constant('K')[0]!;
+    const inpShape = {
+      batched: [1, 3, H, W],
+      unbatched: [3, H, W],
+      batchedIndex: [1, 3, H, W],
+      unbatchedIndex: [3, H, W],
+    }[variant];
+    const outShape = {
+      batched: [1, nClasses, H, W],
+      unbatched: [nClasses, H, W],
+      batchedIndex: [1, H, W],
+      unbatchedIndex: [H, W],
+    }[variant];
 
     // Generate highly distinct, high-contrast colors, see:
     // https://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically/
@@ -189,7 +218,7 @@ export async function createSemanticSegmenter<L extends PropertyKey = string>(
     }
 
     const tensors = [
-      tensor('float32', outShape),
+      tensor(indexMap ? 'int32' : 'float32', outShape),
       tensor('float32', [nClasses, H, W]),
       tensor('float32', [nClasses, H, W]),
       tensor('float32', [H, W, nClasses]),
@@ -224,11 +253,18 @@ export async function createSemanticSegmenter<L extends PropertyKey = string>(
 
         const colormapData = modelOpts.labels.map((l) => returnColormap![l]);
 
-        tOutput
-          .copyTo(tReshape)
-          .through(toChannelsLast, tChanLast)
-          .through(argmax, tMask, -1)
-          .through(applyColormap, tRgba, colormapData);
+        if (indexMap) {
+          // The graph already did the argmax, so there is nothing to reduce:
+          // reshape the (1,H,W) index map to the (H,W,1) the colormap wants.
+          // This also skips the toChannelsLast transpose over H*W*K floats.
+          tOutput.copyTo(tMask).through(applyColormap, tRgba, colormapData);
+        } else {
+          tOutput
+            .copyTo(tReshape)
+            .through(toChannelsLast, tChanLast)
+            .through(argmax, tMask, -1)
+            .through(applyColormap, tRgba, colormapData);
+        }
       } else {
         tOutput
           .copyTo(tReshape)

--- a/packages/react-native-executorch/src/models.ts
+++ b/packages/react-native-executorch/src/models.ts
@@ -172,12 +172,16 @@ function family<V extends Record<string, { readonly DEFAULT: unknown }>>(
 }
 
 const BASE_URL = 'https://huggingface.co/software-mansion/react-native-executorch';
-// Every model currently resolves through VERSION_TAG, the latest published
-// stable tag. `NEXT_VERSION_TAG = 'resolve/v0.11.0'` gets declared next to this
-// one by the first model re-exported for 0.11, and each such model's URL moves
-// over to it; the constant is absent until then rather than declared and unused,
-// because noUnusedLocals rejects a constant nothing reads.
+// Models resolve through VERSION_TAG, the latest published stable tag, unless
+// they have been re-exported for the next release, in which case their URL moves
+// over to NEXT_VERSION_TAG. Both tags are pinned snapshots, so a model only
+// changes when its URL is moved here.
 const VERSION_TAG = 'resolve/v0.10.0';
+// Semantic segmentation models re-exported for 0.11: their Core ML variants now
+// emit an index map instead of per-class logits (see the `batchedIndex` and
+// `unbatchedIndex` schema variants). The XNNPACK variants are unchanged and stay
+// on VERSION_TAG.
+const NEXT_VERSION_TAG = 'resolve/v0.11.0';
 
 // =============================================================================
 // Classification
@@ -303,7 +307,7 @@ const LRASPP_MOBILENET_V3_LARGE_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLa
   modelOpts: LRASPP_MOBILENET_V3_LARGE_OPTS,
 };
 const LRASPP_MOBILENET_V3_LARGE_COREML_FP16: SemanticSegmenterModel<PascalVocLabel> = {
-  modelPath: `${BASE_URL}-lraspp/${VERSION_TAG}/coreml/lraspp_mobilenet_v3_large_coreml_fp16.pte`,
+  modelPath: `${BASE_URL}-lraspp/${NEXT_VERSION_TAG}/coreml/lraspp_mobilenet_v3_large_coreml_fp16.pte`,
   modelOpts: LRASPP_MOBILENET_V3_LARGE_OPTS,
 };
 
@@ -323,7 +327,7 @@ const DEEPLAB_V3_RESNET50_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> =
   modelOpts: DEEPLAB_V3_OPTS,
 };
 const DEEPLAB_V3_RESNET50_COREML_FP16: SemanticSegmenterModel<PascalVocLabel> = {
-  modelPath: `${BASE_URL}-deeplab-v3/${VERSION_TAG}/coreml/deeplab_v3_resnet50_coreml_fp16.pte`,
+  modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/coreml/deeplab_v3_resnet50_coreml_fp16.pte`,
   modelOpts: DEEPLAB_V3_OPTS,
 };
 const DEEPLAB_V3_RESNET101_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
@@ -335,7 +339,7 @@ const DEEPLAB_V3_RESNET101_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> 
   modelOpts: DEEPLAB_V3_OPTS,
 };
 const DEEPLAB_V3_RESNET101_COREML_FP16: SemanticSegmenterModel<PascalVocLabel> = {
-  modelPath: `${BASE_URL}-deeplab-v3/${VERSION_TAG}/coreml/deeplab_v3_resnet101_coreml_fp16.pte`,
+  modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/coreml/deeplab_v3_resnet101_coreml_fp16.pte`,
   modelOpts: DEEPLAB_V3_OPTS,
 };
 const DEEPLAB_V3_MOBILENET_V3_LARGE_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
@@ -347,7 +351,7 @@ const DEEPLAB_V3_MOBILENET_V3_LARGE_XNNPACK_INT8: SemanticSegmenterModel<PascalV
   modelOpts: DEEPLAB_V3_OPTS,
 };
 const DEEPLAB_V3_MOBILENET_V3_LARGE_COREML_FP16: SemanticSegmenterModel<PascalVocLabel> = {
-  modelPath: `${BASE_URL}-deeplab-v3/${VERSION_TAG}/coreml/deeplab_v3_mobilenet_v3_large_coreml_fp16.pte`,
+  modelPath: `${BASE_URL}-deeplab-v3/${NEXT_VERSION_TAG}/coreml/deeplab_v3_mobilenet_v3_large_coreml_fp16.pte`,
   modelOpts: DEEPLAB_V3_OPTS,
 };
 
@@ -367,7 +371,7 @@ const FCN_RESNET50_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> = {
   modelOpts: FCN_OPTS,
 };
 const FCN_RESNET50_COREML_FP16: SemanticSegmenterModel<PascalVocLabel> = {
-  modelPath: `${BASE_URL}-fcn/${VERSION_TAG}/coreml/fcn_resnet50_coreml_fp16.pte`,
+  modelPath: `${BASE_URL}-fcn/${NEXT_VERSION_TAG}/coreml/fcn_resnet50_coreml_fp16.pte`,
   modelOpts: FCN_OPTS,
 };
 const FCN_RESNET101_XNNPACK_FP32: SemanticSegmenterModel<PascalVocLabel> = {
@@ -379,7 +383,7 @@ const FCN_RESNET101_XNNPACK_INT8: SemanticSegmenterModel<PascalVocLabel> = {
   modelOpts: FCN_OPTS,
 };
 const FCN_RESNET101_COREML_FP16: SemanticSegmenterModel<PascalVocLabel> = {
-  modelPath: `${BASE_URL}-fcn/${VERSION_TAG}/coreml/fcn_resnet101_coreml_fp16.pte`,
+  modelPath: `${BASE_URL}-fcn/${NEXT_VERSION_TAG}/coreml/fcn_resnet101_coreml_fp16.pte`,
   modelOpts: FCN_OPTS,
 };
 


### PR DESCRIPTION
## Description

Core ML segmentation models can now return a `(1,H,W)` int32 index map instead of `(1,K,H,W)` float32 logits. The task already reduced those logits away immediately, so nothing downstream loses information.

Measured on an iPhone 16, all six Core ML segmentation models, 10 iterations after 2 warmups:

| model | before ms | after ms | speedup | peak MB | mem cut |
|---|---|---|---|---|---|
| lraspp-mobilenet-v3-large | 12.63 | 7.75 | 1.63x | 250.97 -> 177.72 | 29% |
| deeplab-v3-mobilenet-v3-large | 31.16 | 25.42 | 1.23x | 253.53 -> 195.25 | 23% |
| fcn-resnet50 | 53.66 | 47.95 | 1.12x | 320.86 -> 297.25 | 7% |
| fcn-resnet101 | 70.65 | 65.41 | 1.08x | 364.05 -> 302.50 | 17% |
| deeplab-v3-resnet50 | 106.29 | 100.85 | 1.05x | 309.00 -> 161.39 | 48% |
| deeplab-v3-resnet101 | 123.08 | 117.51 | 1.05x | 236.09 -> 162.69 | 31% |

The saving is a near constant 5 to 5.7 ms because the argmax cost depends only on the output shape, which is identical across all six. That is a large relative win on the light models and a small one on the heavy backbones, while the memory saving lands everywhere.

The re-exported artifacts are published under the `v0.11.0` tag; this branch points the six Core ML models at it. XNNPACK stays on `v0.10.0`.

### The part worth knowing

`torch.argmax` is the wrong way to do this and makes it **2x slower** (31 -> 65 ms). Core ML lowers it to `ios18.reduce_argmax`, which has no ANE kernel and is pinned to the CPU, so the ANE writes all 21 channels out anyway and the CPU reduces 5.7M elements. The compute plan shows it directly: 194 ANE ops and 1 CPU op.

Building the same reduction from `reduce_max` and elementwise ops keeps it on the ANE (200 ANE ops, 1 CPU op, a cast over 270K elements) and is pixel-exact against `torch.argmax`, ties included.

This is Core ML only. XNNPACK delegates neither `argmax` nor `amax`/`eq`, so the same rewrite splits the graph into 3 delegates and measures **1.19x slower** (160.04 -> 190.21 ms). XNNPACK variants keep the logits contract.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] New feature (change which adds functionality)

### Tested on

- [x] iOS
- [ ] Android

### Testing instructions

With a local index-map `.pte`, `useSemanticSegmenter` resolves the `batchedIndex` schema variant and renders through the colormap branch without the JS argmax. Models emitting logits are unaffected. Please A/B against `main` to confirm the new models are actually faster.

### Related issues

Closes #1459, with a correction: the issue attributed the cost to output bandwidth, and its proposed implementation would have made things slower. The win comes from keeping the reduction on the ANE.

