### PR TITLE
fix(libs): stop shipping backends the app opted out of

### DIFF
--- a/docs/docs/03-core-and-advanced/08-native-libraries.md
+++ b/docs/docs/03-core-and-advanced/08-native-libraries.md
@@ -93,7 +93,7 @@ Specifying a task under `features` is shorthand: it automatically expands to the
 | `imageEmbeddings`      | xnnpack, coreml, mlx, vulkan | opencv              |
 | `classification`       | xnnpack, coreml              | opencv              |
 | `objectDetection`      | xnnpack, coreml              | opencv              |
-| `keypointDetection`    | xnnpack, coreml              | opencv              |
+| `keypointDetection`    | xnnpack, coreml, mlx         | opencv              |
 | `semanticSegmentation` | xnnpack, coreml              | opencv              |
 | `instanceSegmentation` | xnnpack, coreml              | opencv              |
 | `ocr`                  | xnnpack, coreml, vulkan      | opencv              |

--- a/docs/docs/03-core-and-advanced/08-native-libraries.md
+++ b/docs/docs/03-core-and-advanced/08-native-libraries.md
@@ -102,3 +102,60 @@ Specifying a task under `features` is shorthand: it automatically expands to the
 | `textToImage`          | xnnpack, coreml              | opencv              |
 | `segmentAnything`      | xnnpack, coreml              | opencv              |
 | `tokenizer`            | —                            | —                   |
+
+## Binary size
+
+What the backends actually cost, measured rather than estimated. Both tables come
+from `apps/legacy/bare-rn` built in Release with OpenCV and phonemis enabled, so
+the absolute figures move with which features you compile in. **The deltas between
+rows are the transferable part.**
+
+### Android
+
+`arm64-v8a`, symbols stripped as the APK ships them. Covers `libexecutorch.so`,
+the backend libraries, and `libRnExecutorch.so`; it excludes React Native's own
+libraries, which do not change with this configuration.
+
+| backends             | in the APK | ≈ Play download |
+| -------------------- | ---------- | --------------- |
+| `xnnpack`            | 25.18 MB   | 8.16 MB         |
+| `vulkan`             | 33.83 MB   | 9.79 MB         |
+| `xnnpack` + `vulkan` | 36.38 MB   | 10.68 MB        |
+
+Per library:
+
+| library                            | stripped | gzipped |
+| ---------------------------------- | -------- | ------- |
+| `libexecutorch.so`                 | 12.82 MB | 4.39 MB |
+| `libvulkan_executorch_backend.so`  | 11.19 MB | 2.52 MB |
+| `libRnExecutorch.so`               | 9.80 MB  | 2.87 MB |
+| `libxnnpack_executorch_backend.so` | 2.54 MB  | 0.88 MB |
+
+`extractNativeLibs=false` is the default from React Native 0.73, so the install
+grows by the uncompressed figure; the Play column is the compressed transfer.
+
+Vulkan is ~4.4x XNNPACK and almost entirely data: 8.73 MB of its 11.19 MB is
+`.rodata`, effectively embedded SPIR-V, against 2.02 MB of `.text`. It also
+compresses far better than its size suggests.
+
+### iOS
+
+Mach-O size of the app binary, `arm64`, device slice. Each row is a full relink.
+
+| backends                     | app binary | added by the last backend |
+| ---------------------------- | ---------- | ------------------------- |
+| none                         | 19.33 MB   | —                         |
+| `xnnpack`                    | 20.75 MB   | +1.41 MB                  |
+| `xnnpack` + `coreml`         | 21.12 MB   | +0.37 MB                  |
+| `xnnpack` + `coreml` + `mlx` | 26.07 MB   | +4.95 MB                  |
+
+MLX also ships `mlx.metallib` (1.07 MB) as a bundle resource, which is on top of
+the binary.
+
+A backend costs roughly a third of its archive on disk: XNNPACK is a 3.79 MB
+archive for 1.41 MB linked, MLX 15.09 MB for 4.95 MB. The backends are attached
+with `-force_load`, which defeats archive member selection but **not**
+dead-stripping, so the linker still drops what your app cannot reach.
+
+iOS starts leaner than Android because the ExecuTorch runtime is dead-stripped
+into the binary rather than shipped as a standalone library.

--- a/docs/docs/03-core-and-advanced/08-native-libraries.md
+++ b/docs/docs/03-core-and-advanced/08-native-libraries.md
@@ -93,7 +93,7 @@ Specifying a task under `features` is shorthand: it automatically expands to the
 | `imageEmbeddings`      | xnnpack, coreml, mlx, vulkan | opencv              |
 | `classification`       | xnnpack, coreml              | opencv              |
 | `objectDetection`      | xnnpack, coreml              | opencv              |
-| `keypointDetection`    | xnnpack, coreml, mlx         | opencv              |
+| `keypointDetection`    | xnnpack, coreml              | opencv              |
 | `semanticSegmentation` | xnnpack, coreml              | opencv              |
 | `instanceSegmentation` | xnnpack, coreml              | opencv              |
 | `ocr`                  | xnnpack, coreml, vulkan      | opencv              |

--- a/docs/docs/05-other/02-troubleshooting.md
+++ b/docs/docs/05-other/02-troubleshooting.md
@@ -164,3 +164,15 @@ app to the supported ABIs:
 ```properties
 reactNativeArchitectures=arm64-v8a,x86_64
 ```
+
+## `global.loadOCR is not a function`
+
+The deprecated legacy API registers one `load*` global per task, and the tasks
+backed by a native third-party library are only registered when that library is
+compiled in. Opting out of `opencv` therefore drops the legacy vision hooks
+(`useOCR`, `useVerticalOCR`, `useClassification`, `useObjectDetection`,
+`usePoseEstimation`, `useStyleTransfer`, `useSemanticSegmentation`,
+`useInstanceSegmentation`, `useImageEmbeddings`, `useTextToImage`), and opting
+out of `phonemis` drops `useTextToSpeech`. They build fine and throw this on
+first use. Add the library back under `libs`, or list a `feature` that expands
+to it, in [Native Libraries](../03-core-and-advanced/08-native-libraries.md).

--- a/packages/react-native-executorch/__tests__/api/modelVariants.test.ts
+++ b/packages/react-native-executorch/__tests__/api/modelVariants.test.ts
@@ -470,8 +470,8 @@ describe('feature map', () => {
     for (const [, feature, backends, libs] of doc.matchAll(
       /^\|\s*`(\w+)`\s*\|\s*([^|]*?)\s*\|\s*([^|]*?)\s*\|$/gm
     )) {
-      if (FEATURE_MAP[feature])
-        documented.set(feature, { backends: cell(backends), libs: cell(libs) });
+      if (FEATURE_MAP[feature!])
+        documented.set(feature!, { backends: cell(backends!), libs: cell(libs!) });
     }
 
     expect([...documented.keys()].sort()).toEqual(Object.keys(FEATURE_MAP).sort());

--- a/packages/react-native-executorch/__tests__/api/modelVariants.test.ts
+++ b/packages/react-native-executorch/__tests__/api/modelVariants.test.ts
@@ -394,4 +394,27 @@ describe('feature map', () => {
 
     expect(offenders.sort()).toEqual([]);
   });
+
+  it('provisions no backend the registry does not publish for that feature', () => {
+    // The mirror of the case above, and the one that actually bites: a feature
+    // naming a backend nothing in its family exports makes every app using that
+    // feature download a library it can never load. keypointDetection carried
+    // `mlx` this way, which no keypoint model has ever published.
+    const offenders: string[] = [];
+
+    for (const [category, node] of Object.entries(registry)) {
+      const feature = FEATURE_OF_CATEGORY[category]!;
+      // `llm` is the one category two features cover, so neither entry alone has
+      // to justify every backend it names.
+      if (feature === 'llm') continue;
+
+      const published = publishedBackends(node);
+      for (const backend of FEATURE_MAP[feature].backends) {
+        if (!published.has(backend))
+          offenders.push(`${feature} provisions ${backend}, unpublished`);
+      }
+    }
+
+    expect(offenders.sort()).toEqual([]);
+  });
 });

--- a/packages/react-native-executorch/__tests__/api/modelVariants.test.ts
+++ b/packages/react-native-executorch/__tests__/api/modelVariants.test.ts
@@ -369,6 +369,46 @@ describe('feature map', () => {
     return found;
   }
 
+  /** The Hugging Face repo slugs a registry category's URLs point at. */
+  function repoSlugs(node: unknown): Set<string> {
+    const found = new Set<string>();
+    const walk = (value: unknown): void => {
+      if (typeof value === 'string') {
+        const match = value.match(/react-native-executorch-([^/]+)\//);
+        if (match) found.add(match[1]!);
+      } else if (Array.isArray(value)) value.forEach(walk);
+      else if (isObject(value)) Object.values(value).forEach(walk);
+    };
+    walk(node);
+    return found;
+  }
+
+  // `features` provisions for the whole package, and the legacy API keeps model
+  // URLs the new registry has since dropped: the RF-DETR keypoint MLX export
+  // removed in #1418 is still reachable as
+  // RF_DETR_KEYPOINT_PREVIEW_MLX_FP32_MODEL. Those count as published, matched
+  // to a feature through the repo slug they share with the new registry; a
+  // legacy-only slug cannot be classified that way and is skipped.
+  const legacyBackendsBySlug = (() => {
+    const source = readFileSync(join(__dirname, '../../legacy/src/constants/modelUrls.ts'), 'utf8');
+    const bySlug = new Map<string, Set<string>>();
+    for (const [, slug, backend] of source.matchAll(
+      /\$\{URL_PREFIX\}-([^/`]+)\/[^`]*?\/(xnnpack|coreml|mlx|vulkan)\//g
+    )) {
+      if (!bySlug.has(slug!)) bySlug.set(slug!, new Set());
+      bySlug.get(slug!)!.add(backend!);
+    }
+    return bySlug;
+  })();
+
+  /** New-registry exports for a category, plus the legacy ones for its repos. */
+  function allPublishedBackends(node: unknown): Set<string> {
+    const found = publishedBackends(node);
+    for (const slug of repoSlugs(node))
+      for (const backend of legacyBackendsBySlug.get(slug) ?? []) found.add(backend);
+    return found;
+  }
+
   const registry = registryFor({ os: 'ios' });
 
   it('names a feature for every registry category', () => {
@@ -395,11 +435,10 @@ describe('feature map', () => {
     expect(offenders.sort()).toEqual([]);
   });
 
-  it('provisions no backend the registry does not publish for that feature', () => {
+  it('provisions no backend neither API publishes for that feature', () => {
     // The mirror of the case above, and the one that actually bites: a feature
     // naming a backend nothing in its family exports makes every app using that
-    // feature download a library it can never load. keypointDetection carried
-    // `mlx` after the one keypoint MLX export was dropped in #1418.
+    // feature download a library it can never load.
     const offenders: string[] = [];
 
     for (const [category, node] of Object.entries(registry)) {
@@ -408,7 +447,7 @@ describe('feature map', () => {
       // to justify every backend it names.
       if (feature === 'llm') continue;
 
-      const published = publishedBackends(node);
+      const published = allPublishedBackends(node);
       for (const backend of FEATURE_MAP[feature].backends) {
         if (!published.has(backend))
           offenders.push(`${feature} provisions ${backend}, unpublished`);

--- a/packages/react-native-executorch/__tests__/api/modelVariants.test.ts
+++ b/packages/react-native-executorch/__tests__/api/modelVariants.test.ts
@@ -399,7 +399,7 @@ describe('feature map', () => {
     // The mirror of the case above, and the one that actually bites: a feature
     // naming a backend nothing in its family exports makes every app using that
     // feature download a library it can never load. keypointDetection carried
-    // `mlx` this way, which no keypoint model has ever published.
+    // `mlx` after the one keypoint MLX export was dropped in #1418.
     const offenders: string[] = [];
 
     for (const [category, node] of Object.entries(registry)) {
@@ -416,5 +416,31 @@ describe('feature map', () => {
     }
 
     expect(offenders.sort()).toEqual([]);
+  });
+
+  it('matches the feature table in the native libraries doc', () => {
+    // The table is the only place a user reads this map, so it drifting is the
+    // same bug as the map being wrong.
+    const doc = readFileSync(
+      join(__dirname, '../../../../docs/docs/03-core-and-advanced/08-native-libraries.md'),
+      'utf8'
+    );
+    const cell = (value: string) => (value === '—' ? [] : value.split(',').map((s) => s.trim()));
+
+    const documented = new Map<string, { backends: string[]; libs: string[] }>();
+    for (const [, feature, backends, libs] of doc.matchAll(
+      /^\|\s*`(\w+)`\s*\|\s*([^|]*?)\s*\|\s*([^|]*?)\s*\|$/gm
+    )) {
+      if (FEATURE_MAP[feature])
+        documented.set(feature, { backends: cell(backends), libs: cell(libs) });
+    }
+
+    expect([...documented.keys()].sort()).toEqual(Object.keys(FEATURE_MAP).sort());
+    for (const [feature, row] of documented) {
+      expect([feature, row]).toEqual([
+        feature,
+        { backends: FEATURE_MAP[feature].backends, libs: FEATURE_MAP[feature].libs },
+      ]);
+    }
   });
 });

--- a/packages/react-native-executorch/__tests__/legacy/installGuard.test.ts
+++ b/packages/react-native-executorch/__tests__/legacy/installGuard.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The legacy entry installs the JSI bindings as an import-time side effect,
+ * guarded by a check for globals that are already present. Opting out of a
+ * native library removes the per-task globals by design, so the guard reads
+ * only the two that are registered unconditionally. These tests pin that: a
+ * guard listing an opt-out-able global can never go false again, and install()
+ * would re-run on every module evaluation.
+ */
+const mockInstall = jest.fn();
+
+jest.mock('../../legacy/src/native/RnExecutorchModules', () => ({
+  ETInstallerNativeModule: { install: () => mockInstall() },
+}));
+
+// The entry re-exports the whole legacy surface, so importing it pulls in the
+// model registry and, through it, a native event emitter that has no host here.
+jest.mock('react-native-device-info', () => ({ isEmulatorSync: () => false }));
+
+// Every global RnExecutorchInstaller::injectJSIBindings registers outside an
+// #ifdef. The guard reads only SENTINELS; the rest are here so the all-libs-on
+// case is faithful.
+const SENTINELS = ['loadExecutorchModule', '__rne_isEmulator'] as const;
+const ALWAYS_REGISTERED = [
+  ...SENTINELS,
+  'loadLLM',
+  'loadPrivacyFilter',
+  'loadSpeechToText',
+  'loadTextEmbeddings',
+  'loadTokenizerModule',
+  'loadVAD',
+] as const;
+
+// Registered only when their native library is compiled in.
+const OPENCV_BACKED = [
+  'loadOCR',
+  'loadVerticalOCR',
+  'loadClassification',
+  'loadObjectDetection',
+  'loadPoseEstimation',
+  'loadStyleTransfer',
+  'loadSemanticSegmentation',
+  'loadInstanceSegmentation',
+  'loadImageEmbeddings',
+  'loadTextToImage',
+] as const;
+const PHONEMIS_BACKED = ['loadTextToSpeechKokoro'] as const;
+
+const ALL = [...ALWAYS_REGISTERED, ...OPENCV_BACKED, ...PHONEMIS_BACKED];
+
+function setGlobals(names: readonly string[]) {
+  for (const name of ALL) delete (globalThis as any)[name];
+  for (const name of names) {
+    (globalThis as any)[name] = name === '__rne_isEmulator' ? false : () => {};
+  }
+}
+
+function loadLegacyEntry() {
+  jest.isolateModules(() => {
+    require('../../legacy/src/index');
+  });
+}
+
+let warn: jest.SpyInstance;
+beforeEach(() => {
+  warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  warn.mockRestore();
+  setGlobals([]);
+});
+
+describe('the legacy install guard', () => {
+  it('installs when the bindings are not there yet', () => {
+    setGlobals([]);
+    loadLegacyEntry();
+    expect(mockInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reinstall once the unconditional globals are set', () => {
+    setGlobals(ALL);
+    loadLegacyEntry();
+    expect(mockInstall).not.toHaveBeenCalled();
+  });
+
+  it('does not reinstall when opencv was opted out', () => {
+    setGlobals([...ALWAYS_REGISTERED, ...PHONEMIS_BACKED]);
+    loadLegacyEntry();
+    expect(mockInstall).not.toHaveBeenCalled();
+  });
+
+  it('does not reinstall when phonemis was opted out', () => {
+    setGlobals([...ALWAYS_REGISTERED, ...OPENCV_BACKED]);
+    loadLegacyEntry();
+    expect(mockInstall).not.toHaveBeenCalled();
+  });
+
+  it('does not reinstall when both libraries were opted out', () => {
+    setGlobals(ALWAYS_REGISTERED);
+    loadLegacyEntry();
+    expect(mockInstall).not.toHaveBeenCalled();
+  });
+
+  it('still installs if a sentinel is missing', () => {
+    setGlobals([...OPENCV_BACKED, ...PHONEMIS_BACKED, '__rne_isEmulator']);
+    loadLegacyEntry();
+    expect(mockInstall).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-native-executorch/android/build.gradle.kts
+++ b/packages/react-native-executorch/android/build.gradle.kts
@@ -144,8 +144,13 @@ android {
         getByName("main") {
             // Prebuilt executorch + backend .so live under
             // third-party/android/libs/executorch/<abi>/. Pointing jniLibs here
-            // makes Gradle package them (libexecutorch.so + the enabled
-            // lib*_executorch_backend.so) into the APK alongside our own .so.
+            // makes Gradle package them into the APK alongside our own .so.
+            //
+            // Gradle packages every .so it finds under a jniLibs source dir, so
+            // this alone ships backends the app opted out of: -DRNE_ENABLE_* only
+            // stops CMake importing and linking them, which is enough for
+            // behaviour but has no bearing on packaging. `packaging.jniLibs
+            // .excludes` below drops the disabled ones back out.
             jniLibs.srcDirs("../third-party/android/libs/executorch")
             // Include generated codegen if using TurboModules
             java.srcDirs("${project.buildDir}/generated/source/codegen/java")
@@ -160,6 +165,25 @@ android {
     packaging {
         // Prevents "Duplicate Library" errors with the React Native JSI engine
         resources.excludes.add("**/libjsi.so")
+
+        // Ship only the backends the resolved config asks for. Without this an
+        // app declaring `backends: ["vulkan"]` still carries 2.67 MB of XNNPACK
+        // that nothing links, registers or loads, because jniLibs packages the
+        // directory rather than the link graph. This is the Android counterpart
+        // of the podspec deciding its -force_load entries from the same config.
+        //
+        // Keyed off the backend .so names rather than a staging dir so that a
+        // user who provisions third-party/ by hand gets the same treatment.
+        val backendLibs = mapOf(
+            "enableXnnpack" to "libxnnpack_executorch_backend.so",
+            "enableVulkan" to "libvulkan_executorch_backend.so"
+        )
+        for ((flag, soName) in backendLibs) {
+            if (rneConfig[flag] == false) {
+                logger.lifecycle("[RnExecutorch] $flag is off; excluding $soName from the APK")
+                jniLibs.excludes.add("**/$soName")
+            }
+        }
     }
 
     compileOptions {

--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-executorch",
   "version": "0.11.0",
-  "nativeLibsVersion": "0.10.0",
+  "nativeLibsVersion": "0.10.1",
   "description": "An easy way to run AI models in React Native with ExecuTorch",
   "main": "./lib/module/index.js",
   "module": "./lib/module/index.js",

--- a/packages/react-native-executorch/scripts/download-libs.js
+++ b/packages/react-native-executorch/scripts/download-libs.js
@@ -493,7 +493,9 @@ function pruneDisabledBackends(targets, { backends }) {
       if (backends.includes(backend)) continue;
       for (const pattern of patterns) {
         for (const stale of expandPattern(destDir, pattern)) {
-          console.log(`[react-native-executorch] Removing ${backend} binary (not enabled): ${path.relative(THIRD_PARTY_DIR, stale)}`);
+          console.log(
+            `[react-native-executorch] Removing ${backend} binary (not enabled): ${path.relative(THIRD_PARTY_DIR, stale)}`
+          );
           fs.rmSync(stale, { recursive: true, force: true });
         }
       }

--- a/packages/react-native-executorch/scripts/download-libs.js
+++ b/packages/react-native-executorch/scripts/download-libs.js
@@ -152,9 +152,11 @@ const FEATURE_MAP = {
   // YOLO is xnnpack-only, ssdlite/rf_detr add coreml → union.
   objectDetection: { backends: ['xnnpack', 'coreml'], libs: ['opencv'] },
   // Keypoint detection (#1280): BlazeFace + YOLO26-pose ship xnnpack; RF-DETR
-  // keypoint adds coreml → union. No MLX: nothing in this family publishes one.
+  // keypoint adds coreml → union. mlx stays for the legacy API, whose
+  // RF_DETR_KEYPOINT_PREVIEW_MLX_FP32_MODEL outlived the new registry's MLX
+  // keypoint export (dropped in #1418).
   // (Named to track the useKeypointDetector hook; main calls this poseEstimation.)
-  keypointDetection: { backends: ['xnnpack', 'coreml'], libs: ['opencv'] },
+  keypointDetection: { backends: ['xnnpack', 'coreml', 'mlx'], libs: ['opencv'] },
   // DeepLab/FCN/LR-ASPP/selfie all ship xnnpack + coreml.
   semanticSegmentation: { backends: ['xnnpack', 'coreml'], libs: ['opencv'] },
   // YOLO-seg xnnpack-only, rf_detr-seg/fastsam add coreml → union.

--- a/packages/react-native-executorch/scripts/download-libs.js
+++ b/packages/react-native-executorch/scripts/download-libs.js
@@ -152,9 +152,9 @@ const FEATURE_MAP = {
   // YOLO is xnnpack-only, ssdlite/rf_detr add coreml → union.
   objectDetection: { backends: ['xnnpack', 'coreml'], libs: ['opencv'] },
   // Keypoint detection (#1280): BlazeFace + YOLO26-pose ship xnnpack; RF-DETR
-  // keypoint adds coreml + mlx → union. (Named to track the useKeypointDetector
-  // hook; main calls this poseEstimation.)
-  keypointDetection: { backends: ['xnnpack', 'coreml', 'mlx'], libs: ['opencv'] },
+  // keypoint adds coreml → union. No MLX: nothing in this family publishes one.
+  // (Named to track the useKeypointDetector hook; main calls this poseEstimation.)
+  keypointDetection: { backends: ['xnnpack', 'coreml'], libs: ['opencv'] },
   // DeepLab/FCN/LR-ASPP/selfie all ship xnnpack + coreml.
   semanticSegmentation: { backends: ['xnnpack', 'coreml'], libs: ['opencv'] },
   // YOLO-seg xnnpack-only, rf_detr-seg/fastsam add coreml → union.

--- a/packages/react-native-executorch/scripts/download-libs.js
+++ b/packages/react-native-executorch/scripts/download-libs.js
@@ -11,9 +11,10 @@
  *
  *   headers.tar.gz                   -- ExecuTorch + c10 + torch + tokenizers + opencv
  *                                       headers (platform-independent; always downloaded)
- *   core-android-arm64-v8a.tar.gz    -- executorch, pthreadpool, cpuinfo for arm64
- *   core-android-x86_64.tar.gz       -- executorch for x86_64
- *   core-ios.tar.gz                  -- ExecutorchLib.xcframework (without xnnpack/coreml)
+ *   core-android-arm64-v8a.tar.gz    -- libexecutorch.so (+ executorch.jar) for arm64;
+ *                                       pthreadpool and cpuinfo are statically linked in
+ *   core-android-x86_64.tar.gz       -- libexecutorch.so for x86_64
+ *   core-ios.tar.gz                  -- ExecutorchLib.xcframework + libthreadpool_*.a
  *   opencv-android-arm64-v8a.tar.gz  -- OpenCV for arm64
  *   opencv-android-x86_64.tar.gz     -- OpenCV for x86_64
  *   opencv-ios.tar.gz                -- OpenCV xcframework
@@ -461,6 +462,66 @@ async function isCacheValid(artifact) {
   return expectedChecksum === actualChecksum;
 }
 
+// The backend binaries each artifact owns, relative to the extraction dir. Used
+// to clear stale copies: nothing else removes them, and `isCacheValid()`
+// short-circuits the download, so turning a backend OFF after an install would
+// otherwise leave the old binary in place and (on Android) keep shipping it.
+const BACKEND_FILES = {
+  android: {
+    xnnpack: ['executorch/*/libxnnpack_executorch_backend.so'],
+    vulkan: ['executorch/*/libvulkan_executorch_backend.so'],
+  },
+  ios: {
+    xnnpack: ['XnnpackBackend.xcframework'],
+    coreml: ['CoreMLBackend.xcframework'],
+    mlx: ['MLXBackend.xcframework', 'libs/executorch/mlx.metallib'],
+  },
+};
+
+// Removes the binaries of backends the resolved config does not ask for, so a
+// config change takes effect without anyone deleting third-party/ by hand.
+function pruneDisabledBackends(targets, { backends }) {
+  for (const target of targets) {
+    const platform = target.startsWith('android') ? 'android' : 'ios';
+    const destDir =
+      platform === 'android'
+        ? path.join(THIRD_PARTY_DIR, 'android', 'libs')
+        : path.join(THIRD_PARTY_DIR, 'ios');
+    if (!fs.existsSync(destDir)) continue;
+
+    for (const [backend, patterns] of Object.entries(BACKEND_FILES[platform])) {
+      if (backends.includes(backend)) continue;
+      for (const pattern of patterns) {
+        for (const stale of expandPattern(destDir, pattern)) {
+          console.log(`[react-native-executorch] Removing ${backend} binary (not enabled): ${path.relative(THIRD_PARTY_DIR, stale)}`);
+          fs.rmSync(stale, { recursive: true, force: true });
+        }
+      }
+    }
+  }
+}
+
+// Resolves a path that may contain a single `*` segment (the Android ABI dir).
+// A dependency-free stand-in for a glob, since this script runs at postinstall
+// with nothing but Node's stdlib available.
+function expandPattern(root, pattern) {
+  const segments = pattern.split('/');
+  let candidates = [root];
+  for (const segment of segments) {
+    const next = [];
+    for (const base of candidates) {
+      if (segment === '*') {
+        if (!fs.existsSync(base)) continue;
+        for (const entry of fs.readdirSync(base)) next.push(path.join(base, entry));
+      } else {
+        next.push(path.join(base, segment));
+      }
+    }
+    candidates = next;
+  }
+  return candidates.filter((candidate) => fs.existsSync(candidate));
+}
+
 function extract(tarball, destDir) {
   ensureDir(destDir);
   // `-m` stamps extracted files with the extraction time instead of the mtime
@@ -525,6 +586,10 @@ async function main() {
     console.log(`  ✓ Done`);
   }
 
+  // Belt and braces to core no longer carrying backends: this also clears
+  // binaries left by an EARLIER install that had the backend enabled.
+  pruneDisabledBackends(targets, config);
+
   console.log('[react-native-executorch] Native libs ready.');
 }
 
@@ -536,4 +601,12 @@ if (require.main === module) {
   });
 }
 
-module.exports = { ALL_BACKENDS, ALL_LIBS, FEATURE_MAP, findUserConfig, readUserConfig };
+module.exports = {
+  ALL_BACKENDS,
+  ALL_LIBS,
+  BACKEND_FILES,
+  FEATURE_MAP,
+  findUserConfig,
+  readUserConfig,
+  pruneDisabledBackends,
+};

--- a/packages/react-native-executorch/scripts/package-release-artifacts.sh
+++ b/packages/react-native-executorch/scripts/package-release-artifacts.sh
@@ -8,15 +8,15 @@
 #   ./scripts/package-release-artifacts.sh
 #
 # Output: dist-artifacts/
-#   core-android-arm64-v8a.tar.gz + .sha256
-#   core-android-x86_64.tar.gz   + .sha256
+#   core-android-arm64-v8a.tar.gz + .sha256  (libexecutorch.so + executorch.jar)
+#   core-android-x86_64.tar.gz   + .sha256  (libexecutorch.so)
 #   opencv-android-arm64-v8a.tar.gz + .sha256
 #   opencv-android-x86_64.tar.gz   + .sha256
 #   xnnpack-android-arm64-v8a.tar.gz + .sha256
 #   xnnpack-android-x86_64.tar.gz   + .sha256
 #   vulkan-android-arm64-v8a.tar.gz + .sha256
 #   vulkan-android-x86_64.tar.gz   + .sha256
-#   core-ios.tar.gz       + .sha256
+#   core-ios.tar.gz       + .sha256  (ExecutorchLib.xcframework + libthreadpool_*.a)
 #   xnnpack-ios.tar.gz    + .sha256
 #   coreml-ios.tar.gz     + .sha256
 #   mlx-ios.tar.gz        + .sha256 (device-slice xcframework + mlx.metallib resource)
@@ -48,6 +48,11 @@
 #   gh release delete v0.10.0-libs-test --repo software-mansion/react-native-executorch --yes
 
 set -euo pipefail
+
+# macOS tar writes AppleDouble `._*` sidecars for any file carrying extended
+# attributes. They extract alongside the real libraries and are noise for
+# anything globbing those directories.
+export COPYFILE_DISABLE=1
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PACKAGE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -174,18 +179,21 @@ echo "Android:"
 # statically linked into libexecutorch.so (not shipped separately). The
 # ABI-independent executorch.jar (ExecuTorch Java API for the JNI bridge) rides
 # along in the arm64 core tarball, which is always downloaded.
+# Core carries the runtime ONLY. The backend .so ship in their own tarballs, so
+# that an app which opted a backend out never downloads it -- and on Android,
+# never packages it, since jniLibs bundles whatever sits in the directory.
 echo "  → core-android-arm64-v8a"
 _ca_tmp=$(mktemp -d)
 mkdir -p "$_ca_tmp/executorch/arm64-v8a"
-cp -r "$ANDROID_LIBS/executorch/arm64-v8a/." "$_ca_tmp/executorch/arm64-v8a/"
+cp "$ANDROID_LIBS/executorch/arm64-v8a/libexecutorch.so" "$_ca_tmp/executorch/arm64-v8a/"
 cp "$ANDROID_LIBS/executorch.jar" "$_ca_tmp/executorch.jar"
 tar -czf "$OUT/core-android-arm64-v8a.tar.gz" -C "$_ca_tmp" .
 shasum -a 256 "$OUT/core-android-arm64-v8a.tar.gz" | awk '{print $1}' > "$OUT/core-android-arm64-v8a.tar.gz.sha256"
 echo "    ✓ $(du -sh "$OUT/core-android-arm64-v8a.tar.gz" | cut -f1)"
 rm -rf "$_ca_tmp"
 
-package_merged "core-android-x86_64" \
-  "executorch/x86_64"       "$ANDROID_LIBS/executorch/x86_64"
+package_file "core-android-x86_64" \
+  "executorch/x86_64"       "$ANDROID_LIBS/executorch/x86_64/libexecutorch.so"
 
 package_merged "opencv-android-arm64-v8a" \
   "opencv/arm64-v8a"              "$ANDROID_LIBS/opencv/arm64-v8a" \
@@ -217,11 +225,30 @@ package_file "vulkan-android-x86_64" \
 echo ""
 echo "iOS:"
 
-# pthreadpool + cpuinfo are bundled into libthreadpool_*.a (in libs/executorch),
-# so no separate libs/pthreadpool or libs/cpuinfo dirs are shipped.
-package_merged "core-ios" \
-  "ExecutorchLib.xcframework"  "$IOS_DIR/ExecutorchLib.xcframework" \
-  "libs/executorch"            "$IOS_DIR/libs/executorch"
+# pthreadpool + cpuinfo are bundled into libthreadpool_*.a, the only archives
+# under libs/executorch/ the podspec references (as -force_load entries). The
+# rest of that directory -- backend, kernel, kleidiai and llm archives -- is
+# linked by nothing: the backends ship as xcframeworks in their own tarballs and
+# everything else is already inside ExecutorchLib.xcframework. Shipping the
+# directory wholesale cost ~36 MB of unreferenced device-slice .a per install,
+# and made xnnpack-ios/coreml-ios/mlx-ios exact duplicates of what core already
+# carried.
+echo "  → core-ios"
+_ci_tmp=$(mktemp -d)
+mkdir -p "$_ci_tmp/ExecutorchLib.xcframework" "$_ci_tmp/libs/executorch"
+cp -r "$IOS_DIR/ExecutorchLib.xcframework/." "$_ci_tmp/ExecutorchLib.xcframework/"
+for _tp in libthreadpool_ios.a libthreadpool_simulator.a; do
+  if [ ! -f "$IOS_DIR/libs/executorch/$_tp" ]; then
+    echo "    ✗ Source file not found: $IOS_DIR/libs/executorch/$_tp" >&2
+    rm -rf "$_ci_tmp"
+    exit 1
+  fi
+  cp "$IOS_DIR/libs/executorch/$_tp" "$_ci_tmp/libs/executorch/"
+done
+tar -czf "$OUT/core-ios.tar.gz" -C "$_ci_tmp" .
+shasum -a 256 "$OUT/core-ios.tar.gz" | awk '{print $1}' > "$OUT/core-ios.tar.gz.sha256"
+echo "    ✓ $(du -sh "$OUT/core-ios.tar.gz" | cut -f1)"
+rm -rf "$_ci_tmp"
 
 # phonemis is built from in-tree source (third-party/common/phonemis submodule);
 # no iOS tarball is produced.


### PR DESCRIPTION
## Description

Fixes the parts of #1464 that hold up under checking. The opt-out gated downloads and linking; it did not control what the `core-*` artifacts contain, and on Android it did not control what ships.

Artifacts republished as [`v0.10.1-libs`](https://github.com/software-mansion/react-native-executorch/releases/tag/v0.10.1-libs). **Repackaging only: every library byte is identical to v0.10.0-libs, nothing was recompiled**, so this cannot introduce a behaviour change or hit the Vulkan build's non-determinism.

| artifact | v0.10.0-libs | v0.10.1-libs |
|---|---|---|
| core-android-arm64-v8a | 7.96 MB | 4.49 MB |
| core-android-x86_64 | 8.50 MB | 4.50 MB |
| core-ios | 20.82 MB | 5.87 MB |

### What changed

- **`package-release-artifacts.sh`** stages the runtime only into core. MPS goes with it (§9): `libbackend_mps_*.a` had no toggle in `ALL_BACKENDS` and the podspec never referenced it.
- **`build.gradle.kts`** drives `packaging.jniLibs.excludes` from the resolved config (§4, §5), the Android counterpart of the podspec choosing its `-force_load` entries.
- **`download-libs.js`** prunes backends absent from the config after extracting (§3, §6), so turning one off after an install takes effect instead of silently shipping the old binary.
- **`COPYFILE_DISABLE=1`** when packing (§12).

### Verification

**§4 was inferred in the issue; it is now observed.** apps/legacy/bare-rn, release, arm64-v8a, `backends: ["vulkan"]`, old core staged so XNNPACK is present on disk:

| build | merged_native_libs | libxnnpack |
|---|---|---|
| without the gradle fix | 269,127,104 B | present, 2,673,072 B |
| with `jniLibs.excludes` | 266,454,032 B | absent |

Delta is exactly the XNNPACK library. Read from `merged_native_libs/release/.../arm64-v8a`, the tree the APK packages.

**iOS**: a Release link of the same app against the reduced `core-ios` succeeds. Everything the linker takes from `third-party/ios`:

```
libs/executorch/libthreadpool_ios.a
XnnpackBackend.xcframework/ios-arm64/libXnnpackBackend.a   (-force_load)
CoreMLBackend.xcframework/ios-arm64/libCoreMLBackend.a     (-force_load)
MLXBackend.xcframework/ios-arm64/libMLXBackend.a           (-force_load)
+ ExecutorchLib.framework
```

None of the 21 removed archives appears, so §5 is confirmed by the linker rather than by reading the podspec.

**§6**: turning Vulkan on, then off, now removes the stale binary instead of leaving it to ship.

### One claim in the issue does not reproduce

**§12: there are no AppleDouble sidecars in v0.10.0-libs.** `tar tzf | grep -c '\._'` is 0 for all eight tarballs checked, against the 7 the issue reports. `COPYFILE_DISABLE=1` is added anyway, since it costs nothing and the failure mode is real on macOS.

### Not addressed here

§7 root cause (the two Vulkan binaries differ; fixing §1 removes the *consequence*, since the standalone build is now the only one that can ship, but not the cause), §8 and §11 (inferred from `-force_load` and section sizes, no archive build run), §10 simulator split, §13 docs.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

`nativeLibsVersion` is bumped to 0.10.1, so a fresh install pulls the new artifacts. Declare `backends: ["vulkan"]` in an app's package.json, build a release APK, and check `unzip -l app-release.apk | grep 'lib/arm64-v8a/.*\.so'`: `libxnnpack_executorch_backend.so` should be absent. Flip a backend off after an install and confirm the postinstall log reports removing it.

### Related issues

Refs #1464.
