### PR TITLE
fix(libs): build the ExecuTorch Android libraries against c++_shared

### DIFF
--- a/docs/docs/03-core-and-advanced/08-native-libraries.md
+++ b/docs/docs/03-core-and-advanced/08-native-libraries.md
@@ -118,24 +118,24 @@ libraries, which do not change with this configuration.
 
 | backends             | in the APK | ≈ Play download |
 | -------------------- | ---------- | --------------- |
-| `xnnpack`            | 25.18 MB   | 8.16 MB         |
-| `vulkan`             | 33.83 MB   | 9.79 MB         |
-| `xnnpack` + `vulkan` | 36.38 MB   | 10.68 MB        |
+| `xnnpack`            | 21.86 MB   | 7.06 MB         |
+| `vulkan`             | 30.56 MB   | 8.71 MB         |
+| `xnnpack` + `vulkan` | 32.21 MB   | 9.35 MB         |
 
 Per library:
 
 | library                            | stripped | gzipped |
 | ---------------------------------- | -------- | ------- |
-| `libexecutorch.so`                 | 12.82 MB | 4.39 MB |
-| `libvulkan_executorch_backend.so`  | 11.19 MB | 2.52 MB |
+| `libexecutorch.so`                 | 10.41 MB | 3.56 MB |
+| `libvulkan_executorch_backend.so`  | 10.34 MB | 2.28 MB |
 | `libRnExecutorch.so`               | 9.80 MB  | 2.87 MB |
-| `libxnnpack_executorch_backend.so` | 2.54 MB  | 0.88 MB |
+| `libxnnpack_executorch_backend.so` | 1.65 MB  | 0.63 MB |
 
 `extractNativeLibs=false` is the default from React Native 0.73, so the install
 grows by the uncompressed figure; the Play column is the compressed transfer.
 
-Vulkan is ~4.4x XNNPACK and almost entirely data: 8.73 MB of its 11.19 MB is
-`.rodata`, effectively embedded SPIR-V, against 2.02 MB of `.text`. It also
+Vulkan is ~6.3x XNNPACK and almost entirely data: 8.31 MB of its 10.34 MB is
+`.rodata`, effectively embedded SPIR-V, against 1.50 MB of `.text`. It also
 compresses far better than its size suggests.
 
 ### iOS

--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-executorch",
   "version": "0.11.0",
-  "nativeLibsVersion": "0.10.1",
+  "nativeLibsVersion": "0.10.2",
   "description": "An easy way to run AI models in React Native with ExecuTorch",
   "main": "./lib/module/index.js",
   "module": "./lib/module/index.js",


### PR DESCRIPTION
## Description

`libexecutorch.so` and both standalone backends linked libc++ statically and re-exported it, so each carried a copy of a runtime React Native already ships as `libc++_shared.so`: 2130 of `libexecutorch.so`'s arm64 exports were also exported by `libc++_shared.so`, 91% of that library's surface.

v0.10.2-libs rebuilds all three against `c++_shared` (software-mansion-labs/executorch `@ms/separate-backends-1.4.1` 0e18ed635, filed upstream as pytorch/executorch#22739). Duplicated exports drop from 2130 to 3 weak vague-linkage symbols, and the three libraries shrink by 4.17 MB on arm64. The docs size tables are re-measured.

Stacked on #1466.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [ ] iOS
- [x] Android

### Testing instructions

Run `apps/legacy/bare-rn` on an Android device and generate a completion. Then check the libraries no longer carry libc++:

```bash
NDK=$ANDROID_HOME/ndk/<ver>/toolchains/llvm/prebuilt/<host>/bin
$NDK/llvm-nm -D --defined-only libexecutorch.so | awk '{print $3}' | sort -u > et.syms
$NDK/llvm-nm -D --defined-only libc++_shared.so | awk '{print $3}' | sort -u > cxx.syms
comm -12 et.syms cxx.syms | wc -l    # 3, was 2130
```

iOS is untouched: v0.10.2-libs carries the v0.10.1-libs iOS assets byte for byte.

### Related issues

Closes #1467

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

Validated on a Galaxy S26 Ultra: LFM2.5-1.2B generates through XNNPACK in `apps/legacy/bare-rn`, and MiniLM L6 embeds through Vulkan in `apps/nlp` (`AdrenoVK-0: Application Name : ExecuTorch Vulkan Delegate`, 26 ms, semantically correct ranking).

