### PR TITLE
fix(build): gate the legacy sources on phonemis and opencv

### DIFF
--- a/docs/docs/03-core-and-advanced/08-native-libraries.md
+++ b/docs/docs/03-core-and-advanced/08-native-libraries.md
@@ -77,8 +77,6 @@ Hardware backends provide optimized execution kernels for specific processors an
 - **[OpenCV](https://opencv.org/)** — High-performance computer vision library providing image transformations, color space conversions, resizing, and pixel format operations (used by vision pipelines and multimodal LLMs). Provided on iOS via CocoaPods and on Android as static prebuilt libraries.
 - **[phonemis](https://github.com/IgorSwat/Phonemis)** — High-performance C++ library for Grapheme-to-Phoneme (G2P) conversion, delivering universal IPA phonemization as the frontend for [Text-to-Speech](../02-extensions/speech/02-text-to-speech.md) pipelines. Compiled from source on both Android and iOS when enabled.
 
-Opting a library out also drops the matching hooks from the deprecated legacy API, which then throw at runtime (`global.loadOCR is not a function`) rather than failing the build.
-
 ### Features
 
 Specifying a task under `features` is shorthand: it automatically expands to the union of backends and native libraries required by the pre-exported models in that domain.

--- a/docs/docs/03-core-and-advanced/08-native-libraries.md
+++ b/docs/docs/03-core-and-advanced/08-native-libraries.md
@@ -77,6 +77,8 @@ Hardware backends provide optimized execution kernels for specific processors an
 - **[OpenCV](https://opencv.org/)** — High-performance computer vision library providing image transformations, color space conversions, resizing, and pixel format operations (used by vision pipelines and multimodal LLMs). Provided on iOS via CocoaPods and on Android as static prebuilt libraries.
 - **[phonemis](https://github.com/IgorSwat/Phonemis)** — High-performance C++ library for Grapheme-to-Phoneme (G2P) conversion, delivering universal IPA phonemization as the frontend for [Text-to-Speech](../02-extensions/speech/02-text-to-speech.md) pipelines. Compiled from source on both Android and iOS when enabled.
 
+Opting a library out also drops the matching hooks from the deprecated legacy API, which then throw at runtime (`global.loadOCR is not a function`) rather than failing the build.
+
 ### Features
 
 Specifying a task under `features` is shorthand: it automatically expands to the union of backends and native libraries required by the pre-exported models in that domain.

--- a/packages/react-native-executorch/android/CMakeLists.txt
+++ b/packages/react-native-executorch/android/CMakeLists.txt
@@ -67,7 +67,7 @@ endif()
 # opencv-free and JsiConversions.h includes them unconditionally.
 if(NOT RNE_ENABLE_OPENCV)
   list(FILTER LEGACY_CPP_SOURCES EXCLUDE REGEX
-      "/data_processing/ImageProcessing\\.cpp$|/models/VisionModel\\.cpp$|/utils/Frame|/encoders/vision_encoder\\.cpp$|/models/(classification|embeddings/image|instance_segmentation|object_detection|ocr|pose_estimation|semantic_segmentation|style_transfer|text_to_image|vertical_ocr)/")
+      "/data_processing/ImageProcessing\\.cpp$|/models/VisionModel\\.cpp$|/utils/Frame[^/]*\\.cpp$|/encoders/vision_encoder\\.cpp$|/models/(classification|embeddings/image|instance_segmentation|object_detection|ocr|pose_estimation|semantic_segmentation|style_transfer|text_to_image|vertical_ocr)/")
 endif()
 # ==============================================================================
 

--- a/packages/react-native-executorch/android/CMakeLists.txt
+++ b/packages/react-native-executorch/android/CMakeLists.txt
@@ -55,6 +55,12 @@ file(GLOB_RECURSE LEGACY_CPP_SOURCES
     ${LEGACY_CPP_DIR}/runner/*.cpp
 )
 list(FILTER LEGACY_CPP_SOURCES EXCLUDE REGEX "/tests/")
+# The legacy TTS models are the one part of the legacy tree that needs phonemis,
+# so they follow the same toggle as the current phonemizer rather than being
+# compiled unconditionally against a library that is not there.
+if(NOT RNE_ENABLE_PHONEMIS)
+  list(FILTER LEGACY_CPP_SOURCES EXCLUDE REGEX "/models/text_to_speech/")
+endif()
 # ==============================================================================
 
 set(PHONEMIS_SOURCES ${CPP_DIR}/extensions/speech/phonemizer.cpp)

--- a/packages/react-native-executorch/android/CMakeLists.txt
+++ b/packages/react-native-executorch/android/CMakeLists.txt
@@ -61,6 +61,14 @@ list(FILTER LEGACY_CPP_SOURCES EXCLUDE REGEX "/tests/")
 if(NOT RNE_ENABLE_PHONEMIS)
   list(FILTER LEGACY_CPP_SOURCES EXCLUDE REGEX "/models/text_to_speech/")
 endif()
+# Same story for opencv: the legacy vision models, the image/frame helpers they
+# share and the multimodal LLM's vision encoder all compile against opencv2.
+# Only the sources are dropped - the Types.h headers next to them are
+# opencv-free and JsiConversions.h includes them unconditionally.
+if(NOT RNE_ENABLE_OPENCV)
+  list(FILTER LEGACY_CPP_SOURCES EXCLUDE REGEX
+      "/data_processing/ImageProcessing\\.cpp$|/models/VisionModel\\.cpp$|/utils/Frame|/encoders/vision_encoder\\.cpp$|/models/(classification|embeddings/image|instance_segmentation|object_detection|ocr|pose_estimation|semantic_segmentation|style_transfer|text_to_image|vertical_ocr)/")
+endif()
 # ==============================================================================
 
 set(PHONEMIS_SOURCES ${CPP_DIR}/extensions/speech/phonemizer.cpp)

--- a/packages/react-native-executorch/legacy/cpp/rnexecutorch/RnExecutorchInstaller.cpp
+++ b/packages/react-native-executorch/legacy/cpp/rnexecutorch/RnExecutorchInstaller.cpp
@@ -2,23 +2,25 @@
 
 #include <rnexecutorch/TokenizerModule.h>
 #include <rnexecutorch/host_objects/JsiConversions.h>
+#include <rnexecutorch/models/embeddings/text/TextEmbeddings.h>
+#include <rnexecutorch/models/llm/LLM.h>
+#ifdef RNE_ENABLE_OPENCV
 #include <rnexecutorch/models/classification/Classification.h>
 #include <rnexecutorch/models/embeddings/image/ImageEmbeddings.h>
-#include <rnexecutorch/models/embeddings/text/TextEmbeddings.h>
 #include <rnexecutorch/models/instance_segmentation/BaseInstanceSegmentation.h>
-#include <rnexecutorch/models/llm/LLM.h>
 #include <rnexecutorch/models/object_detection/ObjectDetection.h>
 #include <rnexecutorch/models/ocr/OCR.h>
 #include <rnexecutorch/models/pose_estimation/PoseEstimation.h>
-#include <rnexecutorch/models/privacy_filter/PrivacyFilter.h>
 #include <rnexecutorch/models/semantic_segmentation/BaseSemanticSegmentation.h>
-#include <rnexecutorch/models/speech_to_text/SpeechToText.h>
 #include <rnexecutorch/models/style_transfer/StyleTransfer.h>
 #include <rnexecutorch/models/text_to_image/TextToImage.h>
+#include <rnexecutorch/models/vertical_ocr/VerticalOCR.h>
+#endif
+#include <rnexecutorch/models/privacy_filter/PrivacyFilter.h>
+#include <rnexecutorch/models/speech_to_text/SpeechToText.h>
 #ifdef RNE_ENABLE_PHONEMIS
 #include <rnexecutorch/models/text_to_speech/TextToSpeech.h>
 #endif
-#include <rnexecutorch/models/vertical_ocr/VerticalOCR.h>
 #include <rnexecutorch/models/voice_activity_detection/VoiceActivityDetection.h>
 #include <rnexecutorch/threads/GlobalThreadPool.h>
 #include <rnexecutorch/threads/utils/ThreadUtils.h>
@@ -44,6 +46,10 @@ void RnExecutorchInstaller::injectJSIBindings(
     jsiRuntime->global().setProperty(*jsiRuntime, "__rne_isEmulator",
                                      jsi::Value(isEmulator));
 
+#ifdef RNE_ENABLE_OPENCV
+    // Registered only when opencv is compiled in. An app that opted out of it
+    // gets no `load*` global for these tasks, the same way the current API
+    // omits the whole `cv` namespace.
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadStyleTransfer",
         RnExecutorchInstaller::loadModel<models::style_transfer::StyleTransfer>(
@@ -81,6 +87,7 @@ void RnExecutorchInstaller::injectJSIBindings(
         *jsiRuntime, "loadPoseEstimation",
         RnExecutorchInstaller::loadModel<models::pose_estimation::PoseEstimation>(
             jsiRuntime, jsCallInvoker, "loadPoseEstimation"));
+#endif
 
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadExecutorchModule",
@@ -92,10 +99,12 @@ void RnExecutorchInstaller::injectJSIBindings(
         RnExecutorchInstaller::loadModel<TokenizerModule>(
             jsiRuntime, jsCallInvoker, "loadTokenizerModule"));
 
+#ifdef RNE_ENABLE_OPENCV
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadImageEmbeddings",
         RnExecutorchInstaller::loadModel<models::embeddings::ImageEmbeddings>(
             jsiRuntime, jsCallInvoker, "loadImageEmbeddings"));
+#endif
 
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadTextEmbeddings",
@@ -112,6 +121,7 @@ void RnExecutorchInstaller::injectJSIBindings(
         RnExecutorchInstaller::loadModel<models::privacy_filter::PrivacyFilter>(
             jsiRuntime, jsCallInvoker, "loadPrivacyFilter"));
 
+#ifdef RNE_ENABLE_OPENCV
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadOCR",
         RnExecutorchInstaller::loadModel<models::ocr::OCR>(
@@ -121,6 +131,7 @@ void RnExecutorchInstaller::injectJSIBindings(
         *jsiRuntime, "loadVerticalOCR",
         RnExecutorchInstaller::loadModel<models::ocr::VerticalOCR>(
             jsiRuntime, jsCallInvoker, "loadVerticalOCR"));
+#endif
 
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadSpeechToText",

--- a/packages/react-native-executorch/legacy/cpp/rnexecutorch/RnExecutorchInstaller.cpp
+++ b/packages/react-native-executorch/legacy/cpp/rnexecutorch/RnExecutorchInstaller.cpp
@@ -15,7 +15,9 @@
 #include <rnexecutorch/models/speech_to_text/SpeechToText.h>
 #include <rnexecutorch/models/style_transfer/StyleTransfer.h>
 #include <rnexecutorch/models/text_to_image/TextToImage.h>
+#ifdef RNE_ENABLE_PHONEMIS
 #include <rnexecutorch/models/text_to_speech/TextToSpeech.h>
+#endif
 #include <rnexecutorch/models/vertical_ocr/VerticalOCR.h>
 #include <rnexecutorch/models/voice_activity_detection/VoiceActivityDetection.h>
 #include <rnexecutorch/threads/GlobalThreadPool.h>
@@ -125,10 +127,15 @@ void RnExecutorchInstaller::injectJSIBindings(
         RnExecutorchInstaller::loadModel<models::speech_to_text::SpeechToText>(
             jsiRuntime, jsCallInvoker, "loadSpeechToText"));
 
+#ifdef RNE_ENABLE_PHONEMIS
+    // Only registered when phonemis is compiled in; an app that opted out of
+    // text-to-speech gets no `loadTextToSpeechKokoro` global, the same way the
+    // current API omits `speech.createPhonemizer`.
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadTextToSpeechKokoro",
         RnExecutorchInstaller::loadModel<models::text_to_speech::kokoro::Kokoro>(
             jsiRuntime, jsCallInvoker, "loadTextToSpeechKokoro"));
+#endif
 
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadVAD",

--- a/packages/react-native-executorch/legacy/cpp/rnexecutorch/host_objects/ModelHostObject.h
+++ b/packages/react-native-executorch/legacy/cpp/rnexecutorch/host_objects/ModelHostObject.h
@@ -17,15 +17,16 @@
 #include <rnexecutorch/metaprogramming/FunctionHelpers.h>
 #include <rnexecutorch/metaprogramming/TypeConcepts.h>
 #include <rnexecutorch/models/BaseModel.h>
-#include <rnexecutorch/models/VisionModel.h>
 #include <rnexecutorch/models/llm/LLM.h>
+#ifdef RNE_ENABLE_OPENCV
 #include <rnexecutorch/models/ocr/OCR.h>
-#include <rnexecutorch/models/speech_to_text/SpeechToText.h>
 #include <rnexecutorch/models/text_to_image/TextToImage.h>
+#include <rnexecutorch/models/vertical_ocr/VerticalOCR.h>
+#endif
+#include <rnexecutorch/models/speech_to_text/SpeechToText.h>
 #ifdef RNE_ENABLE_PHONEMIS
 #include <rnexecutorch/models/text_to_speech/TextToSpeech.h>
 #endif
-#include <rnexecutorch/models/vertical_ocr/VerticalOCR.h>
 #include <rnexecutorch/models/voice_activity_detection/VoiceActivityDetection.h>
 #include <rnexecutorch/threads/GlobalThreadPool.h>
 
@@ -204,6 +205,7 @@ public:
                 "getVisualTokenCount"));
         }
 
+#ifdef RNE_ENABLE_OPENCV
         if constexpr (meta::SameAs<Model, models::text_to_image::TextToImage>) {
             addFunctions(
                 JSI_EXPORT_FUNCTION(ModelHostObject<Model>, unload, "unload"));
@@ -221,6 +223,7 @@ public:
             addFunctions(
                 JSI_EXPORT_FUNCTION(ModelHostObject<Model>, unload, "unload"));
         }
+#endif
 
 #ifdef RNE_ENABLE_PHONEMIS
         if constexpr (meta::SameAs<Model, models::text_to_speech::kokoro::Kokoro>) {

--- a/packages/react-native-executorch/legacy/cpp/rnexecutorch/host_objects/ModelHostObject.h
+++ b/packages/react-native-executorch/legacy/cpp/rnexecutorch/host_objects/ModelHostObject.h
@@ -22,7 +22,9 @@
 #include <rnexecutorch/models/ocr/OCR.h>
 #include <rnexecutorch/models/speech_to_text/SpeechToText.h>
 #include <rnexecutorch/models/text_to_image/TextToImage.h>
+#ifdef RNE_ENABLE_PHONEMIS
 #include <rnexecutorch/models/text_to_speech/TextToSpeech.h>
+#endif
 #include <rnexecutorch/models/vertical_ocr/VerticalOCR.h>
 #include <rnexecutorch/models/voice_activity_detection/VoiceActivityDetection.h>
 #include <rnexecutorch/threads/GlobalThreadPool.h>
@@ -220,6 +222,7 @@ public:
                 JSI_EXPORT_FUNCTION(ModelHostObject<Model>, unload, "unload"));
         }
 
+#ifdef RNE_ENABLE_PHONEMIS
         if constexpr (meta::SameAs<Model, models::text_to_speech::kokoro::Kokoro>) {
             addFunctions(
                 JSI_EXPORT_FUNCTION(ModelHostObject<Model>, unload, "unload"));
@@ -236,6 +239,7 @@ public:
                 ModelHostObject<Model>, synchronousHostFunction<&Model::streamFlush>,
                 "streamFlush"));
         }
+#endif
 
         if constexpr (meta::HasGenerateFromString<Model>) {
             addFunctions(

--- a/packages/react-native-executorch/legacy/cpp/rnexecutorch/models/llm/LLM.cpp
+++ b/packages/react-native-executorch/legacy/cpp/rnexecutorch/models/llm/LLM.cpp
@@ -7,7 +7,9 @@
 #include <rnexecutorch/Error.h>
 #include <rnexecutorch/threads/GlobalThreadPool.h>
 #include <runner/encoders/audio_encoder.h>
+#ifdef RNE_ENABLE_OPENCV
 #include <runner/encoders/vision_encoder.h>
+#endif
 #include <runner/multimodal_runner.h>
 #include <runner/text_runner.h>
 
@@ -29,8 +31,17 @@ LLM::LLM(const std::string &modelSource, const std::string &tokenizerSource,
         std::map<llm::MultimodalType, std::unique_ptr<llm::IEncoder>> encoders;
         for (const auto &cap : capabilities) {
             if (cap == "vision") {
+#ifdef RNE_ENABLE_OPENCV
                 encoders[llm::MultimodalType::Image] =
                     std::make_unique<llm::VisionEncoder>(*module_);
+#else
+                // The vision encoder decodes and resizes the image with opencv,
+                // so it is only there when opencv is.
+                throw RnExecutorchError(
+                    RnExecutorchErrorCode::InvalidUserInput,
+                    "The 'vision' capability requires the opencv native library, "
+                    "which this app opted out of in package.json");
+#endif
             } else if (cap == "audio") {
                 encoders[llm::MultimodalType::Audio] =
                     std::make_unique<llm::AudioEncoder>(*module_);

--- a/packages/react-native-executorch/legacy/cpp/rnexecutorch/tests/CMakeLists.txt
+++ b/packages/react-native-executorch/legacy/cpp/rnexecutorch/tests/CMakeLists.txt
@@ -8,15 +8,19 @@ project(RNExecutorchTests)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
-# tests/                         <- CMAKE_SOURCE_DIR (this file's location)
-# rnexecutorch/                  <- RNEXECUTORCH_DIR (parent of tests)
-# common/                        <- COMMON_DIR
-# react-native-executorch/       <- PACKAGE_ROOT
-# <monorepo-root>/               <- MONOREPO_ROOT
-# <monorepo-root>/third-party/   <- THIRD_PARTY_DIR
+# tests/                              <- CMAKE_SOURCE_DIR (this file's location)
+# legacy/cpp/rnexecutorch/            <- RNEXECUTORCH_DIR (parent of tests)
+# legacy/cpp/                         <- COMMON_DIR
+# react-native-executorch/            <- PACKAGE_ROOT
+# <monorepo-root>/                    <- MONOREPO_ROOT
+# <monorepo-root>/third-party/        <- THIRD_PARTY_DIR
 set(RNEXECUTORCH_DIR "${CMAKE_SOURCE_DIR}/..")
 set(COMMON_DIR "${RNEXECUTORCH_DIR}/..")
-set(PACKAGE_ROOT "${COMMON_DIR}/..")
+# Two levels, not one: moving the pre-0.10 tree under legacy/cpp/ put an extra
+# directory between COMMON_DIR and the package root, so every path derived from
+# PACKAGE_ROOT (googletest, phonemis, the Android libs) resolved one level short
+# and the suite could not configure at all.
+set(PACKAGE_ROOT "${COMMON_DIR}/../..")
 set(MONOREPO_ROOT "${PACKAGE_ROOT}/../..")
 set(THIRD_PARTY_DIR "${MONOREPO_ROOT}/third-party")
 set(REACT_NATIVE_DIR "${MONOREPO_ROOT}/node_modules/react-native")
@@ -136,7 +140,14 @@ function(add_rn_test TEST_TARGET TEST_FILENAME)
     # Create executable using the explicit filename provided
     add_executable(${TEST_TARGET} ${TEST_FILENAME} ${ARG_SOURCES})
 
-    target_compile_definitions(${TEST_TARGET} PRIVATE TEST_BUILD)
+    # The host suite always builds the full feature set, so the sources it
+    # compiles must see the feature macros as the app build does. Without
+    # RNE_ENABLE_OPENCV, LLM.cpp takes its opt-out branch and every VLMTest /
+    # GemmaAudioTest case fails in SetUpTestSuite. Safe for the tests that link
+    # neither library: LLM.cpp is the only test source reaching a guarded
+    # opencv symbol, and it links opencv_deps.
+    target_compile_definitions(${TEST_TARGET} PRIVATE
+        TEST_BUILD RNE_ENABLE_OPENCV RNE_ENABLE_PHONEMIS)
     target_link_libraries(${TEST_TARGET} PRIVATE rntests_core gtest_main ${ARG_LIBS})
     target_link_options(${TEST_TARGET} PRIVATE "LINKER:-z,max-page-size=16384")
 

--- a/packages/react-native-executorch/legacy/cpp/rnexecutorch/threads/GlobalThreadPool.h
+++ b/packages/react-native-executorch/legacy/cpp/rnexecutorch/threads/GlobalThreadPool.h
@@ -4,10 +4,12 @@
 #include <executorch/extension/threadpool/cpuinfo_utils.h>
 #include <memory>
 #include <mutex>
-#include <opencv2/opencv.hpp>
 #include <optional>
 #include <rnexecutorch/Log.h>
 #include <rnexecutorch/threads/HighPerformanceThreadPool.h>
+#ifdef RNE_ENABLE_OPENCV
+#include <opencv2/opencv.hpp>
+#endif
 
 namespace rnexecutorch::threads {
 
@@ -39,9 +41,11 @@ public:
                 numThreads, "threads");
             instance = std::make_unique<HighPerformanceThreadPool>(numThreads.value(),
                                                                    config);
+#ifdef RNE_ENABLE_OPENCV
             // Disable OpenCV's internal threading to prevent it from overriding our
             // thread pool configuration, which would cause degraded performance
             cv::setNumThreads(0);
+#endif
         });
     }
 

--- a/packages/react-native-executorch/legacy/src/index.ts
+++ b/packages/react-native-executorch/legacy/src/index.ts
@@ -135,27 +135,11 @@ declare global {
 }
 // eslint-disable no-var
 
-if (
-  global.loadStyleTransfer == null ||
-  global.loadSemanticSegmentation == null ||
-  global.loadInstanceSegmentation == null ||
-  global.loadTextToImage == null ||
-  global.loadExecutorchModule == null ||
-  global.loadClassification == null ||
-  global.loadObjectDetection == null ||
-  global.loadPoseEstimation == null ||
-  global.loadTokenizerModule == null ||
-  global.loadTextEmbeddings == null ||
-  global.loadImageEmbeddings == null ||
-  global.loadVAD == null ||
-  global.loadLLM == null ||
-  global.loadPrivacyFilter == null ||
-  global.loadSpeechToText == null ||
-  global.loadTextToSpeechKokoro == null ||
-  global.loadOCR == null ||
-  global.loadVerticalOCR == null ||
-  global.__rne_isEmulator == null
-) {
+// Only the globals that are registered unconditionally. The per-task ones are
+// absent by design when an app opts out of opencv or phonemis, so including
+// them here would pin the condition to true and re-run install() on every
+// module evaluation.
+if (global.loadExecutorchModule == null || global.__rne_isEmulator == null) {
   if (!ETInstallerNativeModule) {
     throw new Error(
       `Failed to install react-native-executorch: The native module could not be found.`

--- a/packages/react-native-executorch/react-native-executorch.podspec
+++ b/packages/react-native-executorch/react-native-executorch.podspec
@@ -147,6 +147,27 @@ Pod::Spec.new do |s|
     exclude_files += ["legacy/cpp/rnexecutorch/models/text_to_speech/**/*.{cpp,c,h,hpp}"]
   end
   # ==============================================================================
+  # LEGACY SUPPORT: the same for opencv. The legacy vision models, the
+  # image/frame helpers they share and the multimodal LLM's vision encoder all
+  # compile against opencv2, which is not linked when opencv is off. Only the
+  # sources are excluded: the `Types.h` headers sitting next to them are
+  # opencv-free and `JsiConversions.h` includes them unconditionally.
+  # (Remove when react-native-executorch/legacy is dropped)
+  # ==============================================================================
+  unless enable_opencv
+    legacy_dir = "legacy/cpp/rnexecutorch"
+    exclude_files += [
+      "#{legacy_dir}/data_processing/ImageProcessing.cpp",
+      "#{legacy_dir}/models/VisionModel.cpp",
+      "#{legacy_dir}/utils/Frame*.cpp",
+      "legacy/cpp/runner/encoders/vision_encoder.cpp",
+    ]
+    exclude_files += %w[
+      classification embeddings/image instance_segmentation object_detection ocr
+      pose_estimation semantic_segmentation style_transfer text_to_image vertical_ocr
+    ].map { |task| "#{legacy_dir}/models/#{task}/**/*.{cpp,c}" }
+  end
+  # ==============================================================================
   s.exclude_files = exclude_files
 
   # --- Public headers ---

--- a/packages/react-native-executorch/react-native-executorch.podspec
+++ b/packages/react-native-executorch/react-native-executorch.podspec
@@ -136,6 +136,17 @@ Pod::Spec.new do |s|
   # ==============================================================================
   exclude_files += opencv_source_files unless enable_opencv
   exclude_files += phonemis_source_files unless enable_phonemis
+  # ==============================================================================
+  # LEGACY SUPPORT: the legacy TTS models need phonemis too, and `legacy/cpp/**`
+  # above sweeps them in unconditionally. Without this they compile — the
+  # phonemis headers stay on HEADER_SEARCH_PATHS — and fail at link with
+  # undefined phonemis::Pipeline symbols.
+  # (Remove when react-native-executorch/legacy is dropped)
+  # ==============================================================================
+  unless enable_phonemis
+    exclude_files += ["legacy/cpp/rnexecutorch/models/text_to_speech/**/*.{cpp,c,h,hpp}"]
+  end
+  # ==============================================================================
   s.exclude_files = exclude_files
 
   # --- Public headers ---


### PR DESCRIPTION
## Description

Opting out of a native lib broke the build on both platforms. `legacy/cpp/**` is globbed into the library unconditionally, but phonemis and opencv are only compiled and linked under their flags, so the legacy sources were built against libraries that were not there. Android stopped at the include, iOS at the link.

Both now follow the toggle the current API already uses: the sources leave the build, the registration sites are guarded, and the `load*` globals for those tasks are absent, the same way the current API omits `speech.createPhonemizer` and the whole `cv` namespace. `GlobalThreadPool` was the awkward one, core infrastructure that needed opencv for a single `setNumThreads` call.

Also fixes the legacy test suite's `PACKAGE_ROOT`, which has pointed one directory short since the pre-0.10 tree moved under `legacy/cpp/` and left the suite unable to configure at all.

Only sources are excluded, not headers: the `Types.h` files next to them are opencv-free and `JsiConversions.h` includes them unconditionally.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

Build `apps/speech` (`opencv=false, phonemis=true`). It failed before this on both platforms. Then build `apps/computer-vision` (`opencv=true, phonemis=false`) and an all-libs-on config to check the enabled paths.

### Related issues

Closes #1470

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

### Additional notes

`apps/speech` builds clean both platforms: Android native lib and debug APK, iOS pod and app for simulator. The ninja graph drops from 116 objects to 84, with no opencv archives on the link line and no undefined `cv::` symbols in the `.so`. The all-libs-on build (compile and link only, no runtime run of the legacy vision path) still registers every legacy global: the enabled `.so` carries all ten `loadOCR`/`loadStyleTransfer`/... symbols and the opted-out one carries none. The podspec exclusions are inert when opencv is on.

A legacy LLM built with `capabilities: ["vision"]` now throws a named error when opencv is off, rather than failing to link.


