### PR TITLE
fix: backport the legacy opt-out and LLM rollback fixes (#1454, #1471)

### DIFF
--- a/packages/react-native-executorch/__tests__/support/fakeJsi.ts
+++ b/packages/react-native-executorch/__tests__/support/fakeJsi.ts
@@ -286,6 +286,15 @@ function createFakeRunner(
 
     reset: (targetPos?: number): void => {
       assertLive('reset');
+      // The native runner only rewinds: a target past the current position is
+      // rejected rather than clamped. Modelling that here is what makes a
+      // rollback to a stale position observable in a test instead of silently
+      // succeeding.
+      if (targetPos !== undefined && (targetPos < 0 || targetPos > pos)) {
+        throw new Error(
+          `LLMRunner.reset: targetPos must be in range [0, ${pos}], but got ${targetPos}`
+        );
+      }
       pos = targetPos ?? 0;
       runnerCalls.push({ kind: 'reset', targetPos: pos });
     },

--- a/packages/react-native-executorch/__tests__/tasks/llmChatSession.test.ts
+++ b/packages/react-native-executorch/__tests__/tasks/llmChatSession.test.ts
@@ -374,6 +374,42 @@ describe('createLLMChatSession — failure', () => {
     expect(session.getKVCacheState().pos).toBe(posBefore);
   });
 
+  it("reports the turn's own error, not the rollback's, when resetting each turn", async () => {
+    // `resetOnTurn` zeroes the cache at the start of the turn, so the position
+    // captured before it is already unreachable by the time the rollback runs.
+    // Rewinding to it throws, and that throw used to replace the real failure:
+    // a bounded-prefill rejection on a dynamic-shape model surfaced as
+    // "LLMRunner.reset: targetPos must be in range [0, 0]" and read as a KV
+    // cache bug.
+    let failing = false;
+    const session = tracked(
+      await createLLMChatSession(config, {
+        resetOnTurn: true,
+        toolOpts: {
+          tools: [],
+          parseToolCalls: (text) => {
+            if (failing) throw new Error('prefill exceeded the model bound');
+            return { toolCalls: [], textContent: text };
+          },
+        },
+      })
+    );
+
+    // A first turn, so the pre-turn position is past zero when the next one
+    // resets it.
+    await session.sendMessage('first question');
+    expect(session.getKVCacheState().pos).toBeGreaterThan(0);
+    const historyBefore = session.getHistory();
+
+    failing = true;
+    await expect(session.sendMessage('doomed')).rejects.toThrow('prefill exceeded the model bound');
+
+    // The session survives the failed turn: the doomed turn leaves no trace.
+    expect(session.getHistory()).toEqual(historyBefore);
+    failing = false;
+    await expect(session.sendMessage('after')).resolves.toBeDefined();
+  });
+
   it('is still usable after a failed turn', async () => {
     let shouldFail = true;
     const session = tracked(

--- a/packages/react-native-executorch/android/CMakeLists.txt
+++ b/packages/react-native-executorch/android/CMakeLists.txt
@@ -55,6 +55,20 @@ file(GLOB_RECURSE LEGACY_CPP_SOURCES
     ${LEGACY_CPP_DIR}/runner/*.cpp
 )
 list(FILTER LEGACY_CPP_SOURCES EXCLUDE REGEX "/tests/")
+# The legacy TTS models are the one part of the legacy tree that needs phonemis,
+# so they follow the same toggle as the current phonemizer rather than being
+# compiled unconditionally against a library that is not there.
+if(NOT RNE_ENABLE_PHONEMIS)
+  list(FILTER LEGACY_CPP_SOURCES EXCLUDE REGEX "/models/text_to_speech/")
+endif()
+# Same story for opencv: the legacy vision models, the image/frame helpers they
+# share and the multimodal LLM's vision encoder all compile against opencv2.
+# Only the sources are dropped - the Types.h headers next to them are
+# opencv-free and JsiConversions.h includes them unconditionally.
+if(NOT RNE_ENABLE_OPENCV)
+  list(FILTER LEGACY_CPP_SOURCES EXCLUDE REGEX
+      "/data_processing/ImageProcessing\\.cpp$|/models/VisionModel\\.cpp$|/utils/Frame[^/]*\\.cpp$|/encoders/vision_encoder\\.cpp$|/models/(classification|embeddings/image|instance_segmentation|object_detection|ocr|pose_estimation|semantic_segmentation|style_transfer|text_to_image|vertical_ocr)/")
+endif()
 # ==============================================================================
 
 set(PHONEMIS_SOURCES ${CPP_DIR}/extensions/speech/phonemizer.cpp)

--- a/packages/react-native-executorch/legacy/cpp/rnexecutorch/RnExecutorchInstaller.cpp
+++ b/packages/react-native-executorch/legacy/cpp/rnexecutorch/RnExecutorchInstaller.cpp
@@ -2,21 +2,25 @@
 
 #include <rnexecutorch/TokenizerModule.h>
 #include <rnexecutorch/host_objects/JsiConversions.h>
+#include <rnexecutorch/models/embeddings/text/TextEmbeddings.h>
+#include <rnexecutorch/models/llm/LLM.h>
+#ifdef RNE_ENABLE_OPENCV
 #include <rnexecutorch/models/classification/Classification.h>
 #include <rnexecutorch/models/embeddings/image/ImageEmbeddings.h>
-#include <rnexecutorch/models/embeddings/text/TextEmbeddings.h>
 #include <rnexecutorch/models/instance_segmentation/BaseInstanceSegmentation.h>
-#include <rnexecutorch/models/llm/LLM.h>
 #include <rnexecutorch/models/object_detection/ObjectDetection.h>
 #include <rnexecutorch/models/ocr/OCR.h>
 #include <rnexecutorch/models/pose_estimation/PoseEstimation.h>
-#include <rnexecutorch/models/privacy_filter/PrivacyFilter.h>
 #include <rnexecutorch/models/semantic_segmentation/BaseSemanticSegmentation.h>
-#include <rnexecutorch/models/speech_to_text/SpeechToText.h>
 #include <rnexecutorch/models/style_transfer/StyleTransfer.h>
 #include <rnexecutorch/models/text_to_image/TextToImage.h>
-#include <rnexecutorch/models/text_to_speech/TextToSpeech.h>
 #include <rnexecutorch/models/vertical_ocr/VerticalOCR.h>
+#endif
+#include <rnexecutorch/models/privacy_filter/PrivacyFilter.h>
+#include <rnexecutorch/models/speech_to_text/SpeechToText.h>
+#ifdef RNE_ENABLE_PHONEMIS
+#include <rnexecutorch/models/text_to_speech/TextToSpeech.h>
+#endif
 #include <rnexecutorch/models/voice_activity_detection/VoiceActivityDetection.h>
 #include <rnexecutorch/threads/GlobalThreadPool.h>
 #include <rnexecutorch/threads/utils/ThreadUtils.h>
@@ -42,6 +46,10 @@ void RnExecutorchInstaller::injectJSIBindings(
     jsiRuntime->global().setProperty(*jsiRuntime, "__rne_isEmulator",
                                      jsi::Value(isEmulator));
 
+#ifdef RNE_ENABLE_OPENCV
+    // Registered only when opencv is compiled in. An app that opted out of it
+    // gets no `load*` global for these tasks, the same way the current API
+    // omits the whole `cv` namespace.
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadStyleTransfer",
         RnExecutorchInstaller::loadModel<models::style_transfer::StyleTransfer>(
@@ -79,6 +87,7 @@ void RnExecutorchInstaller::injectJSIBindings(
         *jsiRuntime, "loadPoseEstimation",
         RnExecutorchInstaller::loadModel<models::pose_estimation::PoseEstimation>(
             jsiRuntime, jsCallInvoker, "loadPoseEstimation"));
+#endif
 
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadExecutorchModule",
@@ -90,10 +99,12 @@ void RnExecutorchInstaller::injectJSIBindings(
         RnExecutorchInstaller::loadModel<TokenizerModule>(
             jsiRuntime, jsCallInvoker, "loadTokenizerModule"));
 
+#ifdef RNE_ENABLE_OPENCV
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadImageEmbeddings",
         RnExecutorchInstaller::loadModel<models::embeddings::ImageEmbeddings>(
             jsiRuntime, jsCallInvoker, "loadImageEmbeddings"));
+#endif
 
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadTextEmbeddings",
@@ -110,6 +121,7 @@ void RnExecutorchInstaller::injectJSIBindings(
         RnExecutorchInstaller::loadModel<models::privacy_filter::PrivacyFilter>(
             jsiRuntime, jsCallInvoker, "loadPrivacyFilter"));
 
+#ifdef RNE_ENABLE_OPENCV
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadOCR",
         RnExecutorchInstaller::loadModel<models::ocr::OCR>(
@@ -119,16 +131,22 @@ void RnExecutorchInstaller::injectJSIBindings(
         *jsiRuntime, "loadVerticalOCR",
         RnExecutorchInstaller::loadModel<models::ocr::VerticalOCR>(
             jsiRuntime, jsCallInvoker, "loadVerticalOCR"));
+#endif
 
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadSpeechToText",
         RnExecutorchInstaller::loadModel<models::speech_to_text::SpeechToText>(
             jsiRuntime, jsCallInvoker, "loadSpeechToText"));
 
+#ifdef RNE_ENABLE_PHONEMIS
+    // Only registered when phonemis is compiled in; an app that opted out of
+    // text-to-speech gets no `loadTextToSpeechKokoro` global, the same way the
+    // current API omits `speech.createPhonemizer`.
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadTextToSpeechKokoro",
         RnExecutorchInstaller::loadModel<models::text_to_speech::kokoro::Kokoro>(
             jsiRuntime, jsCallInvoker, "loadTextToSpeechKokoro"));
+#endif
 
     jsiRuntime->global().setProperty(
         *jsiRuntime, "loadVAD",

--- a/packages/react-native-executorch/legacy/cpp/rnexecutorch/host_objects/ModelHostObject.h
+++ b/packages/react-native-executorch/legacy/cpp/rnexecutorch/host_objects/ModelHostObject.h
@@ -17,13 +17,16 @@
 #include <rnexecutorch/metaprogramming/FunctionHelpers.h>
 #include <rnexecutorch/metaprogramming/TypeConcepts.h>
 #include <rnexecutorch/models/BaseModel.h>
-#include <rnexecutorch/models/VisionModel.h>
 #include <rnexecutorch/models/llm/LLM.h>
+#ifdef RNE_ENABLE_OPENCV
 #include <rnexecutorch/models/ocr/OCR.h>
-#include <rnexecutorch/models/speech_to_text/SpeechToText.h>
 #include <rnexecutorch/models/text_to_image/TextToImage.h>
-#include <rnexecutorch/models/text_to_speech/TextToSpeech.h>
 #include <rnexecutorch/models/vertical_ocr/VerticalOCR.h>
+#endif
+#include <rnexecutorch/models/speech_to_text/SpeechToText.h>
+#ifdef RNE_ENABLE_PHONEMIS
+#include <rnexecutorch/models/text_to_speech/TextToSpeech.h>
+#endif
 #include <rnexecutorch/models/voice_activity_detection/VoiceActivityDetection.h>
 #include <rnexecutorch/threads/GlobalThreadPool.h>
 
@@ -202,6 +205,7 @@ public:
                 "getVisualTokenCount"));
         }
 
+#ifdef RNE_ENABLE_OPENCV
         if constexpr (meta::SameAs<Model, models::text_to_image::TextToImage>) {
             addFunctions(
                 JSI_EXPORT_FUNCTION(ModelHostObject<Model>, unload, "unload"));
@@ -219,7 +223,9 @@ public:
             addFunctions(
                 JSI_EXPORT_FUNCTION(ModelHostObject<Model>, unload, "unload"));
         }
+#endif
 
+#ifdef RNE_ENABLE_PHONEMIS
         if constexpr (meta::SameAs<Model, models::text_to_speech::kokoro::Kokoro>) {
             addFunctions(
                 JSI_EXPORT_FUNCTION(ModelHostObject<Model>, unload, "unload"));
@@ -236,6 +242,7 @@ public:
                 ModelHostObject<Model>, synchronousHostFunction<&Model::streamFlush>,
                 "streamFlush"));
         }
+#endif
 
         if constexpr (meta::HasGenerateFromString<Model>) {
             addFunctions(

--- a/packages/react-native-executorch/legacy/cpp/rnexecutorch/models/llm/LLM.cpp
+++ b/packages/react-native-executorch/legacy/cpp/rnexecutorch/models/llm/LLM.cpp
@@ -7,7 +7,9 @@
 #include <rnexecutorch/Error.h>
 #include <rnexecutorch/threads/GlobalThreadPool.h>
 #include <runner/encoders/audio_encoder.h>
+#ifdef RNE_ENABLE_OPENCV
 #include <runner/encoders/vision_encoder.h>
+#endif
 #include <runner/multimodal_runner.h>
 #include <runner/text_runner.h>
 
@@ -29,8 +31,17 @@ LLM::LLM(const std::string &modelSource, const std::string &tokenizerSource,
         std::map<llm::MultimodalType, std::unique_ptr<llm::IEncoder>> encoders;
         for (const auto &cap : capabilities) {
             if (cap == "vision") {
+#ifdef RNE_ENABLE_OPENCV
                 encoders[llm::MultimodalType::Image] =
                     std::make_unique<llm::VisionEncoder>(*module_);
+#else
+                // The vision encoder decodes and resizes the image with opencv,
+                // so it is only there when opencv is.
+                throw RnExecutorchError(
+                    RnExecutorchErrorCode::InvalidUserInput,
+                    "The 'vision' capability requires the opencv native library, "
+                    "which this app opted out of in package.json");
+#endif
             } else if (cap == "audio") {
                 encoders[llm::MultimodalType::Audio] =
                     std::make_unique<llm::AudioEncoder>(*module_);

--- a/packages/react-native-executorch/legacy/cpp/rnexecutorch/tests/CMakeLists.txt
+++ b/packages/react-native-executorch/legacy/cpp/rnexecutorch/tests/CMakeLists.txt
@@ -8,15 +8,19 @@ project(RNExecutorchTests)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
-# tests/                         <- CMAKE_SOURCE_DIR (this file's location)
-# rnexecutorch/                  <- RNEXECUTORCH_DIR (parent of tests)
-# common/                        <- COMMON_DIR
-# react-native-executorch/       <- PACKAGE_ROOT
-# <monorepo-root>/               <- MONOREPO_ROOT
-# <monorepo-root>/third-party/   <- THIRD_PARTY_DIR
+# tests/                              <- CMAKE_SOURCE_DIR (this file's location)
+# legacy/cpp/rnexecutorch/            <- RNEXECUTORCH_DIR (parent of tests)
+# legacy/cpp/                         <- COMMON_DIR
+# react-native-executorch/            <- PACKAGE_ROOT
+# <monorepo-root>/                    <- MONOREPO_ROOT
+# <monorepo-root>/third-party/        <- THIRD_PARTY_DIR
 set(RNEXECUTORCH_DIR "${CMAKE_SOURCE_DIR}/..")
 set(COMMON_DIR "${RNEXECUTORCH_DIR}/..")
-set(PACKAGE_ROOT "${COMMON_DIR}/..")
+# Two levels, not one: moving the pre-0.10 tree under legacy/cpp/ put an extra
+# directory between COMMON_DIR and the package root, so every path derived from
+# PACKAGE_ROOT (googletest, phonemis, the Android libs) resolved one level short
+# and the suite could not configure at all.
+set(PACKAGE_ROOT "${COMMON_DIR}/../..")
 set(MONOREPO_ROOT "${PACKAGE_ROOT}/../..")
 set(THIRD_PARTY_DIR "${MONOREPO_ROOT}/third-party")
 set(REACT_NATIVE_DIR "${MONOREPO_ROOT}/node_modules/react-native")
@@ -136,7 +140,14 @@ function(add_rn_test TEST_TARGET TEST_FILENAME)
     # Create executable using the explicit filename provided
     add_executable(${TEST_TARGET} ${TEST_FILENAME} ${ARG_SOURCES})
 
-    target_compile_definitions(${TEST_TARGET} PRIVATE TEST_BUILD)
+    # The host suite always builds the full feature set, so the sources it
+    # compiles must see the feature macros as the app build does. Without
+    # RNE_ENABLE_OPENCV, LLM.cpp takes its opt-out branch and every VLMTest /
+    # GemmaAudioTest case fails in SetUpTestSuite. Safe for the tests that link
+    # neither library: LLM.cpp is the only test source reaching a guarded
+    # opencv symbol, and it links opencv_deps.
+    target_compile_definitions(${TEST_TARGET} PRIVATE
+        TEST_BUILD RNE_ENABLE_OPENCV RNE_ENABLE_PHONEMIS)
     target_link_libraries(${TEST_TARGET} PRIVATE rntests_core gtest_main ${ARG_LIBS})
     target_link_options(${TEST_TARGET} PRIVATE "LINKER:-z,max-page-size=16384")
 

--- a/packages/react-native-executorch/legacy/cpp/rnexecutorch/threads/GlobalThreadPool.h
+++ b/packages/react-native-executorch/legacy/cpp/rnexecutorch/threads/GlobalThreadPool.h
@@ -4,10 +4,12 @@
 #include <executorch/extension/threadpool/cpuinfo_utils.h>
 #include <memory>
 #include <mutex>
-#include <opencv2/opencv.hpp>
 #include <optional>
 #include <rnexecutorch/Log.h>
 #include <rnexecutorch/threads/HighPerformanceThreadPool.h>
+#ifdef RNE_ENABLE_OPENCV
+#include <opencv2/opencv.hpp>
+#endif
 
 namespace rnexecutorch::threads {
 
@@ -39,9 +41,11 @@ public:
                 numThreads, "threads");
             instance = std::make_unique<HighPerformanceThreadPool>(numThreads.value(),
                                                                    config);
+#ifdef RNE_ENABLE_OPENCV
             // Disable OpenCV's internal threading to prevent it from overriding our
             // thread pool configuration, which would cause degraded performance
             cv::setNumThreads(0);
+#endif
         });
     }
 

--- a/packages/react-native-executorch/legacy/src/index.ts
+++ b/packages/react-native-executorch/legacy/src/index.ts
@@ -135,27 +135,11 @@ declare global {
 }
 // eslint-disable no-var
 
-if (
-  global.loadStyleTransfer == null ||
-  global.loadSemanticSegmentation == null ||
-  global.loadInstanceSegmentation == null ||
-  global.loadTextToImage == null ||
-  global.loadExecutorchModule == null ||
-  global.loadClassification == null ||
-  global.loadObjectDetection == null ||
-  global.loadPoseEstimation == null ||
-  global.loadTokenizerModule == null ||
-  global.loadTextEmbeddings == null ||
-  global.loadImageEmbeddings == null ||
-  global.loadVAD == null ||
-  global.loadLLM == null ||
-  global.loadPrivacyFilter == null ||
-  global.loadSpeechToText == null ||
-  global.loadTextToSpeechKokoro == null ||
-  global.loadOCR == null ||
-  global.loadVerticalOCR == null ||
-  global.__rne_isEmulator == null
-) {
+// Only the globals that are registered unconditionally. The per-task ones are
+// absent by design when an app opts out of opencv or phonemis, so including
+// them here would pin the condition to true and re-run install() on every
+// module evaluation.
+if (global.loadExecutorchModule == null || global.__rne_isEmulator == null) {
   if (!ETInstallerNativeModule) {
     throw new Error(
       `Failed to install react-native-executorch: The native module could not be found.`

--- a/packages/react-native-executorch/react-native-executorch.podspec
+++ b/packages/react-native-executorch/react-native-executorch.podspec
@@ -136,6 +136,38 @@ Pod::Spec.new do |s|
   # ==============================================================================
   exclude_files += opencv_source_files unless enable_opencv
   exclude_files += phonemis_source_files unless enable_phonemis
+  # ==============================================================================
+  # LEGACY SUPPORT: the legacy TTS models need phonemis too, and `legacy/cpp/**`
+  # above sweeps them in unconditionally. Without this they compile — the
+  # phonemis headers stay on HEADER_SEARCH_PATHS — and fail at link with
+  # undefined phonemis::Pipeline symbols.
+  # (Remove when react-native-executorch/legacy is dropped)
+  # ==============================================================================
+  unless enable_phonemis
+    exclude_files += ["legacy/cpp/rnexecutorch/models/text_to_speech/**/*.{cpp,c,h,hpp}"]
+  end
+  # ==============================================================================
+  # LEGACY SUPPORT: the same for opencv. The legacy vision models, the
+  # image/frame helpers they share and the multimodal LLM's vision encoder all
+  # compile against opencv2, which is not linked when opencv is off. Only the
+  # sources are excluded: the `Types.h` headers sitting next to them are
+  # opencv-free and `JsiConversions.h` includes them unconditionally.
+  # (Remove when react-native-executorch/legacy is dropped)
+  # ==============================================================================
+  unless enable_opencv
+    legacy_dir = "legacy/cpp/rnexecutorch"
+    exclude_files += [
+      "#{legacy_dir}/data_processing/ImageProcessing.cpp",
+      "#{legacy_dir}/models/VisionModel.cpp",
+      "#{legacy_dir}/utils/Frame*.cpp",
+      "legacy/cpp/runner/encoders/vision_encoder.cpp",
+    ]
+    exclude_files += %w[
+      classification embeddings/image instance_segmentation object_detection ocr
+      pose_estimation semantic_segmentation style_transfer text_to_image vertical_ocr
+    ].map { |task| "#{legacy_dir}/models/#{task}/**/*.{cpp,c}" }
+  end
+  # ==============================================================================
   s.exclude_files = exclude_files
 
   # --- Public headers ---

--- a/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts
+++ b/packages/react-native-executorch/src/extensions/llm/tasks/llmChatSession.ts
@@ -330,10 +330,15 @@ export async function createLLMChatSession(
 
         return { messages: history.slice(turnStartIdx), stats: generationStatsList, finishReason };
       } catch (err) {
-        // Roll back history, KV cache, and active tensors to pre-turn state on failure
+        // Roll back history, KV cache, and active tensors to pre-turn state on
+        // failure. The rewind must never replace the error it is unwinding.
+        //
+        // Under `resetOnTurn` the pre-turn position IS zero: `initialPos` is
+        // read before the turn begins and the turn then zeroed the cache, so
+        // rewinding to it is out of range by construction.
         history.length = turnStartIdx;
         committed = initialCommitted;
-        runner.reset(initialPos);
+        runner.reset(resetOnTurn ? 0 : initialPos);
         chatPreprocessor.clear();
         throw err;
       }


### PR DESCRIPTION
## Description

Cherry-picks two fixes from `main` onto `release/0.10` for the v0.10.2 patch.

- 947e76dc `fix(llm): stop a failed turn's rollback from hiding its cause` (#1454)
- 31f349c3 `fix(build): gate the legacy sources on phonemis and opencv` (#1471)

Both applied without conflict, and every touched file is byte-identical to `main`. No docs changes, per the patch-release rule.

The version bump follows in a separate `Release v0.10.2` commit once this merges.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [ ] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

Both were verified on `main`. #1471 builds `apps/speech` (`opencv=false, phonemis=true`) on both platforms; #1454 is covered by `__tests__/tasks/llmChatSession.test.ts`.

### Related issues

Refs #1470

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
