### PR TITLE
chore: Release v0.10.2

### DIFF
--- a/packages/react-native-executorch/package.json
+++ b/packages/react-native-executorch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-executorch",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "nativeLibsVersion": "0.10.0",
   "description": "An easy way to run AI models in React Native with ExecuTorch",
   "main": "./lib/module/index.js",

--- a/packages/react-native-executorch/src/fetcher/telemetry.ts
+++ b/packages/react-native-executorch/src/fetcher/telemetry.ts
@@ -10,7 +10,7 @@ const DOWNLOAD_EVENT_ENDPOINT = 'https://ai.swmansion.com/telemetry/downloads/ap
 // self-referencing import would need package `exports` support in the consuming
 // bundler to load at all. A wrong value here is analytics noise; a failed
 // import would break the bundle.
-const LIB_VERSION = '0.10.1';
+const LIB_VERSION = '0.10.2';
 
 // Anonymous analytics are on by default; apps opt out via setTelemetryEnabled.
 let telemetryEnabled = true;


### PR DESCRIPTION
## Description

Bumps the core package to v0.10.2 for the patch release, after #1472 landed the two backported fixes.

`LIB_VERSION` in `src/fetcher/telemetry.ts` is a literal rather than an import, so it moves with `package.json`; `__tests__/fetcher/telemetry.test.ts` asserts the two agree. The adapter packages and webrtc are untouched by this patch, so they stay at 0.10.0 and only the core publish workflow applies.

### Introduces a breaking change?

- [ ] Yes
- [x] No

### Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Documentation update (improves or adds clarity to existing documentation)
- [x] Other (chores, tests, code style improvements etc.)

### Tested on

- [x] iOS
- [x] Android

### Testing instructions

`yarn jest __tests__` in `packages/react-native-executorch`.

### Related issues

Refs #1470

### Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
